### PR TITLE
Add project-config bootstrap utility: vp config init

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains an initial v1 implementation with:
 - `vp stop <agent|--all>`
 - `vp list`
 - `vp logs start|stop|status`
+- `vp config init`
 - `vp config show`
 - `vp config path`
 - `vp version`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,7 +129,21 @@ VP_IMAGE_NAMESPACE=myorg vp run claude
 
 ## Project-level config
 
-Create `.vibepod/config.yaml` in your repository to apply settings that only take effect inside that project. Only the keys you specify are merged — everything else falls through to the global config and defaults.
+Use `vp config init` in your repository to create `.vibepod/config.yaml` automatically when it does not already exist:
+
+```bash
+vp config init
+```
+
+If `.vibepod/config.yaml` already exists, this command exits without modifying it; run `vp config init --force` to replace the file.
+
+This writes a minimal starter file:
+
+```yaml
+version: 1
+```
+
+Then add only the keys you want to override. Project config is merged on top of global config and defaults.
 
 ```yaml
 # .vibepod/config.yaml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,6 +57,20 @@ Use `-w` / `--workspace` to target any directory:
 vp run claude -w ~/other-project
 ```
 
+## Bootstrap a project config
+
+Create a project-level config file that you can extend later:
+
+```bash
+vp config init
+```
+
+This creates `.vibepod/config.yaml` in your current directory with a minimal starter:
+
+```yaml
+version: 1
+```
+
 ## Run in the background
 
 Use `-d` / `--detach` to start the container without attaching your terminal:

--- a/src/vibepod/commands/config.py
+++ b/src/vibepod/commands/config.py
@@ -10,9 +10,33 @@ import typer
 import yaml
 
 from vibepod.core.config import get_config, get_global_config_path, get_project_config_path
-from vibepod.utils.console import console
+from vibepod.utils.console import console, error, success
 
 app = typer.Typer(help="Manage configuration")
+
+PROJECT_CONFIG_MINIMAL = "version: 1\n"
+
+
+@app.command("init")
+def init(
+    force: Annotated[
+        bool, typer.Option("--force", help="Overwrite existing project config if present")
+    ] = False,
+) -> None:
+    """Create a minimal project config in the current directory."""
+    project_path = get_project_config_path()
+    if project_path.exists() and not force:
+        error(f"Project config already exists: {project_path}")
+        error("Use --force to overwrite.")
+        raise typer.Exit(1)
+
+    try:
+        project_path.parent.mkdir(parents=True, exist_ok=True)
+        project_path.write_text(PROJECT_CONFIG_MINIMAL, encoding="utf-8")
+    except OSError as exc:
+        error(f"Failed to create project config at {project_path}: {exc}")
+        raise typer.Exit(1) from exc
+    success(f"Created project config: {project_path}")
 
 
 @app.command("show")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from vibepod.cli import app
 from vibepod.core.config import deep_merge
+
+runner = CliRunner()
 
 
 def test_deep_merge() -> None:
@@ -10,3 +17,35 @@ def test_deep_merge() -> None:
     override = {"nested": {"y": 999, "z": 3}, "b": 2}
     merged = deep_merge(base, override)
     assert merged == {"a": 1, "b": 2, "nested": {"x": 1, "y": 999, "z": 3}}
+
+
+def test_config_init_creates_project_config() -> None:
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["config", "init"])
+        assert result.exit_code == 0
+        project_config = Path(".vibepod/config.yaml")
+        assert project_config.exists()
+        assert project_config.read_text(encoding="utf-8") == "version: 1\n"
+
+
+def test_config_init_does_not_overwrite_existing_config_without_force() -> None:
+    with runner.isolated_filesystem():
+        project_config = Path(".vibepod/config.yaml")
+        project_config.parent.mkdir(parents=True, exist_ok=True)
+        project_config.write_text("default_agent: codex\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["config", "init"])
+        assert result.exit_code == 1
+        assert "already exists" in result.stdout
+        assert project_config.read_text(encoding="utf-8") == "default_agent: codex\n"
+
+
+def test_config_init_force_overwrites_existing_config() -> None:
+    with runner.isolated_filesystem():
+        project_config = Path(".vibepod/config.yaml")
+        project_config.parent.mkdir(parents=True, exist_ok=True)
+        project_config.write_text("default_agent: codex\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["config", "init", "--force"])
+        assert result.exit_code == 0
+        assert project_config.read_text(encoding="utf-8") == "version: 1\n"


### PR DESCRIPTION
Adds a new `vp config init` command for quickly bootstrapping a minimal project-level configuration, updates documentation to reflect this new workflow, and introduces tests to ensure correct behavior. The changes streamline the process of setting up and managing project configs.

**New CLI feature:**
- Adds a `vp config init` command to create a minimal `.vibepod/config.yaml` in the current directory, with an option to force overwrite if the file exists.

**Documentation updates:**
- Updates `README.md` to list the new `vp config init` command.
- Expands `docs/configuration.md` and `docs/quickstart.md` with instructions and examples for using `vp config init` to bootstrap a project config.

**Testing:**
- Adds tests to verify that `vp config init` creates the config file, does not overwrite by default, and supports forced overwriting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to initialize a minimal project configuration file in the current directory, with a --force option to overwrite.

* **Documentation**
  * Updated configuration docs and quickstart to recommend and show the new init workflow for bootstrapping project config.

* **Tests**
  * Added tests for init creation, non-overwrite behavior, and force-overwrite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->