### PR TITLE
Add documentation for usage of custom container builds

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -34,6 +34,71 @@ agents:
     image: myorg/my-claude:dev
 ```
 
+## Image customization workflows
+
+VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`). Image customization means changing the image used for one of those IDs.
+
+### 1. Extend an existing image for an agent
+
+Example: add tools to the default Claude image.
+
+1. Create a Dockerfile that extends the current base image.
+
+```dockerfile
+# Dockerfile.claude
+FROM nezhar/claude-container:latest
+
+# Add project-specific utilities.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ripgrep jq \
+  && rm -rf /var/lib/apt/lists/*
+```
+
+2. Build and tag the derived image.
+
+```bash
+docker build -f Dockerfile.claude -t myorg/claude-container:with-tools .
+```
+
+3. Run with the new image (one-off) or set it in config (persistent).
+
+```bash
+# one-off
+VP_IMAGE_CLAUDE=myorg/claude-container:with-tools vp run claude
+```
+
+```yaml
+# ~/.config/vibepod/config.yaml (or .vibepod/config.yaml)
+agents:
+  claude:
+    image: myorg/claude-container:with-tools
+```
+
+### 2. Add a new image for an agent
+
+Example: point `opencode` at a newly published internal image.
+
+1. Build/publish your image to a registry (for example `registry.example.com/team/opencode:2026-03-01`).
+2. Attach that image to the target agent in config.
+
+```yaml
+agents:
+  opencode:
+    image: registry.example.com/team/opencode:2026-03-01
+```
+
+3. Start the agent.
+
+```bash
+vp run opencode
+```
+
+You can also test quickly without editing config:
+
+```bash
+VP_IMAGE_OPENCODE=registry.example.com/team/opencode:2026-03-01 vp run opencode
+```
+
 ## Passing environment variables
 
 Use `-e` / `--env` to inject variables at runtime:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,6 +134,8 @@ VP_IMAGE_NAMESPACE=myorg vp run claude
 # pulls myorg/claude-container:latest
 ```
 
+For end-to-end examples (extending a base image and assigning a brand-new image to an agent), see [Agents > Image customization workflows](agents/index.md#image-customization-workflows).
+
 ## Project-level config
 
 Use `vp config init` in your repository to create `.vibepod/config.yaml` automatically when it does not already exist:


### PR DESCRIPTION
This pull request improves the documentation for customizing agent images in VibePod by adding a new section with step-by-step workflows and cross-references. The changes make it easier for users to understand how to extend existing agent images or assign new images to agents.

Documentation enhancements:

* Added a new "Image customization workflows" section to `docs/agents/index.md`, including detailed instructions and examples for extending agent images and assigning new images to agents.
* Updated `docs/configuration.md` to include a cross-reference to the new image customization workflows section, helping users find relevant examples more easily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive image customization workflows guide for agents, including step-by-step instructions, Dockerfile examples, and commands for extending existing agent images and attaching new ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->