### PR TITLE
Add vp config init <agent> command, with duplicate-agent protection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,14 @@ This writes a minimal starter file:
 version: 1
 ```
 
+To copy a full agent block into the project config, pass the agent name:
+
+```bash
+vp config init claude
+```
+
+This adds `agents.claude` to `.vibepod/config.yaml` (creating the file if needed). If `agents.claude` is already present, the command exits without modifying the file.
+
 Then add only the keys you want to override. Project config is merged on top of global config and defaults.
 
 ```yaml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,6 +71,14 @@ This creates `.vibepod/config.yaml` in your current directory with a minimal sta
 version: 1
 ```
 
+Add a specific agent block into the project config with:
+
+```bash
+vp config init claude
+```
+
+If that agent is already configured under `agents`, the command exits without changing the file.
+
 ## Run in the background
 
 Use `-d` / `--detach` to start the container without attaching your terminal:

--- a/src/vibepod/commands/config.py
+++ b/src/vibepod/commands/config.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 import yaml
 
+from vibepod.constants import SUPPORTED_AGENTS
 from vibepod.core.config import get_config, get_global_config_path, get_project_config_path
 from vibepod.utils.console import console, error, success
 
@@ -19,12 +21,68 @@ PROJECT_CONFIG_MINIMAL = "version: 1\n"
 
 @app.command("init")
 def init(
+    agent: Annotated[
+        str | None, typer.Argument(help="Optional agent config to copy into project")
+    ] = None,
     force: Annotated[
         bool, typer.Option("--force", help="Overwrite existing project config if present")
     ] = False,
 ) -> None:
-    """Create a minimal project config in the current directory."""
+    """Create a minimal project config or add a specific agent config."""
     project_path = get_project_config_path()
+    if agent is not None:
+        if agent not in SUPPORTED_AGENTS:
+            error(f"Unknown agent '{agent}'. Supported: {', '.join(SUPPORTED_AGENTS)}")
+            raise typer.Exit(1)
+
+        try:
+            project_path.parent.mkdir(parents=True, exist_ok=True)
+
+            project_config: dict[str, Any] = {}
+            if project_path.exists():
+                loaded = yaml.safe_load(project_path.read_text(encoding="utf-8"))
+                if loaded is None:
+                    loaded = {}
+                if not isinstance(loaded, dict):
+                    error(f"Project config must contain a YAML mapping: {project_path}")
+                    raise typer.Exit(1)
+                project_config = loaded
+
+            project_config.setdefault("version", 1)
+            agents_config = project_config.setdefault("agents", {})
+            if not isinstance(agents_config, dict):
+                error(f"Project config key 'agents' must be a YAML mapping: {project_path}")
+                raise typer.Exit(1)
+
+            if agent in agents_config:
+                error(f"Project config already contains agent '{agent}': {project_path}")
+                raise typer.Exit(1)
+
+            effective_agents = get_config().get("agents", {})
+            if not isinstance(effective_agents, dict):
+                error(f"Could not resolve config for agent '{agent}'.")
+                raise typer.Exit(1)
+
+            effective_agent = effective_agents.get(agent)
+            if not isinstance(effective_agent, dict):
+                error(f"Could not resolve config for agent '{agent}'.")
+                raise typer.Exit(1)
+
+            agents_config[agent] = copy.deepcopy(effective_agent)
+            project_path.write_text(
+                yaml.safe_dump(project_config, sort_keys=False),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            error(f"Failed to update project config at {project_path}: {exc}")
+            raise typer.Exit(1) from exc
+        except yaml.YAMLError as exc:
+            error(f"Failed to parse project config at {project_path}: {exc}")
+            raise typer.Exit(1) from exc
+
+        success(f"Added agent config '{agent}' to project config: {project_path}")
+        return
+
     if project_path.exists() and not force:
         error(f"Project config already exists: {project_path}")
         error("Use --force to overwrite.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
 from typer.testing import CliRunner
 
 from vibepod.cli import app
@@ -50,6 +51,59 @@ def test_config_init_force_overwrites_existing_config() -> None:
         result = runner.invoke(app, ["config", "init", "--force"])
         assert result.exit_code == 0
         assert project_config.read_text(encoding="utf-8") == "version: 1\n"
+
+
+def test_config_init_with_agent_creates_project_config_with_agent_block() -> None:
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["config", "init", "claude"])
+        assert result.exit_code == 0
+
+        project_config = Path(".vibepod/config.yaml")
+        loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
+        assert isinstance(loaded, dict)
+        assert loaded["version"] == 1
+        assert isinstance(loaded.get("agents"), dict)
+        assert isinstance(loaded["agents"].get("claude"), dict)
+        assert loaded["agents"]["claude"]["enabled"] is True
+        assert loaded["agents"]["claude"]["env"] == {}
+        assert loaded["agents"]["claude"]["volumes"] == []
+        assert loaded["agents"]["claude"]["init"] == []
+        assert isinstance(loaded["agents"]["claude"]["image"], str)
+
+
+def test_config_init_with_agent_appends_to_existing_project_config() -> None:
+    with runner.isolated_filesystem():
+        project_config = Path(".vibepod/config.yaml")
+        project_config.parent.mkdir(parents=True, exist_ok=True)
+        project_config.write_text("version: 1\ndefault_agent: codex\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["config", "init", "gemini"])
+        assert result.exit_code == 0
+
+        loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
+        assert isinstance(loaded, dict)
+        assert loaded["default_agent"] == "codex"
+        assert isinstance(loaded.get("agents"), dict)
+        assert isinstance(loaded["agents"].get("gemini"), dict)
+
+
+def test_config_init_with_agent_fails_when_agent_already_configured() -> None:
+    with runner.isolated_filesystem():
+        project_config = Path(".vibepod/config.yaml")
+        project_config.parent.mkdir(parents=True, exist_ok=True)
+        project_config.write_text(
+            "version: 1\nagents:\n  claude:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["config", "init", "claude"])
+        assert result.exit_code == 1
+        assert "already contains agent 'claude'" in result.stdout
+
+        loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
+        assert isinstance(loaded, dict)
+        assert isinstance(loaded.get("agents"), dict)
+        assert loaded["agents"]["claude"]["enabled"] is True
 
 
 def test_default_config_exposes_agent_init(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Enhances the project configuration workflow by adding support for initializing and managing specific agent blocks within the project config file. The changes improve usability by allowing users to copy a full agent configuration from the global config into the project config, with safeguards against overwriting existing agent settings. The documentation and tests have also been updated to reflect and verify these new capabilities.

**Project configuration command improvements:**

* Added support for `vp config init <agent>` to copy a specific agent's config into the project config, creating `.vibepod/config.yaml` if needed and preventing overwrites if the agent is already present.
* Improved error handling and validation for agent names and config structure when adding agent blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to initialize project config with a specific agent using `vp config init <agent>`, which copies the agent's configuration into the project config file (exits without changes if the agent already exists).

* **Documentation**
  * Updated configuration and quickstart guides to document the agent initialization workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->