### PR TITLE
Add agent shortcut aliases and name resolution

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,16 +37,12 @@ Press **Ctrl+C** to stop the container when you are done.
 
 ## Shortcuts
 
-Every agent has a single-letter shortcut so you don't have to type `run`:
+You can start agents with either the full name or a single-letter shortcut:
 
 ```bash
-vp c   # claude
-vp g   # gemini
-vp o   # opencode
-vp d   # devstral
-vp a   # auggie
-vp p   # copilot
-vp x   # codex
+vp claude   # full name
+vp c        # shortcut
+vp run c    # shortcut with run also works
 ```
 
 ## Point at a different workspace

--- a/src/vibepod/cli.py
+++ b/src/vibepod/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import typer
 
 from vibepod.commands import config, list_cmd, logs, proxy, run, stop, update
+from vibepod.constants import AGENT_SHORTCUTS, SUPPORTED_AGENTS
 
 app = typer.Typer(
     name="vp",
@@ -23,52 +24,26 @@ app.add_typer(config.app, name="config")
 app.add_typer(proxy.app, name="proxy")
 
 
-@app.command("c", hidden=True)
-def alias_claude() -> None:
-    """Alias for `vp run claude`."""
-    run.run(agent="claude")
+def _register_run_alias(command_name: str, agent_name: str) -> None:
+    def _alias(bound_agent: str = agent_name) -> None:
+        run.run(agent=bound_agent)
 
-
-@app.command("g", hidden=True)
-def alias_gemini() -> None:
-    """Alias for `vp run gemini`."""
-    run.run(agent="gemini")
-
-
-@app.command("o", hidden=True)
-def alias_opencode() -> None:
-    """Alias for `vp run opencode`."""
-    run.run(agent="opencode")
-
-
-@app.command("d", hidden=True)
-def alias_devstral() -> None:
-    """Alias for `vp run devstral`."""
-    run.run(agent="devstral")
-
-
-@app.command("a", hidden=True)
-def alias_auggie() -> None:
-    """Alias for `vp run auggie`."""
-    run.run(agent="auggie")
-
-
-@app.command("p", hidden=True)
-def alias_copilot() -> None:
-    """Alias for `vp run copilot`."""
-    run.run(agent="copilot")
-
-
-@app.command("x", hidden=True)
-def alias_codex() -> None:
-    """Alias for `vp run codex`."""
-    run.run(agent="codex")
+    _alias.__name__ = f"alias_{command_name}"
+    _alias.__doc__ = f"Alias for `vp run {agent_name}`."
+    app.command(command_name, hidden=True)(_alias)
 
 
 @app.command("ui", hidden=True)
 def alias_ui() -> None:
     """Alias for `vp logs start`."""
     logs.logs_start()
+
+
+for shortcut, agent in AGENT_SHORTCUTS.items():
+    _register_run_alias(shortcut, agent)
+
+for agent in SUPPORTED_AGENTS:
+    _register_run_alias(agent, agent)
 
 
 def main() -> None:

--- a/src/vibepod/commands/list_cmd.py
+++ b/src/vibepod/commands/list_cmd.py
@@ -8,6 +8,7 @@ import typer
 from rich.table import Table
 
 from vibepod.constants import DEFAULT_IMAGES, EXIT_DOCKER_NOT_RUNNING, SUPPORTED_AGENTS
+from vibepod.core.agents import get_agent_shortcut
 from vibepod.core.docker import DockerClientError, DockerManager
 from vibepod.utils.console import console, error
 
@@ -41,8 +42,10 @@ def list_agents(
     rows: list[dict[str, str]] = []
     for agent in SUPPORTED_AGENTS:
         container = mapped.get(agent)
+        shortcut = get_agent_shortcut(agent) or "-"
         rows.append(
             {
+                "short": shortcut,
                 "agent": agent,
                 "image": DEFAULT_IMAGES[agent],
                 "status": container.status if container else "stopped",
@@ -60,10 +63,11 @@ def list_agents(
         return
 
     table = Table(title="VibePod Agents")
+    table.add_column("SHORT", style="green")
     table.add_column("AGENT", style="cyan")
     table.add_column("IMAGE", style="magenta")
     table.add_column("STATUS")
     table.add_column("WORKSPACE")
     for row in rows:
-        table.add_row(row["agent"], row["image"], row["status"], row["workspace"])
+        table.add_row(row["short"], row["agent"], row["image"], row["status"], row["workspace"])
     console.print(table)

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -18,8 +18,9 @@ from vibepod.constants import EXIT_DOCKER_NOT_RUNNING, SUPPORTED_AGENTS
 from vibepod.core.agents import (
     agent_config_dir,
     effective_agent_image,
+    get_agent_shortcut,
     get_agent_spec,
-    is_supported_agent,
+    resolve_agent_name,
 )
 from vibepod.core.config import get_config
 from vibepod.core.docker import DockerClientError, DockerManager
@@ -216,10 +217,16 @@ def run(
 ) -> None:
     """Start an agent container."""
     config = get_config()
-    selected_agent = agent or str(config.get("default_agent", "claude"))
-
-    if not is_supported_agent(selected_agent):
-        error(f"Unknown agent '{selected_agent}'. Supported: {', '.join(SUPPORTED_AGENTS)}")
+    selected_agent_input = agent or str(config.get("default_agent", "claude"))
+    selected_agent = resolve_agent_name(selected_agent_input)
+    if selected_agent is None:
+        supported_labels: list[str] = []
+        for supported_agent in SUPPORTED_AGENTS:
+            shortcut = get_agent_shortcut(supported_agent)
+            supported_labels.append(
+                f"{supported_agent} ({shortcut})" if shortcut else supported_agent
+            )
+        error(f"Unknown agent '{selected_agent_input}'. Supported: {', '.join(supported_labels)}")
         raise typer.Exit(1)
 
     workspace_path = workspace.expanduser().resolve()

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -18,7 +18,25 @@ LOGS_DB_FILE = CONFIG_DIR / "logs.db"
 DOCKER_NETWORK = "vibepod-network"
 CONTAINER_LABEL_MANAGED = "vibepod.managed"
 
-SUPPORTED_AGENTS = ("claude", "gemini", "opencode", "devstral", "auggie", "copilot", "codex")
+SUPPORTED_AGENTS = (
+    "claude",
+    "gemini",
+    "opencode",
+    "devstral",
+    "auggie",
+    "copilot",
+    "codex",
+)
+
+AGENT_SHORTCUTS: dict[str, str] = {
+    "c": "claude",
+    "g": "gemini",
+    "o": "opencode",
+    "d": "devstral",
+    "a": "auggie",
+    "p": "copilot",
+    "x": "codex",
+}
 
 DEFAULT_IMAGES: dict[str, str] = {
     "claude": os.environ.get(
@@ -54,13 +72,7 @@ DEFAULT_IMAGES: dict[str, str] = {
 }
 
 DEFAULT_ALIASES: dict[str, str] = {
-    "c": "run claude",
-    "g": "run gemini",
-    "o": "run opencode",
-    "d": "run devstral",
-    "a": "run auggie",
-    "p": "run copilot",
-    "x": "run codex",
+    **{shortcut: f"run {agent}" for shortcut, agent in AGENT_SHORTCUTS.items()},
     "ui": "logs start",
 }
 

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from vibepod.constants import DEFAULT_IMAGES, SUPPORTED_AGENTS
+from vibepod.constants import AGENT_SHORTCUTS, DEFAULT_IMAGES, SUPPORTED_AGENTS
 from vibepod.core.config import get_config_root
 
 
@@ -91,9 +91,23 @@ AGENT_SPECS: dict[str, AgentSpec] = {
     ),
 }
 
+_SHORTCUT_BY_AGENT = {agent: shortcut for shortcut, agent in AGENT_SHORTCUTS.items()}
+
 
 def is_supported_agent(agent: str) -> bool:
     return agent in SUPPORTED_AGENTS
+
+
+def resolve_agent_name(agent: str) -> str | None:
+    normalized = agent.strip().lower()
+    if normalized in SUPPORTED_AGENTS:
+        return normalized
+    return AGENT_SHORTCUTS.get(normalized)
+
+
+def get_agent_shortcut(agent: str) -> str | None:
+    normalized = agent.strip().lower()
+    return _SHORTCUT_BY_AGENT.get(normalized)
 
 
 def get_agent_spec(agent: str) -> AgentSpec:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -4,19 +4,30 @@ from __future__ import annotations
 
 import pytest
 
-from vibepod.core.agents import get_agent_spec, is_supported_agent
+from vibepod.constants import AGENT_SHORTCUTS, SUPPORTED_AGENTS
+from vibepod.core.agents import (
+    get_agent_shortcut,
+    get_agent_spec,
+    is_supported_agent,
+    resolve_agent_name,
+)
 
 
 def test_supported_agent() -> None:
-    assert is_supported_agent("claude") is True
-    assert is_supported_agent("copilot") is True
-    assert is_supported_agent("codex") is True
+    for agent in SUPPORTED_AGENTS:
+        assert is_supported_agent(agent) is True
     assert is_supported_agent("unknown") is False
 
 
 def test_get_agent_spec_supported() -> None:
-    assert get_agent_spec("copilot").id == "copilot"
-    assert get_agent_spec("codex").id == "codex"
+    for agent in SUPPORTED_AGENTS:
+        spec = get_agent_spec(agent)
+        assert spec.id == agent
+        assert spec.provider
+        assert spec.image
+        assert spec.config_subdir
+        assert spec.config_mount_path
+        assert isinstance(spec.extra_env, dict)
 
 
 def test_devstral_spec_matches_container_contract() -> None:
@@ -31,3 +42,22 @@ def test_devstral_spec_matches_container_contract() -> None:
 def test_get_agent_spec_unknown() -> None:
     with pytest.raises(ValueError):
         get_agent_spec("unknown")
+
+
+def test_resolve_agent_name_accepts_short_and_full_forms() -> None:
+    for shortcut, agent in AGENT_SHORTCUTS.items():
+        assert resolve_agent_name(shortcut) == agent
+        assert resolve_agent_name(shortcut.upper()) == agent
+    for agent in SUPPORTED_AGENTS:
+        assert resolve_agent_name(agent) == agent
+        assert resolve_agent_name(f" {agent.upper()} ") == agent
+    assert resolve_agent_name("unknown") is None
+
+
+def test_get_agent_shortcut_known_agent() -> None:
+    expected_by_agent = {agent: shortcut for shortcut, agent in AGENT_SHORTCUTS.items()}
+    assert set(expected_by_agent.keys()) == set(SUPPORTED_AGENTS)
+    for agent in SUPPORTED_AGENTS:
+        assert get_agent_shortcut(agent) == expected_by_agent[agent]
+        assert get_agent_shortcut(f" {agent.upper()} ") == expected_by_agent[agent]
+    assert get_agent_shortcut("unknown") is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typer.testing import CliRunner
 
 from vibepod.cli import app
+from vibepod.commands import run as run_cmd
 
 runner = CliRunner()
 
@@ -19,3 +20,16 @@ def test_version() -> None:
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert "VibePod CLI" in result.stdout
+
+
+def test_full_agent_name_alias_runs_agent(monkeypatch) -> None:
+    called: dict[str, str | None] = {"agent": None}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        called["agent"] = agent
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["claude"])
+    assert result.exit_code == 0
+    assert called["agent"] == "claude"

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,31 @@
+"""List command tests."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from vibepod.cli import app
+from vibepod.commands import list_cmd
+from vibepod.constants import AGENT_SHORTCUTS, SUPPORTED_AGENTS
+
+runner = CliRunner()
+
+
+def test_list_json_includes_short_and_full_agent_names(monkeypatch) -> None:
+    class _FakeDockerManager:
+        def list_managed(self, all_containers: bool = True):  # noqa: ARG002
+            return []
+
+    monkeypatch.setattr(list_cmd, "DockerManager", _FakeDockerManager)
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+
+    rows = json.loads(result.stdout)
+    by_agent = {row["agent"]: row for row in rows}
+    assert set(by_agent.keys()) == set(SUPPORTED_AGENTS)
+
+    for shortcut, agent in AGENT_SHORTCUTS.items():
+        assert by_agent[agent]["short"] == shortcut

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,6 +8,7 @@ import pytest
 import typer
 
 from vibepod.commands import run as run_cmd
+from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
 from vibepod.core.docker import DockerClientError, DockerManager
 
 
@@ -259,3 +260,21 @@ def test_resolve_launch_command_requires_non_empty_process() -> None:
 
     with pytest.raises(DockerClientError):
         manager.resolve_launch_command("example/image:latest", None)
+
+
+def test_run_accepts_short_agent_name(monkeypatch, tmp_path: Path) -> None:
+    class _UnavailableDockerManager:
+        def __init__(self) -> None:
+            raise DockerClientError("Docker unavailable")
+
+    monkeypatch.setattr(
+        run_cmd,
+        "get_config",
+        lambda: {"default_agent": "claude", "agents": {"claude": {"env": {}}}},
+    )
+    monkeypatch.setattr(run_cmd, "DockerManager", _UnavailableDockerManager)
+
+    with pytest.raises(typer.Exit) as exc:
+        run_cmd.run(agent="c", workspace=tmp_path)
+
+    assert exc.value.exit_code == EXIT_DOCKER_NOT_RUNNING


### PR DESCRIPTION
Adds support for running agents using both their full names and single-letter shortcuts throughout the CLI, improving usability and consistency. It introduces internal logic to resolve agent names from shortcuts, updates command aliases, enhances error messages, and improves the display of agent information. Comprehensive tests are added to ensure the new shortcut functionality works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full agent names accepted as CLI commands alongside single-letter shortcuts.
  * Agent listing now shows each agent’s shortcut.
  * Error messages now include available agents with their shortcuts.

* **Documentation**
  * Quickstart updated with mixed examples demonstrating full-name, single-letter, and run-enabled shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->