### PR TITLE
Add fixes for mistral vibe cli and devstral container

### DIFF
--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -16,9 +16,11 @@ class AgentSpec:
     provider: str
     image: str
     config_subdir: str
-    command: list[str]
+    command: list[str] | None
     config_mount_path: str
     extra_env: dict[str, str]
+    platform: str | None = None
+    run_as_host_user: bool = False
 
 
 AGENT_SPECS: dict[str, AgentSpec] = {
@@ -54,9 +56,11 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         "mistral",
         DEFAULT_IMAGES["devstral"],
         "devstral",
-        ["devstral"],
+        None,
         "/config",
-        {"HOME": "/config"},
+        {"HOME": "/config", "WORKSPACE_PATH": "/workspace"},
+        platform="linux/amd64",
+        run_as_host_user=True,
     ),
     "auggie": AgentSpec(
         "auggie",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -19,6 +19,15 @@ def test_get_agent_spec_supported() -> None:
     assert get_agent_spec("codex").id == "codex"
 
 
+def test_devstral_spec_matches_container_contract() -> None:
+    spec = get_agent_spec("devstral")
+    assert spec.command is None
+    assert spec.extra_env["HOME"] == "/config"
+    assert spec.extra_env["WORKSPACE_PATH"] == "/workspace"
+    assert spec.platform == "linux/amd64"
+    assert spec.run_as_host_user is True
+
+
 def test_get_agent_spec_unknown() -> None:
     with pytest.raises(ValueError):
         get_agent_spec("unknown")


### PR DESCRIPTION
This pull request introduces support for specifying the container platform and running containers as the host user for agents, with a particular focus on the "devstral" agent. It updates the agent specification to include new fields, ensures these fields are respected when running containers, and adds tests to verify the new behavior.