### PR TITLE
Handle proxy file-permission issues and container attribution

### DIFF
--- a/tests/test_proxy_permissions.py
+++ b/tests/test_proxy_permissions.py
@@ -1,0 +1,88 @@
+"""Proxy permission and mapping behavior tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vibepod.commands import run as run_cmd
+from vibepod.core import docker as docker_mod
+from vibepod.core.docker import DockerManager
+
+
+def test_update_container_mapping_success(tmp_path: Path) -> None:
+    mapping_path = tmp_path / "proxy" / "containers.json"
+    mapping_path.parent.mkdir(parents=True, exist_ok=True)
+
+    updated = run_cmd._update_container_mapping(
+        mapping_path,
+        "172.18.0.3",
+        "abc123",
+        "vibepod-claude-test",
+        "claude",
+    )
+
+    assert updated is True
+    data = json.loads(mapping_path.read_text())
+    assert data["172.18.0.3"]["container_id"] == "abc123"
+    assert data["172.18.0.3"]["container_name"] == "vibepod-claude-test"
+    assert data["172.18.0.3"]["agent"] == "claude"
+
+
+def test_update_container_mapping_permission_error_returns_false(
+    tmp_path: Path, monkeypatch
+) -> None:
+    mapping_path = tmp_path / "proxy" / "containers.json"
+    mapping_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _fail_replace(src: str, dst: str) -> None:
+        del src, dst
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(run_cmd.os, "replace", _fail_replace)
+
+    updated = run_cmd._update_container_mapping(
+        mapping_path,
+        "172.18.0.4",
+        "def456",
+        "vibepod-codex-test",
+        "codex",
+    )
+    assert updated is False
+
+
+def test_ensure_proxy_runs_container_as_current_user(tmp_path: Path, monkeypatch) -> None:
+    class _FakeContainers:
+        def __init__(self) -> None:
+            self.run_kwargs: dict | None = None
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+            return {"id": "proxy"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+
+    monkeypatch.setattr(DockerManager, "find_proxy", lambda self: None)
+    monkeypatch.setattr(docker_mod.os, "getuid", lambda: 1234)
+    monkeypatch.setattr(docker_mod.os, "getgid", lambda: 2345)
+
+    db_path = tmp_path / "proxy" / "proxy.db"
+    ca_dir = tmp_path / "proxy" / "mitmproxy"
+    manager.ensure_proxy(
+        image="vibepod/proxy:latest",
+        db_path=db_path,
+        ca_dir=ca_dir,
+        port=8080,
+        network="vibepod-network",
+    )
+
+    run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
+    assert run_kwargs is not None
+    assert run_kwargs["user"] == "1234:2345"
+    assert db_path.parent.exists()
+    assert ca_dir.exists()


### PR DESCRIPTION
This pull request introduces improvements to the proxy container management and permission handling in the `vibepod` project. The main changes focus on ensuring containers are run as the current user, improving error handling when updating container mappings, and adding tests to verify these behaviors.

**Proxy container management and permissions:**

* Modified `ensure_proxy` in `docker.py` to run the proxy container as the current user by setting the `user` field in `run_kwargs` when possible. This helps prevent permission issues with files created by the container.
* Added tests in `tests/test_proxy_permissions.py` to verify that the proxy container is run as the current user and that required directories are created.

**Container mapping and error handling:**

* Changed `_update_container_mapping` in `run.py` to return a boolean indicating success or failure, and improved error handling for file operations by catching `OSError` and returning `False` on failure. [[1]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaL55-R58) [[2]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaR75-R77)
* Updated the `run` function in `run.py` to check the result of `_update_container_mapping` and display a warning if the mapping could not be updated due to permission issues.
* Added tests in `tests/test_proxy_permissions.py` to verify that `_update_container_mapping` returns `False` on permission errors and that it correctly updates the mapping on success.