### PR TITLE
Add support for podman as container runtime

### DIFF
--- a/.github/workflows/runtime-integration.yml
+++ b/.github/workflows/runtime-integration.yml
@@ -1,0 +1,51 @@
+name: Runtime Integration
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  version-runtime:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - docker-only
+          - podman-only
+          - none
+          - both-auto
+          - both-default-docker
+          - both-default-podman
+          - both-switch
+
+    env:
+      VP_REAL_RUNTIME_SCENARIO: ${{ matrix.scenario }}
+      VP_RUNTIME_PROBE_TIMEOUT: "20"
+      PYTHONUNBUFFERED: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Prepare runtime scenario and run tests
+        run: |
+          export XDG_RUNTIME_DIR="${RUNNER_TEMP}/xdg-runtime"
+          bash scripts/prepare_runtime_scenario.sh "${VP_REAL_RUNTIME_SCENARIO}"
+          python -m pytest -q tests/test_version_integration.py
+
+      - name: Clean up runtime scenario
+        if: always()
+        run: bash scripts/cleanup_runtime_scenario.sh

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This repository contains an initial v1 implementation with:
 - `vp list`
 - `vp config init`
 - `vp config show`
+- `vp config runtime`
 - `vp config path`
 - `vp version`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,10 @@ default_agent: claude
 # See docs/podman.md for setup instructions
 container_runtime: auto
 
+# Container user namespace mode passed to new containers (default: null)
+# For Podman, "keep-id" preserves host UID/GID on compatible images
+container_userns_mode: null
+
 # Pull the latest image before every run (default: true)
 # Can be overridden per agent with agents.<agent>.auto_pull
 auto_pull: true
@@ -118,6 +122,7 @@ These variables override the corresponding config keys without editing any file:
 | Variable | Config key | Example |
 |---|---|---|
 | `VP_CONTAINER_RUNTIME` | `container_runtime` | `VP_CONTAINER_RUNTIME=podman` |
+| `VP_CONTAINER_USERNS_MODE` | `container_userns_mode` | `VP_CONTAINER_USERNS_MODE=keep-id` |
 | `VP_DEFAULT_AGENT` | `default_agent` | `VP_DEFAULT_AGENT=vibe` |
 | `VP_AUTO_PULL` | `auto_pull` | `VP_AUTO_PULL=true` |
 | `VP_LOG_LEVEL` | `log_level` | `VP_LOG_LEVEL=debug` |
@@ -201,7 +206,7 @@ Commit this file to share project defaults with your team.
 
 VibePod starts a `vibepod-proxy` container alongside every agent. It acts as an HTTP(S) MITM proxy and logs all outbound requests to a SQLite database viewable in the Datasette UI (`vp logs start`).
 
-The proxy is reachable inside the Docker network as `http://vibepod-proxy:8080`. It is not published on a host port.
+VibePod injects the proxy endpoint into agent containers automatically over the internal runtime network. It is not published on a host port.
 
 To disable the proxy globally:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ VibePod merges configuration from four sources in order, with each layer overrid
 3. **Project config** — `.vibepod/config.yaml` in the current directory
 4. **Environment variables** — override specific keys at runtime
 
-Run `vp config path` to print the exact paths in use, and `vp config show` to print the fully merged result.
+Run `vp config path` to print the exact paths in use, `vp config show` to print the fully merged result, and `vp config runtime` to view or change the saved global container runtime.
 
 ## Full reference
 
@@ -159,6 +159,24 @@ VP_IMAGE_NAMESPACE=myorg vp run claude
 ```
 
 For end-to-end examples (extending a base image and assigning a brand-new image to an agent), see [Agents > Image customization workflows](agents/index.md#image-customization-workflows).
+
+## Runtime preference
+
+Use `vp config runtime` to inspect the saved global runtime preference:
+
+```bash
+vp config runtime
+```
+
+Set it explicitly without editing YAML by hand:
+
+```bash
+vp config runtime podman
+vp config runtime docker
+vp config runtime auto
+```
+
+This updates `container_runtime` in the global config file (`~/.config/vibepod/config.yaml` by default).
 
 ## Project-level config
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,10 @@ version: 1
 # Alias `vibe` resolves to `devstral`.
 default_agent: claude
 
+# Container runtime: auto | docker | podman (default: auto)
+# See docs/podman.md for setup instructions
+container_runtime: auto
+
 # Pull the latest image before every run (default: true)
 # Can be overridden per agent with agents.<agent>.auto_pull
 auto_pull: true
@@ -113,6 +117,7 @@ These variables override the corresponding config keys without editing any file:
 
 | Variable | Config key | Example |
 |---|---|---|
+| `VP_CONTAINER_RUNTIME` | `container_runtime` | `VP_CONTAINER_RUNTIME=podman` |
 | `VP_DEFAULT_AGENT` | `default_agent` | `VP_DEFAULT_AGENT=vibe` |
 | `VP_AUTO_PULL` | `auto_pull` | `VP_AUTO_PULL=true` |
 | `VP_LOG_LEVEL` | `log_level` | `VP_LOG_LEVEL=debug` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # VibePod
 
-**One CLI for all AI coding agents — running in Docker containers.**
+**One CLI for all AI coding agents — running in Docker or Podman containers.**
 
-VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker container, pointed at any workspace directory, with a single command. Agent credentials, config, and session logs are persisted across runs without touching your host environment.
+VibePod (`vp`) lets you run any supported AI coding agent in an isolated container, pointed at any workspace directory, with a single command. Agent credentials, config, and session logs are persisted across runs without touching your host environment.
 
 ## Why VibePod?
 
@@ -26,6 +26,7 @@ VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker 
 ## Next Steps
 
 - [**Quickstart**](quickstart.md) — install and run your first agent in two minutes.
+- [**Using Podman**](podman.md) — set up Podman as an alternative to Docker.
 - [**Development**](development.md) — local setup, tests, and docs workflow.
 - [**Agents**](agents/index.md) — per-agent setup and credential instructions.
 - [**Configuration**](configuration.md) — full reference for global and project-level config.

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -66,6 +66,8 @@ VibePod uses the standard [Docker SDK for Python](https://docker-py.readthedocs.
 
 The rootless Podman socket is discovered via `$XDG_RUNTIME_DIR/podman/podman.sock` (falling back to `/run/user/<uid>/podman/podman.sock`). The rootful socket at `/run/podman/podman.sock` is only used when running as root.
 
+VibePod allows up to 10 seconds for runtime detection probes. If your Podman socket is slower on a particular host, set `VP_RUNTIME_PROBE_TIMEOUT` to a larger value in seconds before running `vp`.
+
 ## Known limitations
 
 ### Interactive attach
@@ -76,6 +78,26 @@ The `attach_socket()` call in Podman's Docker-compat layer has minor gaps under 
 vp run claude -d
 podman attach vibepod-claude-<id>
 ```
+
+### User namespace mapping
+
+If you want Podman to preserve your host UID/GID for compatible containers, set a user namespace mode such as `keep-id`:
+
+```bash
+vp run claude --runtime podman --userns keep-id
+```
+
+You can also set it globally:
+
+```bash
+export VP_CONTAINER_USERNS_MODE=keep-id
+```
+
+```yaml
+container_userns_mode: keep-id
+```
+
+This works best for images that run as your host UID. Images that switch to a different in-container user may still produce remapped ownership on bind mounts.
 
 ### Volume permissions
 

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -1,0 +1,102 @@
+# Using Podman
+
+VibePod works with [Podman](https://podman.io/) as an alternative to Docker. Rootless Podman is fully supported — no `sudo` required.
+
+## Prerequisites
+
+- Podman 4.0+
+- The rootless Podman socket enabled:
+
+```bash
+systemctl --user enable --now podman.socket
+```
+
+Verify the socket is active:
+
+```bash
+systemctl --user status podman.socket
+```
+
+## Selecting the runtime
+
+VibePod auto-detects available runtimes. If only Podman is installed, it is used automatically. When both Docker and Podman are available, VibePod prompts you to choose (and remembers your choice).
+
+You can also set the runtime explicitly using any of the methods below. They are listed in priority order — the first one found wins:
+
+### 1. CLI flag
+
+Pass `--runtime` to any command:
+
+```bash
+vp run claude --runtime podman
+vp stop --all --runtime podman
+vp logs start --runtime podman
+```
+
+### 2. Environment variable
+
+Set `VP_CONTAINER_RUNTIME` to skip the prompt entirely:
+
+```bash
+export VP_CONTAINER_RUNTIME=podman
+vp run claude
+```
+
+This is useful in CI or shell profiles where you always want a specific runtime.
+
+### 3. Global config
+
+Add `container_runtime` to `~/.config/vibepod/config.yaml`:
+
+```yaml
+container_runtime: podman
+```
+
+When VibePod prompts you to choose a runtime interactively, it saves your answer here automatically so you are not asked again.
+
+Set it back to `auto` to re-enable detection:
+
+```yaml
+container_runtime: auto
+```
+
+## How it works
+
+VibePod uses the standard [Docker SDK for Python](https://docker-py.readthedocs.io/) to communicate with Podman through its Docker-compatible REST API. No additional Python packages are needed.
+
+The rootless Podman socket is discovered via `$XDG_RUNTIME_DIR/podman/podman.sock` (falling back to `/run/user/<uid>/podman/podman.sock`). The rootful socket at `/run/podman/podman.sock` is only used when running as root.
+
+## Known limitations
+
+### Interactive attach
+
+The `attach_socket()` call in Podman's Docker-compat layer has minor gaps under rootless mode. If you experience rendering issues while attached to a container, try running with `--detach` and using `podman attach` directly:
+
+```bash
+vp run claude -d
+podman attach vibepod-claude-<id>
+```
+
+### Volume permissions
+
+Rootless Podman uses user-namespace remapping: your host UID is mapped to root inside the container, while other UIDs are mapped to subordinate ranges. Container images that drop privileges via `su` or `gosu` may encounter permission errors on bind-mounted files.
+
+VibePod handles this automatically for its own managed directories (agent config, proxy data, CA certificates) by adjusting permissions before and during container startup. Your workspace directory is mounted as-is and is not modified.
+
+If you still see permission errors on workspace files, adjust permissions for the owner first. For collaborative setups that share a group, you can optionally grant group write access as well. Avoid making the workspace world-writable.
+
+```bash
+chmod -R u+rwX ~/my-project
+# Optional for shared group workspaces:
+chmod -R g+rwX ~/my-project
+```
+
+### Rootful Podman
+
+VibePod targets rootless Podman. The rootful socket (`/run/podman/podman.sock`) is only probed when running as root. If you need rootful Podman as a non-root user, set `DOCKER_HOST` explicitly:
+
+```bash
+export DOCKER_HOST=unix:///run/podman/podman.sock
+```
+
+Note that this will require elevated privileges (e.g. via `sudo` or polkit).

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -46,7 +46,13 @@ This is useful in CI or shell profiles where you always want a specific runtime.
 
 ### 3. Global config
 
-Add `container_runtime` to `~/.config/vibepod/config.yaml`:
+Set the saved global runtime with the CLI:
+
+```bash
+vp config runtime podman
+```
+
+This writes `container_runtime` to `~/.config/vibepod/config.yaml`:
 
 ```yaml
 container_runtime: podman
@@ -55,6 +61,10 @@ container_runtime: podman
 When VibePod prompts you to choose a runtime interactively, it saves your answer here automatically so you are not asked again.
 
 Set it back to `auto` to re-enable detection:
+
+```bash
+vp config runtime auto
+```
 
 ```yaml
 container_runtime: auto

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Python 3.10+
-- Docker (running)
+- Docker **or** [Podman](podman.md) (running)
 
 ## Install
 
@@ -124,5 +124,6 @@ This starts a Datasette container and opens `http://localhost:8001` in your brow
 ## Next Steps
 
 - [Configure an agent](agents/index.md) — set API keys and per-agent options.
+- [Using Podman](podman.md) — set up Podman as an alternative to Docker.
 - [Configuration reference](configuration.md) — tune defaults, the proxy, and logging.
 - [CLI Reference](cli-reference.md) — every command and flag.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Quickstart: quickstart.md
+  - Using Podman: podman.md
   - Development: development.md
   - Agents: agents/index.md
   - Configuration: configuration.md

--- a/scripts/cleanup_runtime_scenario.sh
+++ b/scripts/cleanup_runtime_scenario.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNNER_TEMP="${RUNNER_TEMP:-/tmp}"
+PODMAN_PID_FILE="${RUNNER_TEMP}/podman-service.pid"
+
+if [[ -f "${PODMAN_PID_FILE}" ]]; then
+  kill "$(cat "${PODMAN_PID_FILE}")" >/dev/null 2>&1 || true
+  rm -f "${PODMAN_PID_FILE}"
+fi

--- a/scripts/prepare_runtime_scenario.sh
+++ b/scripts/prepare_runtime_scenario.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO="${1:?missing runtime scenario}"
+RUNNER_TEMP="${RUNNER_TEMP:-/tmp}"
+XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-${RUNNER_TEMP}/xdg-runtime}"
+PODMAN_DIR="${XDG_RUNTIME_DIR}/podman"
+PODMAN_SOCKET_PATH="${PODMAN_DIR}/podman.sock"
+PODMAN_SOCKET_URL="unix://${PODMAN_SOCKET_PATH}"
+PODMAN_PID_FILE="${RUNNER_TEMP}/podman-service.pid"
+PODMAN_LOG_FILE="${RUNNER_TEMP}/podman-service.log"
+
+wait_for_docker() {
+  for _ in $(seq 1 30); do
+    if docker version >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  docker version
+}
+
+wait_for_podman() {
+  for _ in $(seq 1 30); do
+    if [[ -S "${PODMAN_SOCKET_PATH}" ]] && podman --url "${PODMAN_SOCKET_URL}" version >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  podman --url "${PODMAN_SOCKET_URL}" version
+}
+
+ensure_docker_started() {
+  if command -v systemctl >/dev/null 2>&1; then
+    sudo systemctl start docker.socket || true
+    sudo systemctl start docker.service || true
+  fi
+  if command -v service >/dev/null 2>&1; then
+    sudo service docker start || true
+  fi
+  wait_for_docker
+}
+
+stop_docker() {
+  if command -v systemctl >/dev/null 2>&1; then
+    sudo systemctl stop docker.service || true
+    sudo systemctl stop docker.socket || true
+  fi
+  if command -v service >/dev/null 2>&1; then
+    sudo service docker stop || true
+  fi
+  sleep 2
+}
+
+install_podman() {
+  sudo touch /etc/subuid /etc/subgid
+
+  if ! grep -q "^${USER}:" /etc/subuid; then
+    echo "${USER}:100000:65536" | sudo tee -a /etc/subuid >/dev/null
+  fi
+  if ! grep -q "^${USER}:" /etc/subgid; then
+    echo "${USER}:100000:65536" | sudo tee -a /etc/subgid >/dev/null
+  fi
+
+  if command -v podman >/dev/null 2>&1; then
+    return 0
+  fi
+
+  sudo apt-get update
+  sudo apt-get install -y podman
+}
+
+stop_podman_service() {
+  if [[ -f "${PODMAN_PID_FILE}" ]]; then
+    kill "$(cat "${PODMAN_PID_FILE}")" >/dev/null 2>&1 || true
+    rm -f "${PODMAN_PID_FILE}"
+  fi
+  rm -f "${PODMAN_SOCKET_PATH}"
+}
+
+start_podman_service() {
+  install_podman
+  stop_podman_service
+
+  mkdir -p "${PODMAN_DIR}"
+  chmod 700 "${XDG_RUNTIME_DIR}"
+
+  nohup podman system service --time=0 "${PODMAN_SOCKET_URL}" >"${PODMAN_LOG_FILE}" 2>&1 &
+  echo "$!" >"${PODMAN_PID_FILE}"
+
+  wait_for_podman
+}
+
+case "${SCENARIO}" in
+  docker-only)
+    stop_podman_service
+    ensure_docker_started
+    ;;
+  podman-only)
+    start_podman_service
+    stop_docker
+    ;;
+  none)
+    stop_podman_service
+    stop_docker
+    ;;
+  both-auto|both-default-docker|both-default-podman|both-switch)
+    ensure_docker_started
+    start_podman_service
+    ;;
+  *)
+    echo "Unknown runtime scenario: ${SCENARIO}" >&2
+    exit 1
+    ;;
+esac
+
+echo "Prepared runtime scenario: ${SCENARIO}"
+docker version >/dev/null 2>&1 && docker version --format '{{.Server.Version}}' || true
+command -v podman >/dev/null 2>&1 && podman --url "${PODMAN_SOCKET_URL}" version --format '{{.Server.Version}}' || true

--- a/src/vibepod/cli.py
+++ b/src/vibepod/cli.py
@@ -93,9 +93,14 @@ def _register_run_alias(command_name: str, agent_name: str) -> None:
 
 
 @app.command("ui", hidden=True)
-def alias_ui() -> None:
+def alias_ui(
+    port: int | None = None,
+    no_open: bool = False,
+    runtime: str | None = None,
+    userns: str | None = None,
+) -> None:
     """Alias for `vp logs start`."""
-    logs.logs_start()
+    logs.logs_start(port=port, no_open=no_open, runtime=runtime, userns=userns)
 
 
 for shortcut, agent in AGENT_SHORTCUTS.items():

--- a/src/vibepod/commands/config.py
+++ b/src/vibepod/commands/config.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any
 import typer
 import yaml
 
-from vibepod.constants import SUPPORTED_AGENTS
+from vibepod.constants import RUNTIME_AUTO, SUPPORTED_AGENTS, SUPPORTED_RUNTIMES
 from vibepod.core.allowed_dirs import (
     add_allowed_dir,
     is_protected_dir,
@@ -18,6 +18,7 @@ from vibepod.core.allowed_dirs import (
     remove_allowed_dir,
 )
 from vibepod.core.config import get_config, get_global_config_path, get_project_config_path
+from vibepod.core.runtime import get_saved_runtime_preference, save_runtime_preference
 from vibepod.utils.console import console, error, success
 
 app = typer.Typer(help="Manage configuration")
@@ -114,6 +115,48 @@ def show(
         return
     dumped = yaml.safe_dump(cfg, sort_keys=False)
     console.print(dumped)
+
+
+@app.command("runtime")
+def runtime(
+    value: Annotated[
+        str | None,
+        typer.Argument(help="Default global runtime: auto, docker, or podman"),
+    ] = None,
+) -> None:
+    """Show or set the saved default container runtime."""
+    if value is None:
+        try:
+            print(get_saved_runtime_preference())
+        except (OSError, ValueError) as exc:
+            error(str(exc))
+            raise typer.Exit(1) from exc
+        except yaml.YAMLError as exc:
+            error(f"Failed to parse global config at {get_global_config_path()}: {exc}")
+            raise typer.Exit(1) from exc
+        return
+
+    allowed = (RUNTIME_AUTO, *SUPPORTED_RUNTIMES)
+    normalized = value.strip().lower()
+    if normalized not in allowed:
+        error(f"Unknown runtime '{value}'. Supported: {', '.join(allowed)}")
+        raise typer.Exit(1)
+
+    try:
+        save_runtime_preference(normalized)
+    except OSError as exc:
+        error(f"Failed to update global config at {get_global_config_path()}: {exc}")
+        raise typer.Exit(1) from exc
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
+    except yaml.YAMLError as exc:
+        error(f"Failed to parse global config at {get_global_config_path()}: {exc}")
+        raise typer.Exit(1) from exc
+
+    success(
+        f"Set default container runtime to '{normalized}' in {get_global_config_path()}"
+    )
 
 
 @app.command("path")

--- a/src/vibepod/commands/list_cmd.py
+++ b/src/vibepod/commands/list_cmd.py
@@ -9,7 +9,8 @@ from rich.table import Table
 
 from vibepod.constants import DEFAULT_IMAGES, EXIT_DOCKER_NOT_RUNNING, SUPPORTED_AGENTS
 from vibepod.core.agents import get_agent_shortcut
-from vibepod.core.docker import DockerClientError, DockerManager
+from vibepod.core.config import get_config
+from vibepod.core.docker import DockerClientError, get_manager
 from vibepod.utils.console import console, error
 
 
@@ -49,10 +50,14 @@ def list_agents(
         bool, typer.Option("-r", "--running", help="Show only running agents")
     ] = False,
     as_json: Annotated[bool, typer.Option("--json", help="Output JSON")] = False,
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
 ) -> None:
     """List available agents and running containers."""
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=get_config())
         containers = manager.list_managed(all_containers=True)
     except DockerClientError as exc:
         if running:

--- a/src/vibepod/commands/logs.py
+++ b/src/vibepod/commands/logs.py
@@ -13,7 +13,7 @@ import typer
 
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
 from vibepod.core.config import get_config
-from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag
+from vibepod.core.docker import DockerClientError, _is_latest_tag, get_manager
 from vibepod.utils.console import error, info, success, warning
 
 app = typer.Typer(help="View logs and traffic UI")
@@ -41,6 +41,10 @@ def _wait_for_datasette(port: int) -> bool:
 def logs_start(
     port: Annotated[int | None, typer.Option("--port", help="Datasette host port")] = None,
     no_open: Annotated[bool, typer.Option("--no-open", help="Do not open browser")] = False,
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
 ) -> None:
     """Start or reuse Datasette for session and proxy logs."""
     config = get_config()
@@ -55,7 +59,7 @@ def logs_start(
     ).expanduser()
 
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=config)
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
@@ -90,10 +94,14 @@ def logs_start(
 @app.command("stop")
 def logs_stop(
     force: Annotated[bool, typer.Option("-f", "--force", help="Force stop")] = False,
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
 ) -> None:
     """Stop the Datasette container."""
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=get_config())
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
@@ -108,10 +116,15 @@ def logs_stop(
 
 
 @app.command("status")
-def logs_status() -> None:
+def logs_status(
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
+) -> None:
     """Show Datasette container status."""
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=get_config())
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
@@ -129,6 +142,10 @@ def logs_status() -> None:
 def logs_ui(
     port: Annotated[int | None, typer.Option("--port", help="Datasette host port")] = None,
     no_open: Annotated[bool, typer.Option("--no-open", help="Do not open browser")] = False,
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
 ) -> None:
     """Alias for `vp logs start`."""
-    logs_start(port=port, no_open=no_open)
+    logs_start(port=port, no_open=no_open, runtime=runtime)

--- a/src/vibepod/commands/logs.py
+++ b/src/vibepod/commands/logs.py
@@ -12,7 +12,7 @@ from typing import Annotated
 import typer
 
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
-from vibepod.core.config import get_config
+from vibepod.core.config import get_config, get_container_userns_mode
 from vibepod.core.docker import DockerClientError, _is_latest_tag, get_manager
 from vibepod.utils.console import error, info, success, warning
 
@@ -45,9 +45,14 @@ def logs_start(
         str | None,
         typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
     ] = None,
+    userns: Annotated[
+        str | None,
+        typer.Option("--userns", help="Container user namespace mode (for example keep-id)"),
+    ] = None,
 ) -> None:
     """Start or reuse Datasette for session and proxy logs."""
     config = get_config()
+    container_userns_mode = get_container_userns_mode(config, override=userns)
     log_cfg = config.get("logging", {})
     proxy_cfg = config.get("proxy", {})
 
@@ -79,6 +84,7 @@ def logs_start(
         logs_db_path=logs_db_path,
         proxy_db_path=proxy_db_path,
         port=datasette_port,
+        userns_mode=container_userns_mode,
     )
 
     if _wait_for_datasette(datasette_port):
@@ -146,6 +152,10 @@ def logs_ui(
         str | None,
         typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
     ] = None,
+    userns: Annotated[
+        str | None,
+        typer.Option("--userns", help="Container user namespace mode (for example keep-id)"),
+    ] = None,
 ) -> None:
     """Alias for `vp logs start`."""
-    logs_start(port=port, no_open=no_open, runtime=runtime)
+    logs_start(port=port, no_open=no_open, runtime=runtime, userns=userns)

--- a/src/vibepod/commands/proxy.py
+++ b/src/vibepod/commands/proxy.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
-from vibepod.core.config import get_config
+from vibepod.core.config import get_config, get_container_userns_mode
 from vibepod.core.docker import DockerClientError, _is_latest_tag, get_manager
 from vibepod.utils.console import error, info, success, warning
 
@@ -21,9 +21,14 @@ def proxy_start(
         str | None,
         typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
     ] = None,
+    userns: Annotated[
+        str | None,
+        typer.Option("--userns", help="Container user namespace mode (for example keep-id)"),
+    ] = None,
 ) -> None:
     """Start the proxy container."""
     config = get_config()
+    container_userns_mode = get_container_userns_mode(config, override=userns)
     proxy_cfg = config.get("proxy", {})
 
     proxy_image = str(proxy_cfg.get("image", "vibepod/proxy:latest"))
@@ -57,6 +62,7 @@ def proxy_start(
         db_path=db_path,
         ca_dir=ca_dir,
         network=network_name,
+        userns_mode=container_userns_mode,
     )
     success("Proxy is running")
 

--- a/src/vibepod/commands/proxy.py
+++ b/src/vibepod/commands/proxy.py
@@ -9,14 +9,19 @@ import typer
 
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
 from vibepod.core.config import get_config
-from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag
+from vibepod.core.docker import DockerClientError, _is_latest_tag, get_manager
 from vibepod.utils.console import error, info, success, warning
 
 app = typer.Typer(help="Manage the HTTP(S) proxy")
 
 
 @app.command("start")
-def proxy_start() -> None:
+def proxy_start(
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
+) -> None:
     """Start the proxy container."""
     config = get_config()
     proxy_cfg = config.get("proxy", {})
@@ -35,7 +40,7 @@ def proxy_start() -> None:
     network_name = str(config.get("network", "vibepod-network"))
 
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=config)
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
@@ -59,10 +64,14 @@ def proxy_start() -> None:
 @app.command("stop")
 def proxy_stop(
     force: Annotated[bool, typer.Option("-f", "--force", help="Force stop")] = False,
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
 ) -> None:
     """Stop the proxy container."""
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=get_config())
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
@@ -77,10 +86,15 @@ def proxy_stop(
 
 
 @app.command("status")
-def proxy_status() -> None:
+def proxy_status(
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
+) -> None:
     """Show proxy container status."""
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=get_config())
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -15,7 +15,7 @@ import typer
 from rich.prompt import Confirm, Prompt
 
 from vibepod import __version__
-from vibepod.constants import EXIT_DOCKER_NOT_RUNNING, SUPPORTED_AGENTS
+from vibepod.constants import EXIT_DOCKER_NOT_RUNNING, RUNTIME_PODMAN, SUPPORTED_AGENTS
 from vibepod.core.agents import (
     agent_config_dir,
     effective_agent_image,
@@ -25,7 +25,7 @@ from vibepod.core.agents import (
 )
 from vibepod.core.allowed_dirs import add_allowed_dir, is_dir_allowed, is_protected_dir
 from vibepod.core.config import get_config
-from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag
+from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag, get_manager
 from vibepod.core.session_logger import SessionLogger
 from vibepod.utils.console import error, info, success, warning
 
@@ -277,6 +277,10 @@ def run(
             help="I Know What I'm Doing: enable auto-approval / skip permission prompts",
         ),
     ] = False,
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
 ) -> None:
     """Start an agent container.
 
@@ -375,7 +379,7 @@ def run(
     image = effective_agent_image(selected_agent, config)
 
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=config)
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
@@ -395,14 +399,30 @@ def run(
 
     command = spec.command
     entrypoint: list[str] | None = None
-    if init_commands:
-        info(f"Applying {len(init_commands)} init command(s) before startup")
+
+    # On rootless Podman the container starts as root (mapped from the host
+    # UID) but often switches to a non-root user via su/gosu.  That non-root
+    # user gets a subordinate UID that can't read files owned by root inside
+    # the container.  Injecting a chmod before the real entrypoint ensures the
+    # config mount is accessible after the user switch.
+    podman_fixup: list[str] = []
+    if manager.runtime == RUNTIME_PODMAN:
+        paths_to_fix = [spec.config_mount_path]
+        extra_volumes_pre = _agent_extra_volumes(selected_agent, agent_config_dir(selected_agent))
+        if extra_volumes_pre:
+            paths_to_fix.extend(cp for _, cp, _ in extra_volumes_pre)
+        quoted = " ".join(f"'{p}'" for p in dict.fromkeys(paths_to_fix))
+        podman_fixup = [f"chmod -R a+rwX {quoted} 2>/dev/null || true"]
+
+    if init_commands or podman_fixup:
+        if init_commands:
+            info(f"Applying {len(init_commands)} init command(s) before startup")
         try:
             command = manager.resolve_launch_command(image=image, command=spec.command)
         except DockerClientError as exc:
             error(str(exc))
             raise typer.Exit(1) from exc
-        entrypoint = _init_entrypoint(init_commands)
+        entrypoint = _init_entrypoint(podman_fixup + init_commands)
 
     if ikwid:
         if spec.ikwid_args:

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -468,8 +468,11 @@ def run(
     proxy_db_path: Path | None = None
 
     extra_volumes = _agent_extra_volumes(selected_agent, config_dir)
-    for host_path, _, _ in extra_volumes:
-        Path(host_path).mkdir(parents=True, exist_ok=True)
+    # Capture the VibePod-managed host paths *before* non-managed volumes
+    # (e.g. X11 sockets) are appended; only these get permission tightening.
+    managed_extra_dirs = list(dict.fromkeys(Path(hp) for hp, _, _ in extra_volumes))
+    for path in managed_extra_dirs:
+        path.mkdir(parents=True, exist_ok=True)
 
     if paste_images:
         display = os.environ.get("DISPLAY", "")
@@ -539,6 +542,7 @@ def run(
         version=__version__,
         network=network_name,
         extra_volumes=extra_volumes,
+        managed_extra_dirs=managed_extra_dirs,
         platform=spec.platform,
         user=container_user,
         userns_mode=container_userns_mode,

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -24,7 +24,7 @@ from vibepod.core.agents import (
     resolve_agent_name,
 )
 from vibepod.core.allowed_dirs import add_allowed_dir, is_dir_allowed, is_protected_dir
-from vibepod.core.config import get_config
+from vibepod.core.config import get_config, get_container_userns_mode
 from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag, get_manager
 from vibepod.core.session_logger import SessionLogger
 from vibepod.utils.console import error, info, success, warning
@@ -281,6 +281,10 @@ def run(
         str | None,
         typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
     ] = None,
+    userns: Annotated[
+        str | None,
+        typer.Option("--userns", help="Container user namespace mode (for example keep-id)"),
+    ] = None,
 ) -> None:
     """Start an agent container.
 
@@ -293,6 +297,7 @@ def run(
         list(click_ctx.args) if click_ctx is not None and click_ctx.args else []
     )
     config = get_config()
+    container_userns_mode = get_container_userns_mode(config, override=userns)
     selected_agent_input = agent or str(config.get("default_agent", "claude"))
     selected_agent = resolve_agent_name(selected_agent_input)
     if selected_agent is None:
@@ -486,11 +491,12 @@ def run(
         if _is_latest_tag(proxy_image):
             manager.pull_if_newer(proxy_image)
 
-        manager.ensure_proxy(
+        proxy_container = manager.ensure_proxy(
             image=proxy_image,
             db_path=proxy_db_path,
             ca_dir=proxy_ca_dir or proxy_db_path.parent / "mitmproxy",
             network=network_name,
+            userns_mode=container_userns_mode,
         )
 
         if proxy_ca_path:
@@ -504,7 +510,8 @@ def run(
             if not ca_ready:
                 warning(f"Proxy CA not found yet at {proxy_ca_path}")
 
-        proxy_url = "http://vibepod-proxy:8080"
+        proxy_host = _get_container_ip(proxy_container, network_name) or "vibepod-proxy"
+        proxy_url = f"http://{proxy_host}:8080"
         merged_env.setdefault("HTTP_PROXY", proxy_url)
         merged_env.setdefault("HTTPS_PROXY", proxy_url)
         merged_env.setdefault("NO_PROXY", "localhost,127.0.0.1,::1")
@@ -534,6 +541,7 @@ def run(
         extra_volumes=extra_volumes,
         platform=spec.platform,
         user=container_user,
+        userns_mode=container_userns_mode,
         entrypoint=entrypoint,
     )
 

--- a/src/vibepod/commands/stop.py
+++ b/src/vibepod/commands/stop.py
@@ -7,7 +7,8 @@ from typing import Annotated
 import typer
 
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
-from vibepod.core.docker import DockerClientError, DockerManager
+from vibepod.core.config import get_config
+from vibepod.core.docker import DockerClientError, get_manager
 from vibepod.utils.console import error, success
 
 
@@ -18,13 +19,17 @@ def stop(
         typer.Option("-a", "--all", help="Stop all VibePod managed containers"),
     ] = False,
     force: Annotated[bool, typer.Option("-f", "--force", help="Force stop")] = False,
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
 ) -> None:
     """Stop one agent container, or all managed containers."""
     if not all_containers and agent is None:
         raise typer.BadParameter("Provide an AGENT or use --all")
 
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime, config=get_config())
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc

--- a/src/vibepod/commands/update.py
+++ b/src/vibepod/commands/update.py
@@ -8,26 +8,34 @@ from typing import Annotated, Any
 import typer
 
 from vibepod import __version__
-from vibepod.core.docker import DockerClientError, DockerManager
+from vibepod.core.config import get_config
+from vibepod.core.docker import DockerClientError, get_manager
 
 
-def _docker_version() -> str:
+def _runtime_version(runtime_override: str | None = None) -> tuple[str, str]:
+    """Return (runtime_name, version_string)."""
     try:
-        manager = DockerManager()
+        manager = get_manager(runtime_override=runtime_override, config=get_config())
         version_info: dict[str, Any] = manager.client.version()
-        return str(version_info.get("Version", "unknown"))
+        return manager.runtime, str(version_info.get("Version", "unknown"))
     except DockerClientError:
-        return "unavailable"
+        return "unknown", "unavailable"
 
 
 def version(
     as_json: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    runtime: Annotated[
+        str | None,
+        typer.Option("--runtime", help="Container runtime to use (docker or podman)"),
+    ] = None,
 ) -> None:
     """Show version and runtime information."""
+    rt_name, rt_version = _runtime_version(runtime_override=runtime)
     info = {
         "vibepod": __version__,
         "python": platform.python_version(),
-        "docker": _docker_version(),
+        "runtime": rt_name,
+        "runtime_version": rt_version,
     }
 
     if as_json:
@@ -38,4 +46,4 @@ def version(
 
     print(f"VibePod CLI: {info['vibepod']}")
     print(f"Python:      {info['python']}")
-    print(f"Docker:      {info['docker']}")
+    print(f"Runtime:     {info['runtime']} {info['runtime_version']}")

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -18,6 +18,16 @@ LOGS_DB_FILE = CONFIG_DIR / "logs.db"
 DOCKER_NETWORK = "vibepod-network"
 CONTAINER_LABEL_MANAGED = "vibepod.managed"
 
+# Container runtime constants
+RUNTIME_AUTO = "auto"
+RUNTIME_DOCKER = "docker"
+RUNTIME_PODMAN = "podman"
+SUPPORTED_RUNTIMES = (RUNTIME_DOCKER, RUNTIME_PODMAN)
+
+DOCKER_SOCKET = "unix:///var/run/docker.sock"
+PODMAN_SOCKET_ROOTLESS = "unix:///run/user/{uid}/podman/podman.sock"
+PODMAN_SOCKET_ROOTFUL = "unix:///run/podman/podman.sock"
+
 SUPPORTED_AGENTS = (
     "claude",
     "gemini",

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -13,6 +13,7 @@ from vibepod.constants import (
     DEFAULT_ALIASES,
     DEFAULT_IMAGES,
     PROJECT_CONFIG_FILE,
+    RUNTIME_AUTO,
 )
 
 
@@ -30,6 +31,7 @@ def _default_config() -> dict[str, Any]:
         "version": 1,
         "default_agent": "claude",
         "auto_pull": True,
+        "container_runtime": RUNTIME_AUTO,
         "auto_remove": True,
         "network": "vibepod-network",
         "log_level": "info",
@@ -147,6 +149,7 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
 def _apply_env(config: dict[str, Any]) -> dict[str, Any]:
     mappings: dict[str, tuple[str, Any]] = {
         "VP_DEFAULT_AGENT": ("default_agent", str),
+        "VP_CONTAINER_RUNTIME": ("container_runtime", str),
         "VP_AUTO_PULL": ("auto_pull", lambda x: x.lower() == "true"),
         "VP_LOG_LEVEL": ("log_level", str),
         "VP_NO_COLOR": ("no_color", lambda x: x.lower() == "true"),

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -147,10 +147,14 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
     return merged
 
 
+def _parse_container_runtime(value: str) -> str:
+    return value.strip().lower()
+
+
 def _apply_env(config: dict[str, Any]) -> dict[str, Any]:
     mappings: dict[str, tuple[str, Any]] = {
         "VP_DEFAULT_AGENT": ("default_agent", str),
-        "VP_CONTAINER_RUNTIME": ("container_runtime", str),
+        "VP_CONTAINER_RUNTIME": ("container_runtime", _parse_container_runtime),
         "VP_CONTAINER_USERNS_MODE": ("container_userns_mode", lambda x: x.strip() or None),
         "VP_AUTO_PULL": ("auto_pull", lambda x: x.lower() == "true"),
         "VP_LOG_LEVEL": ("log_level", str),

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -32,6 +32,7 @@ def _default_config() -> dict[str, Any]:
         "default_agent": "claude",
         "auto_pull": True,
         "container_runtime": RUNTIME_AUTO,
+        "container_userns_mode": None,
         "auto_remove": True,
         "network": "vibepod-network",
         "log_level": "info",
@@ -150,6 +151,7 @@ def _apply_env(config: dict[str, Any]) -> dict[str, Any]:
     mappings: dict[str, tuple[str, Any]] = {
         "VP_DEFAULT_AGENT": ("default_agent", str),
         "VP_CONTAINER_RUNTIME": ("container_runtime", str),
+        "VP_CONTAINER_USERNS_MODE": ("container_userns_mode", lambda x: x.strip() or None),
         "VP_AUTO_PULL": ("auto_pull", lambda x: x.lower() == "true"),
         "VP_LOG_LEVEL": ("log_level", str),
         "VP_NO_COLOR": ("no_color", lambda x: x.lower() == "true"),
@@ -197,6 +199,18 @@ def get_config() -> dict[str, Any]:
 
     config = _apply_env(config)
     return config
+
+
+def get_container_userns_mode(
+    config: dict[str, Any],
+    override: str | None = None,
+) -> str | None:
+    """Return the configured container user namespace mode, if any."""
+    raw: Any = override if override is not None else config.get("container_userns_mode")
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    return value or None
 
 
 def get_config_value(key: str, default: Any = None) -> Any:

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from vibepod.constants import CONTAINER_LABEL_MANAGED
+from vibepod.constants import CONTAINER_LABEL_MANAGED, RUNTIME_DOCKER, RUNTIME_PODMAN
 
 docker: Any | None
 APIError: type[Exception]
@@ -47,6 +47,24 @@ def _is_latest_tag(image: str) -> bool:
     return ":" not in name or name.endswith(":latest")
 
 
+def get_manager(
+    runtime_override: str | None = None,
+    config: dict[str, Any] | None = None,
+) -> DockerManager:
+    """Create a :class:`DockerManager` using the resolved container runtime.
+
+    Delegates runtime detection/selection to :mod:`vibepod.core.runtime`.
+    """
+    from vibepod.core.runtime import resolve_runtime
+
+    try:
+        runtime_name, socket_url = resolve_runtime(override=runtime_override, config=config)
+    except RuntimeError as exc:
+        raise DockerClientError(str(exc)) from exc
+
+    return DockerManager(base_url=socket_url, runtime=runtime_name)
+
+
 def _normalize_command(value: Any) -> list[str]:
     """Normalize Docker command/entrypoint values to a list of strings."""
     if value is None:
@@ -59,16 +77,53 @@ def _normalize_command(value: Any) -> list[str]:
 
 
 class DockerManager:
-    """Manager for all Docker operations."""
+    """Manager for all Docker/Podman operations via the Docker SDK."""
 
-    def __init__(self) -> None:
+    def __init__(self, base_url: str | None = None, runtime: str = RUNTIME_DOCKER) -> None:
         if docker is None:
             raise DockerClientError("Docker SDK not installed")
+        self.runtime = runtime
         try:
-            self.client = docker.from_env()
+            if base_url:
+                self.client = docker.DockerClient(base_url=base_url)
+            else:
+                self.client = docker.from_env()
             self.client.ping()
         except DockerException as exc:
-            raise DockerClientError(f"Docker is not available: {exc}") from exc
+            raise DockerClientError(f"Container runtime is not available: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _prepare_volume_dir(self, path: Path) -> None:
+        """Ensure *path* is accessible inside a rootless Podman container.
+
+        Rootless Podman maps the host UID to root inside the container, but
+        a non-root process started via ``su`` / ``gosu`` in the entrypoint
+        gets a subordinate UID that cannot read host files with standard
+        permissions.  Making VibePod-managed directories world-accessible
+        (``0o777``) avoids "Permission denied" errors without needing
+        ``userns_mode=keep-id`` (which breaks entrypoints that call ``su``).
+
+        This is only applied to directories VibePod itself creates — never
+        to the user's workspace.
+        """
+        if self.runtime != RUNTIME_PODMAN:
+            return
+        try:
+            path.chmod(0o777)
+            for child in path.rglob("*"):
+                try:
+                    child.chmod(0o777 if child.is_dir() else 0o666)
+                except OSError:
+                    pass
+        except OSError:
+            pass
+
+    def _run_container(self, **kwargs: Any) -> Any:
+        """Create and start a container via the high-level SDK."""
+        return self.client.containers.run(**kwargs)
 
     def pull_image(self, image: str) -> None:
         try:
@@ -183,6 +238,12 @@ class DockerManager:
 
         environment = {**env}
 
+        # Ensure VibePod-managed dirs are accessible inside rootless Podman
+        self._prepare_volume_dir(config_dir)
+        if extra_volumes:
+            for host_path, _, _ in extra_volumes:
+                self._prepare_volume_dir(Path(host_path))
+
         volumes: list[str] = [
             f"{workspace}:/workspace:rw",
             f"{config_dir}:{config_mount_path}:rw",
@@ -207,12 +268,12 @@ class DockerManager:
             }
             if platform:
                 run_kwargs["platform"] = platform
-            if user:
-                run_kwargs["user"] = user
             if entrypoint:
                 run_kwargs["entrypoint"] = entrypoint
+            if user:
+                run_kwargs["user"] = user
 
-            return self.client.containers.run(**run_kwargs)
+            return self._run_container(**run_kwargs)
         except APIError as exc:
             raise DockerClientError(f"Failed to start container: {exc}") from exc
 
@@ -258,6 +319,9 @@ class DockerManager:
         if not logs_db_path.exists():
             logs_db_path.touch()
 
+        self._prepare_volume_dir(logs_db_path.parent)
+        self._prepare_volume_dir(proxy_db_path.parent)
+
         logs_parent = Path(os.path.abspath(str(logs_db_path.parent)))
         proxy_parent = Path(os.path.abspath(str(proxy_db_path.parent)))
 
@@ -273,19 +337,21 @@ class DockerManager:
             logs_db_container_path = f"/mount/logs/{logs_db_path.name}"
             proxy_db_container_path = f"/mount/proxy/{proxy_db_path.name}"
 
-        return self.client.containers.run(
-            image=image,
-            name="vibepod-datasette",
-            detach=True,
-            labels={"vibepod.managed": "true", "vibepod.role": "datasette"},
-            environment={
+        run_kwargs: dict[str, Any] = {
+            "image": image,
+            "name": "vibepod-datasette",
+            "detach": True,
+            "labels": {"vibepod.managed": "true", "vibepod.role": "datasette"},
+            "environment": {
                 "LOGS_DB_PATH": logs_db_container_path,
                 "PROXY_DB_PATH": proxy_db_container_path,
                 "DATASETTE_PORT": "8001",
             },
-            volumes=volumes,
-            ports={"8001/tcp": port},
-        )
+            "volumes": volumes,
+            "ports": {"8001/tcp": port},
+        }
+
+        return self._run_container(**run_kwargs)
 
     def find_proxy(self) -> Any | None:
         containers = self.client.containers.list(
@@ -302,6 +368,9 @@ class DockerManager:
 
         db_path.parent.mkdir(parents=True, exist_ok=True)
         ca_dir.mkdir(parents=True, exist_ok=True)
+
+        self._prepare_volume_dir(db_path.parent)
+        self._prepare_volume_dir(ca_dir)
 
         volumes = {
             str(db_path.parent): {"bind": "/data", "mode": "rw"},
@@ -322,15 +391,23 @@ class DockerManager:
             "extra_hosts": {"host.docker.internal": "host-gateway"},
         }
 
-        getuid = getattr(os, "getuid", None)
-        getgid = getattr(os, "getgid", None)
-        if callable(getuid) and callable(getgid):
-            run_kwargs["user"] = f"{getuid()}:{getgid()}"
+        if self.runtime != RUNTIME_PODMAN:
+            getuid = getattr(os, "getuid", None)
+            getgid = getattr(os, "getgid", None)
+            if callable(getuid) and callable(getgid):
+                run_kwargs["user"] = f"{getuid()}:{getgid()}"
 
-        return self.client.containers.run(**run_kwargs)
+        return self._run_container(**run_kwargs)
 
     def attach_interactive(self, container: Any, logger: Any = None) -> None:
         """Attach local stdin/stdout to a running container TTY."""
+        if self.runtime == RUNTIME_PODMAN:
+            import logging
+
+            logging.getLogger(__name__).debug(
+                "Interactive attach via Podman compat API — "
+                "if you experience issues, try running with Docker instead."
+            )
 
         def resize_tty() -> None:
             size = shutil.get_terminal_size(fallback=(120, 40))

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -122,6 +122,27 @@ class DockerManager:
         except OSError:
             pass
 
+    def _resolved_userns_mode(self, userns_mode: str | None) -> str | None:
+        """Normalize user namespace modes per runtime.
+
+        Podman supports modes like ``keep-id`` that Docker rejects, so only
+        forward values that make sense for the selected runtime.
+        """
+        if userns_mode is None:
+            return None
+
+        normalized = userns_mode.strip().lower()
+        if not normalized:
+            return None
+
+        if self.runtime == RUNTIME_PODMAN:
+            return normalized if normalized in {"auto", "keep-id", "nomap"} else None
+
+        if normalized in {"auto", "keep-id", "nomap"}:
+            return None
+
+        return normalized
+
     def _run_container(self, **kwargs: Any) -> Any:
         """Create and start a container via the high-level SDK."""
         return self.client.containers.run(**kwargs)
@@ -254,6 +275,7 @@ class DockerManager:
             volumes.extend(f"{host}:{bind}:{mode}" for host, bind, mode in extra_volumes)
 
         try:
+            resolved_userns_mode = self._resolved_userns_mode(userns_mode)
             run_kwargs: dict[str, Any] = {
                 "image": image,
                 "name": container_name,
@@ -274,8 +296,8 @@ class DockerManager:
                 run_kwargs["entrypoint"] = entrypoint
             if user:
                 run_kwargs["user"] = user
-            if userns_mode:
-                run_kwargs["userns_mode"] = userns_mode
+            if resolved_userns_mode:
+                run_kwargs["userns_mode"] = resolved_userns_mode
 
             return self._run_container(**run_kwargs)
         except APIError as exc:
@@ -346,6 +368,7 @@ class DockerManager:
             logs_db_container_path = f"/mount/logs/{logs_db_path.name}"
             proxy_db_container_path = f"/mount/proxy/{proxy_db_path.name}"
 
+        resolved_userns_mode = self._resolved_userns_mode(userns_mode)
         run_kwargs: dict[str, Any] = {
             "image": image,
             "name": "vibepod-datasette",
@@ -359,8 +382,8 @@ class DockerManager:
             "volumes": volumes,
             "ports": {"8001/tcp": port},
         }
-        if userns_mode:
-            run_kwargs["userns_mode"] = userns_mode
+        if resolved_userns_mode:
+            run_kwargs["userns_mode"] = resolved_userns_mode
 
         return self._run_container(**run_kwargs)
 
@@ -414,13 +437,14 @@ class DockerManager:
             "extra_hosts": {"host.docker.internal": "host-gateway"},
         }
 
+        resolved_userns_mode = self._resolved_userns_mode(userns_mode)
         if self.runtime != RUNTIME_PODMAN:
             getuid = getattr(os, "getuid", None)
             getgid = getattr(os, "getgid", None)
             if callable(getuid) and callable(getgid):
                 run_kwargs["user"] = f"{getuid()}:{getgid()}"
-        if userns_mode:
-            run_kwargs["userns_mode"] = userns_mode
+        if resolved_userns_mode:
+            run_kwargs["userns_mode"] = resolved_userns_mode
 
         container = self._run_container(**run_kwargs)
         try:

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -59,7 +59,7 @@ def get_manager(
 
     try:
         runtime_name, socket_url = resolve_runtime(override=runtime_override, config=config)
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         raise DockerClientError(str(exc)) from exc
 
     return DockerManager(base_url=socket_url, runtime=runtime_name)

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+import yaml
+
 from vibepod.constants import CONTAINER_LABEL_MANAGED, RUNTIME_DOCKER, RUNTIME_PODMAN
 
 docker: Any | None
@@ -61,6 +63,10 @@ def get_manager(
         runtime_name, socket_url = resolve_runtime(override=runtime_override, config=config)
     except (RuntimeError, ValueError) as exc:
         raise DockerClientError(str(exc)) from exc
+    except OSError as exc:
+        raise DockerClientError(f"Failed to access runtime config: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise DockerClientError(f"Failed to parse runtime config: {exc}") from exc
 
     return DockerManager(base_url=socket_url, runtime=runtime_name)
 
@@ -97,26 +103,23 @@ class DockerManager:
     # ------------------------------------------------------------------
 
     def _prepare_volume_dir(self, path: Path) -> None:
-        """Ensure *path* is accessible inside a rootless Podman container.
+        """Tighten permissions on VibePod-managed bind-mount sources.
 
-        Rootless Podman maps the host UID to root inside the container, but
-        a non-root process started via ``su`` / ``gosu`` in the entrypoint
-        gets a subordinate UID that cannot read host files with standard
-        permissions.  Making VibePod-managed directories world-accessible
-        (``0o777``) avoids "Permission denied" errors in the default Podman
-        setup. Users can opt into ``userns_mode=keep-id`` for compatible
-        images, but entrypoints that switch users may still need this fallback.
-
-        This is only applied to directories VibePod itself creates — never
-        to the user's workspace.
+        These directories hold sensitive state (agent credentials, the
+        mitmproxy CA private key, proxy/logs DBs) and must stay owner-only
+        on the host. Container access is arranged without widening host
+        perms: rootless Podman maps the host UID to container root by
+        default (owner can read), ``userns_mode=keep-id`` keeps the UID,
+        and for user-switching agent images an in-container chmod fixup
+        runs as root before the user-switch (see ``commands/run.py``).
         """
         if self.runtime != RUNTIME_PODMAN:
             return
         try:
-            path.chmod(0o777)
+            path.chmod(0o700)
             for child in path.rglob("*"):
                 try:
-                    child.chmod(0o777 if child.is_dir() else 0o666)
+                    child.chmod(0o700 if child.is_dir() else 0o600)
                 except OSError:
                     pass
         except OSError:
@@ -245,6 +248,7 @@ class DockerManager:
         version: str,
         network: str | None = None,
         extra_volumes: list[tuple[str, str, str]] | None = None,
+        managed_extra_dirs: list[Path] | None = None,
         platform: str | None = None,
         user: str | None = None,
         userns_mode: str | None = None,
@@ -261,11 +265,13 @@ class DockerManager:
 
         environment = {**env}
 
-        # Ensure VibePod-managed dirs are accessible inside rootless Podman
+        # Ensure VibePod-managed dirs are accessible inside rootless Podman.
+        # Only explicitly declared managed dirs are tightened; generic
+        # extra_volumes (e.g. X11 sockets) must not be touched.
         self._prepare_volume_dir(config_dir)
-        if extra_volumes:
-            for host_path, _, _ in extra_volumes:
-                self._prepare_volume_dir(Path(host_path))
+        if managed_extra_dirs:
+            for path in managed_extra_dirs:
+                self._prepare_volume_dir(path)
 
         volumes: list[str] = [
             f"{workspace}:/workspace:rw",

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -103,8 +103,9 @@ class DockerManager:
         a non-root process started via ``su`` / ``gosu`` in the entrypoint
         gets a subordinate UID that cannot read host files with standard
         permissions.  Making VibePod-managed directories world-accessible
-        (``0o777``) avoids "Permission denied" errors without needing
-        ``userns_mode=keep-id`` (which breaks entrypoints that call ``su``).
+        (``0o777``) avoids "Permission denied" errors in the default Podman
+        setup. Users can opt into ``userns_mode=keep-id`` for compatible
+        images, but entrypoints that switch users may still need this fallback.
 
         This is only applied to directories VibePod itself creates — never
         to the user's workspace.
@@ -225,6 +226,7 @@ class DockerManager:
         extra_volumes: list[tuple[str, str, str]] | None = None,
         platform: str | None = None,
         user: str | None = None,
+        userns_mode: str | None = None,
         entrypoint: list[str] | None = None,
     ) -> Any:
         container_name = name or f"vibepod-{agent}-{uuid4().hex[:8]}"
@@ -272,6 +274,8 @@ class DockerManager:
                 run_kwargs["entrypoint"] = entrypoint
             if user:
                 run_kwargs["user"] = user
+            if userns_mode:
+                run_kwargs["userns_mode"] = userns_mode
 
             return self._run_container(**run_kwargs)
         except APIError as exc:
@@ -304,7 +308,12 @@ class DockerManager:
         return containers[0] if containers else None
 
     def ensure_datasette(
-        self, image: str, logs_db_path: Path, proxy_db_path: Path, port: int
+        self,
+        image: str,
+        logs_db_path: Path,
+        proxy_db_path: Path,
+        port: int,
+        userns_mode: str | None = None,
     ) -> Any:
         existing = self.find_datasette()
         if existing:
@@ -350,6 +359,8 @@ class DockerManager:
             "volumes": volumes,
             "ports": {"8001/tcp": port},
         }
+        if userns_mode:
+            run_kwargs["userns_mode"] = userns_mode
 
         return self._run_container(**run_kwargs)
 
@@ -359,10 +370,22 @@ class DockerManager:
         )
         return containers[0] if containers else None
 
-    def ensure_proxy(self, image: str, db_path: Path, ca_dir: Path, network: str) -> Any:
+    def ensure_proxy(
+        self,
+        image: str,
+        db_path: Path,
+        ca_dir: Path,
+        network: str,
+        userns_mode: str | None = None,
+    ) -> Any:
         existing = self.find_proxy()
         if existing:
+            existing.reload()
             if existing.status == "running":
+                attached = existing.attrs.get("NetworkSettings", {}).get("Networks", {}) or {}
+                if network not in attached:
+                    self.connect_network(existing, network)
+                    existing.reload()
                 return existing
             existing.remove(force=True)
 
@@ -396,8 +419,15 @@ class DockerManager:
             getgid = getattr(os, "getgid", None)
             if callable(getuid) and callable(getgid):
                 run_kwargs["user"] = f"{getuid()}:{getgid()}"
+        if userns_mode:
+            run_kwargs["userns_mode"] = userns_mode
 
-        return self._run_container(**run_kwargs)
+        container = self._run_container(**run_kwargs)
+        try:
+            container.reload()
+        except Exception:
+            pass
+        return container
 
     def attach_interactive(self, container: Any, logger: Any = None) -> None:
         """Attach local stdin/stdout to a running container TTY."""

--- a/src/vibepod/core/runtime.py
+++ b/src/vibepod/core/runtime.py
@@ -1,0 +1,163 @@
+"""Container runtime detection and selection (Docker / Podman)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import yaml
+
+from vibepod.constants import (
+    DOCKER_SOCKET,
+    PODMAN_SOCKET_ROOTFUL,
+    PODMAN_SOCKET_ROOTLESS,
+    RUNTIME_AUTO,
+    RUNTIME_DOCKER,
+    RUNTIME_PODMAN,
+    SUPPORTED_RUNTIMES,
+)
+from vibepod.core.config import get_config_root
+
+
+def _socket_candidates() -> list[tuple[str, str]]:
+    """Return (runtime_name, socket_url) pairs to probe.
+
+    For Podman the rootless socket is preferred.  ``XDG_RUNTIME_DIR`` is
+    checked first (works on all distros), then the conventional
+    ``/run/user/{uid}`` path.  The rootful socket is only included when
+    running as root, since it requires elevated privileges otherwise.
+    """
+    candidates: list[tuple[str, str]] = [(RUNTIME_DOCKER, DOCKER_SOCKET)]
+
+    uid = os.getuid() if hasattr(os, "getuid") else 1000
+
+    # Rootless Podman — prefer XDG_RUNTIME_DIR, fall back to /run/user/{uid}
+    xdg_runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg_runtime:
+        candidates.append(
+            (RUNTIME_PODMAN, f"unix://{xdg_runtime}/podman/podman.sock")
+        )
+    candidates.append(
+        (RUNTIME_PODMAN, PODMAN_SOCKET_ROOTLESS.format(uid=uid))
+    )
+
+    # Rootful Podman — only useful when already running as root
+    if uid == 0:
+        candidates.append((RUNTIME_PODMAN, PODMAN_SOCKET_ROOTFUL))
+
+    return candidates
+
+
+def _probe_socket(base_url: str) -> bool:
+    """Return True if a container engine responds on *base_url*."""
+    try:
+        import docker as _docker
+
+        client = _docker.DockerClient(base_url=base_url, timeout=3)
+        client.ping()
+        client.close()
+        return True
+    except Exception:
+        return False
+
+
+def detect_available_runtimes() -> dict[str, str]:
+    """Detect which container runtimes are reachable.
+
+    Returns a dict mapping runtime name to the first working socket URL,
+    e.g. ``{"docker": "unix:///var/run/docker.sock"}``.
+    """
+    found: dict[str, str] = {}
+    for name, url in _socket_candidates():
+        if name in found:
+            continue
+        if _probe_socket(url):
+            found[name] = url
+    return found
+
+
+def save_runtime_preference(runtime: str) -> None:
+    """Persist *runtime* as ``container_runtime`` in the global config file."""
+    config_path = get_config_root() / "config.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict[str, Any] = {}
+    if config_path.exists():
+        content = config_path.read_text(encoding="utf-8")
+        if content.strip():
+            loaded = yaml.safe_load(content)
+            if isinstance(loaded, dict):
+                existing = loaded
+
+    existing["container_runtime"] = runtime
+    config_path.write_text(yaml.safe_dump(existing, sort_keys=False), encoding="utf-8")
+
+
+def resolve_runtime(
+    override: str | None = None,
+    config: dict[str, Any] | None = None,
+) -> tuple[str, str]:
+    """Determine which container runtime and socket to use.
+
+    Priority:
+    1. *override* (``--runtime`` CLI flag)
+    2. ``VP_CONTAINER_RUNTIME`` env var
+    3. ``container_runtime`` config key (saved preference)
+    4. Auto-detect: single runtime → use it; both → prompt (or Docker in non-TTY)
+
+    Returns ``(runtime_name, socket_url)``.
+
+    Raises ``RuntimeError`` when no runtime is available.
+    """
+    from rich.prompt import Prompt
+
+    cfg = config or {}
+
+    # --- explicit choice (flag → env → config) ---
+    explicit: str | None = override
+    if explicit is None:
+        explicit = os.environ.get("VP_CONTAINER_RUNTIME")
+    if explicit is None:
+        saved = cfg.get("container_runtime", RUNTIME_AUTO)
+        if saved != RUNTIME_AUTO:
+            explicit = str(saved)
+
+    available = detect_available_runtimes()
+
+    if explicit is not None:
+        explicit = explicit.lower()
+        if explicit not in SUPPORTED_RUNTIMES:
+            raise RuntimeError(
+                f"Unknown container runtime '{explicit}'. "
+                f"Supported: {', '.join(SUPPORTED_RUNTIMES)}"
+            )
+        if explicit not in available:
+            raise RuntimeError(
+                f"Container runtime '{explicit}' is not available. "
+                "Is the daemon/service running?"
+            )
+        return explicit, available[explicit]
+
+    # --- auto-detect ---
+    if not available:
+        raise RuntimeError(
+            "No container runtime found. Install and start Docker or Podman."
+        )
+
+    if len(available) == 1:
+        name = next(iter(available))
+        return name, available[name]
+
+    # Both available — prompt if interactive, else default to Docker
+    if sys.stdin.isatty():
+        choice = Prompt.ask(
+            "Multiple container runtimes detected. Which one should VibePod use?",
+            choices=list(SUPPORTED_RUNTIMES),
+            default=RUNTIME_DOCKER,
+        )
+        save_runtime_preference(choice)
+        return choice, available[choice]
+
+    return RUNTIME_DOCKER, available[RUNTIME_DOCKER]
+

--- a/src/vibepod/core/runtime.py
+++ b/src/vibepod/core/runtime.py
@@ -185,7 +185,7 @@ def resolve_runtime(
     available = detect_available_runtimes()
 
     if explicit is not None:
-        explicit = explicit.lower()
+        explicit = explicit.strip().lower()
         if explicit not in SUPPORTED_RUNTIMES:
             raise RuntimeError(
                 f"Unknown container runtime '{explicit}'. "

--- a/src/vibepod/core/runtime.py
+++ b/src/vibepod/core/runtime.py
@@ -19,6 +19,8 @@ from vibepod.constants import (
 )
 from vibepod.core.config import get_config_root
 
+DEFAULT_RUNTIME_PROBE_TIMEOUT = 10.0
+
 
 def _socket_candidates() -> list[tuple[str, str]]:
     """Return (runtime_name, socket_url) pairs to probe.
@@ -49,12 +51,29 @@ def _socket_candidates() -> list[tuple[str, str]]:
     return candidates
 
 
+def _runtime_probe_timeout() -> float:
+    """Return the timeout used for container runtime detection probes."""
+    raw = os.environ.get("VP_RUNTIME_PROBE_TIMEOUT")
+    if raw is None:
+        return DEFAULT_RUNTIME_PROBE_TIMEOUT
+    try:
+        timeout = float(raw)
+    except ValueError:
+        return DEFAULT_RUNTIME_PROBE_TIMEOUT
+    return timeout if timeout > 0 else DEFAULT_RUNTIME_PROBE_TIMEOUT
+
+
 def _probe_socket(base_url: str) -> bool:
     """Return True if a container engine responds on *base_url*."""
     try:
         import docker as _docker
 
-        client = _docker.DockerClient(base_url=base_url, timeout=3)
+        # Podman's Docker-compatible API can take several seconds to answer
+        # even simple probes on some hosts, so use a wider timeout here.
+        client = _docker.DockerClient(
+            base_url=base_url,
+            timeout=_runtime_probe_timeout(),
+        )
         client.ping()
         client.close()
         return True
@@ -151,13 +170,20 @@ def resolve_runtime(
 
     # Both available — prompt if interactive, else default to Docker
     if sys.stdin.isatty():
+        prompt_choices = list(available)
+        default_choice = RUNTIME_DOCKER if RUNTIME_DOCKER in available else prompt_choices[0]
         choice = Prompt.ask(
             "Multiple container runtimes detected. Which one should VibePod use?",
-            choices=list(SUPPORTED_RUNTIMES),
-            default=RUNTIME_DOCKER,
+            choices=prompt_choices,
+            default=default_choice,
         )
+        selected_url = available.get(choice)
+        if selected_url is None:
+            raise RuntimeError(
+                f"Container runtime '{choice}' is not available. "
+                "Is the daemon/service running?"
+            )
         save_runtime_preference(choice)
-        return choice, available[choice]
+        return choice, selected_url
 
     return RUNTIME_DOCKER, available[RUNTIME_DOCKER]
-

--- a/src/vibepod/core/runtime.py
+++ b/src/vibepod/core/runtime.py
@@ -22,6 +22,10 @@ from vibepod.core.config import get_config_root
 DEFAULT_RUNTIME_PROBE_TIMEOUT = 10.0
 
 
+def _allowed_runtime_preferences() -> tuple[str, ...]:
+    return (RUNTIME_AUTO, *SUPPORTED_RUNTIMES)
+
+
 def _socket_candidates() -> list[tuple[str, str]]:
     """Return (runtime_name, socket_url) pairs to probe.
 
@@ -96,8 +100,41 @@ def detect_available_runtimes() -> dict[str, str]:
     return found
 
 
+def get_saved_runtime_preference() -> str:
+    """Return the saved global ``container_runtime`` preference."""
+    config_path = get_config_root() / "config.yaml"
+    if not config_path.exists():
+        return RUNTIME_AUTO
+
+    content = config_path.read_text(encoding="utf-8")
+    if not content.strip():
+        return RUNTIME_AUTO
+
+    loaded = yaml.safe_load(content)
+    if loaded is None:
+        return RUNTIME_AUTO
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Global config must contain a YAML mapping: {config_path}")
+
+    saved = loaded.get("container_runtime", RUNTIME_AUTO)
+    runtime = str(saved).strip().lower() or RUNTIME_AUTO
+    if runtime not in _allowed_runtime_preferences():
+        raise ValueError(
+            f"Unknown container runtime '{runtime}'. "
+            f"Supported: {', '.join(_allowed_runtime_preferences())}"
+        )
+    return runtime
+
+
 def save_runtime_preference(runtime: str) -> None:
     """Persist *runtime* as ``container_runtime`` in the global config file."""
+    normalized = runtime.strip().lower()
+    if normalized not in _allowed_runtime_preferences():
+        raise ValueError(
+            f"Unknown container runtime '{normalized}'. "
+            f"Supported: {', '.join(_allowed_runtime_preferences())}"
+        )
+
     config_path = get_config_root() / "config.yaml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -106,10 +143,13 @@ def save_runtime_preference(runtime: str) -> None:
         content = config_path.read_text(encoding="utf-8")
         if content.strip():
             loaded = yaml.safe_load(content)
-            if isinstance(loaded, dict):
-                existing = loaded
+            if loaded is None:
+                loaded = {}
+            if not isinstance(loaded, dict):
+                raise ValueError(f"Global config must contain a YAML mapping: {config_path}")
+            existing = loaded
 
-    existing["container_runtime"] = runtime
+    existing["container_runtime"] = normalized
     config_path.write_text(yaml.safe_dump(existing, sort_keys=False), encoding="utf-8")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,6 +139,15 @@ def test_container_userns_mode_env_override(monkeypatch, tmp_path: Path) -> None
     assert config["container_userns_mode"] == "keep-id"
 
 
+def test_container_runtime_env_override_is_normalized(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("VP_CONTAINER_RUNTIME", " PodMan ")
+    config = get_config()
+    assert config["container_runtime"] == "podman"
+
+
 def test_per_agent_auto_pull_override(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
     global_config = tmp_path / "config.yaml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,6 +126,19 @@ def test_default_config_exposes_agent_auto_pull(monkeypatch, tmp_path: Path) -> 
         assert agents[agent]["auto_pull"] is None
 
 
+def test_default_config_exposes_container_userns_mode(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    config = get_config()
+    assert config["container_userns_mode"] is None
+
+
+def test_container_userns_mode_env_override(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("VP_CONTAINER_USERNS_MODE", "keep-id")
+    config = get_config()
+    assert config["container_userns_mode"] == "keep-id"
+
+
 def test_per_agent_auto_pull_override(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
     global_config = tmp_path / "config.yaml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -267,3 +267,43 @@ def test_list_allowed_dirs_empty(monkeypatch, tmp_path: Path) -> None:
     result = runner.invoke(app, ["config", "list-allowed-dirs"])
     assert result.exit_code == 0
     assert "No directories" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# runtime subcommand tests
+# ---------------------------------------------------------------------------
+
+
+def test_config_runtime_shows_saved_global_runtime(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+
+    result = runner.invoke(app, ["config", "runtime"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "auto"
+
+
+def test_config_runtime_updates_global_config(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    global_config = tmp_path / "config.yaml"
+    global_config.write_text("default_agent: codex\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["config", "runtime", "podman"])
+
+    assert result.exit_code == 0
+    loaded = yaml.safe_load(global_config.read_text(encoding="utf-8"))
+    assert loaded == {
+        "default_agent": "codex",
+        "container_runtime": "podman",
+    }
+    assert "Set default container runtime to 'podman'" in result.stdout
+
+
+def test_config_runtime_rejects_unknown_value(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+
+    result = runner.invoke(app, ["config", "runtime", "nerdctl"])
+
+    assert result.exit_code == 1
+    assert "Supported: auto, docker, podman" in result.stdout
+    assert not (tmp_path / "config.yaml").exists()

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -18,7 +18,7 @@ def test_list_json_includes_short_and_full_agent_names(monkeypatch) -> None:
         def list_managed(self, all_containers: bool = True):  # noqa: ARG002
             return []
 
-    monkeypatch.setattr(list_cmd, "DockerManager", _FakeDockerManager)
+    monkeypatch.setattr(list_cmd, "get_manager", lambda **kwargs: _FakeDockerManager())
 
     result = runner.invoke(app, ["list", "--json"])
     assert result.exit_code == 0
@@ -61,7 +61,7 @@ def test_list_running_json_preserves_multiple_instances(monkeypatch) -> None:
                 ),
             ]
 
-    monkeypatch.setattr(list_cmd, "DockerManager", _FakeDockerManager)
+    monkeypatch.setattr(list_cmd, "get_manager", lambda **kwargs: _FakeDockerManager())
 
     result = runner.invoke(app, ["list", "--running", "--json"])
     assert result.exit_code == 0

--- a/tests/test_proxy_permissions.py
+++ b/tests/test_proxy_permissions.py
@@ -51,7 +51,7 @@ def test_update_container_mapping_permission_error_returns_false(
     assert updated is False
 
 
-def test_ensure_proxy_runs_container_as_current_user_and_forwards_userns_mode(
+def test_ensure_proxy_runs_container_as_current_user_and_omits_podman_userns_mode_on_docker(
     tmp_path: Path, monkeypatch
 ) -> None:
     class _FakeContainers:
@@ -87,7 +87,7 @@ def test_ensure_proxy_runs_container_as_current_user_and_forwards_userns_mode(
     run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
     assert run_kwargs is not None
     assert run_kwargs["user"] == "1234:2345"
-    assert run_kwargs["userns_mode"] == "keep-id"
+    assert "userns_mode" not in run_kwargs
     assert "ports" not in run_kwargs
     assert run_kwargs["extra_hosts"] == {"host.docker.internal": "host-gateway"}
     assert db_path.parent.exists()
@@ -120,6 +120,74 @@ def test_ensure_datasette_forwards_userns_mode(tmp_path: Path, monkeypatch) -> N
         logs_db_path=logs_db_path,
         proxy_db_path=proxy_db_path,
         port=8001,
+        userns_mode="keep-id",
+    )
+
+    run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
+    assert run_kwargs is not None
+    assert run_kwargs["userns_mode"] == "keep-id"
+
+
+def test_ensure_datasette_omits_podman_userns_mode_on_docker(tmp_path: Path, monkeypatch) -> None:
+    class _FakeContainers:
+        def __init__(self) -> None:
+            self.run_kwargs: dict | None = None
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+            return {"id": "datasette"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "docker"
+
+    monkeypatch.setattr(DockerManager, "find_datasette", lambda self: None)
+
+    logs_db_path = tmp_path / "logs" / "logs.db"
+    proxy_db_path = tmp_path / "proxy" / "proxy.db"
+    manager.ensure_datasette(
+        image="vibepod/datasette:latest",
+        logs_db_path=logs_db_path,
+        proxy_db_path=proxy_db_path,
+        port=8001,
+        userns_mode="keep-id",
+    )
+
+    run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
+    assert run_kwargs is not None
+    assert "userns_mode" not in run_kwargs
+
+
+def test_ensure_proxy_forwards_podman_userns_mode(tmp_path: Path, monkeypatch) -> None:
+    class _FakeContainers:
+        def __init__(self) -> None:
+            self.run_kwargs: dict | None = None
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+            return {"id": "proxy"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "podman"
+
+    monkeypatch.setattr(DockerManager, "find_proxy", lambda self: None)
+
+    db_path = tmp_path / "proxy" / "proxy.db"
+    ca_dir = tmp_path / "proxy" / "mitmproxy"
+    manager.ensure_proxy(
+        image="vibepod/proxy:latest",
+        db_path=db_path,
+        ca_dir=ca_dir,
+        network="vibepod-network",
         userns_mode="keep-id",
     )
 

--- a/tests/test_proxy_permissions.py
+++ b/tests/test_proxy_permissions.py
@@ -66,6 +66,7 @@ def test_ensure_proxy_runs_container_as_current_user(tmp_path: Path, monkeypatch
 
     manager = object.__new__(DockerManager)
     manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "docker"
 
     monkeypatch.setattr(DockerManager, "find_proxy", lambda self: None)
     monkeypatch.setattr(docker_mod.os, "getuid", lambda: 1234)

--- a/tests/test_proxy_permissions.py
+++ b/tests/test_proxy_permissions.py
@@ -51,7 +51,9 @@ def test_update_container_mapping_permission_error_returns_false(
     assert updated is False
 
 
-def test_ensure_proxy_runs_container_as_current_user(tmp_path: Path, monkeypatch) -> None:
+def test_ensure_proxy_runs_container_as_current_user_and_forwards_userns_mode(
+    tmp_path: Path, monkeypatch
+) -> None:
     class _FakeContainers:
         def __init__(self) -> None:
             self.run_kwargs: dict | None = None
@@ -79,12 +81,81 @@ def test_ensure_proxy_runs_container_as_current_user(tmp_path: Path, monkeypatch
         db_path=db_path,
         ca_dir=ca_dir,
         network="vibepod-network",
+        userns_mode="keep-id",
     )
 
     run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
     assert run_kwargs is not None
     assert run_kwargs["user"] == "1234:2345"
+    assert run_kwargs["userns_mode"] == "keep-id"
     assert "ports" not in run_kwargs
     assert run_kwargs["extra_hosts"] == {"host.docker.internal": "host-gateway"}
     assert db_path.parent.exists()
     assert ca_dir.exists()
+
+
+def test_ensure_datasette_forwards_userns_mode(tmp_path: Path, monkeypatch) -> None:
+    class _FakeContainers:
+        def __init__(self) -> None:
+            self.run_kwargs: dict | None = None
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+            return {"id": "datasette"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "podman"
+
+    monkeypatch.setattr(DockerManager, "find_datasette", lambda self: None)
+
+    logs_db_path = tmp_path / "logs" / "logs.db"
+    proxy_db_path = tmp_path / "proxy" / "proxy.db"
+    manager.ensure_datasette(
+        image="vibepod/datasette:latest",
+        logs_db_path=logs_db_path,
+        proxy_db_path=proxy_db_path,
+        port=8001,
+        userns_mode="keep-id",
+    )
+
+    run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
+    assert run_kwargs is not None
+    assert run_kwargs["userns_mode"] == "keep-id"
+
+
+def test_ensure_proxy_connects_existing_proxy_to_requested_network(monkeypatch) -> None:
+    connected: list[tuple[object, str]] = []
+
+    class _Proxy:
+        def __init__(self) -> None:
+            self.status = "running"
+            self.attrs = {"NetworkSettings": {"Networks": {"old-network": {}}}}
+
+        def reload(self) -> None:
+            pass
+
+    manager = object.__new__(DockerManager)
+    manager.runtime = "podman"
+    existing = _Proxy()
+
+    monkeypatch.setattr(DockerManager, "find_proxy", lambda self: existing)
+    monkeypatch.setattr(
+        DockerManager,
+        "connect_network",
+        lambda self, container, network_name: connected.append((container, network_name)),
+    )
+
+    returned = manager.ensure_proxy(
+        image="vibepod/proxy:latest",
+        db_path=Path("/tmp/proxy.db"),
+        ca_dir=Path("/tmp/mitmproxy"),
+        network="vibepod-network",
+    )
+
+    assert returned is existing
+    assert connected == [(existing, "vibepod-network")]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -66,6 +66,7 @@ def test_run_agent_supports_duplicate_host_mounts(tmp_path: Path) -> None:
 
     manager = object.__new__(DockerManager)
     manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "docker"
 
     workspace = tmp_path / "workspace"
     config_dir = tmp_path / "agents" / "auggie"
@@ -115,6 +116,7 @@ def test_run_agent_forwards_platform_and_user(tmp_path: Path) -> None:
 
     manager = object.__new__(DockerManager)
     manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "docker"
 
     workspace = tmp_path / "workspace"
     config_dir = tmp_path / "agents" / "devstral"
@@ -158,6 +160,7 @@ def test_run_agent_forwards_entrypoint(tmp_path: Path) -> None:
 
     manager = object.__new__(DockerManager)
     manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "docker"
 
     workspace = tmp_path / "workspace"
     config_dir = tmp_path / "agents" / "claude"
@@ -1244,16 +1247,15 @@ def test_llm_per_agent_env_overrides_llm(monkeypatch, tmp_path: Path) -> None:
 
 
 def test_run_accepts_short_agent_name(monkeypatch, tmp_path: Path) -> None:
-    class _UnavailableDockerManager:
-        def __init__(self) -> None:
-            raise DockerClientError("Docker unavailable")
+    def _unavailable_get_manager(**kwargs):
+        raise DockerClientError("Docker unavailable")
 
     monkeypatch.setattr(
         run_cmd,
         "get_config",
         lambda: {"default_agent": "claude", "agents": {"claude": {"env": {}}}},
     )
-    monkeypatch.setattr(run_cmd, "DockerManager", _UnavailableDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", _unavailable_get_manager)
 
     with pytest.raises(typer.Exit) as exc:
         run_cmd.run(agent="c", workspace=tmp_path)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -187,6 +187,90 @@ def test_run_agent_forwards_userns_mode(tmp_path: Path) -> None:
     assert run_kwargs["userns_mode"] == "keep-id"
 
 
+def test_run_agent_omits_podman_userns_mode_for_docker(tmp_path: Path) -> None:
+    class _FakeContainers:
+        def __init__(self) -> None:
+            self.run_kwargs: dict | None = None
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+            return {"id": "agent"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "docker"
+
+    workspace = tmp_path / "workspace"
+    config_dir = tmp_path / "agents" / "claude"
+    workspace.mkdir(parents=True, exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    manager.run_agent(
+        agent="claude",
+        image="vibepod/claude:latest",
+        workspace=workspace,
+        config_dir=config_dir,
+        config_mount_path="/claude",
+        env={},
+        command=["claude"],
+        auto_remove=True,
+        name=None,
+        version="0.2.1",
+        network="vibepod-network",
+        userns_mode="keep-id",
+    )
+
+    run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
+    assert run_kwargs is not None
+    assert "userns_mode" not in run_kwargs
+
+
+def test_run_agent_preserves_host_userns_mode_for_docker(tmp_path: Path) -> None:
+    class _FakeContainers:
+        def __init__(self) -> None:
+            self.run_kwargs: dict | None = None
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+            return {"id": "agent"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "docker"
+
+    workspace = tmp_path / "workspace"
+    config_dir = tmp_path / "agents" / "claude"
+    workspace.mkdir(parents=True, exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    manager.run_agent(
+        agent="claude",
+        image="vibepod/claude:latest",
+        workspace=workspace,
+        config_dir=config_dir,
+        config_mount_path="/claude",
+        env={},
+        command=["claude"],
+        auto_remove=True,
+        name=None,
+        version="0.2.1",
+        network="vibepod-network",
+        userns_mode="host",
+    )
+
+    run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
+    assert run_kwargs is not None
+    assert run_kwargs["userns_mode"] == "host"
+
+
 def test_run_agent_forwards_entrypoint(tmp_path: Path) -> None:
     class _FakeContainers:
         def __init__(self) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -313,6 +313,57 @@ def test_run_agent_forwards_entrypoint(tmp_path: Path) -> None:
     assert run_kwargs["entrypoint"] == ["/bin/sh", "-lc", 'echo "init"; exec "$@"', "--"]
 
 
+def test_run_agent_prepare_volume_dir_only_on_managed_dirs(tmp_path: Path) -> None:
+    """_prepare_volume_dir must be called on managed_extra_dirs but NOT on
+    unmanaged extra_volumes such as X11 sockets."""
+    prepared: list[Path] = []
+
+    class _FakeContainers:
+        def run(self, **kwargs):
+            return {"id": "agent"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "podman"
+    # Intercept permission-tightening calls to record which paths were touched.
+    manager._prepare_volume_dir = lambda path: prepared.append(path)  # type: ignore[method-assign]
+
+    workspace = tmp_path / "workspace"
+    config_dir = tmp_path / "agents" / "claude"
+    managed_dir = tmp_path / "managed"
+    workspace.mkdir(parents=True, exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    managed_dir.mkdir(parents=True, exist_ok=True)
+
+    manager.run_agent(
+        agent="claude",
+        image="vibepod/claude:latest",
+        workspace=workspace,
+        config_dir=config_dir,
+        config_mount_path="/claude",
+        env={},
+        command=["claude"],
+        auto_remove=True,
+        name=None,
+        version="0.2.1",
+        network="vibepod-network",
+        extra_volumes=[
+            ("/tmp/.X11-unix", "/tmp/.X11-unix", "rw"),  # non-managed — must NOT be tightened
+        ],
+        managed_extra_dirs=[managed_dir],
+    )
+
+    assert config_dir in prepared, "config_dir should always be prepared"
+    assert managed_dir in prepared, "managed_extra_dirs entries should be prepared"
+    assert Path("/tmp/.X11-unix") not in prepared, (
+        "non-managed extra_volumes (e.g. X11 sockets) must not have permissions tightened"
+    )
+
+
 def test_x11_volumes_and_env_returns_socket_and_display() -> None:
     volumes, env = run_cmd._x11_volumes_and_env(":0")
     assert ("/tmp/.X11-unix", "/tmp/.X11-unix", "rw") in volumes
@@ -640,6 +691,8 @@ def test_cli_run_forwards_extra_args_to_agent_command(monkeypatch, tmp_path: Pat
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -670,7 +723,7 @@ def test_cli_run_forwards_extra_args_to_agent_command(monkeypatch, tmp_path: Pat
             return container
 
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     result = CliRunner().invoke(
         app,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -329,6 +329,8 @@ def test_paste_images_flag_adds_x11_volumes_and_env(monkeypatch, tmp_path: Path)
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -360,7 +362,7 @@ def test_paste_images_flag_adds_x11_volumes_and_env(monkeypatch, tmp_path: Path)
 
     monkeypatch.setenv("DISPLAY", ":0")
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True, paste_images=True)
 
@@ -374,6 +376,8 @@ def test_paste_images_flag_warns_when_display_not_set(monkeypatch, tmp_path: Pat
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -405,7 +409,7 @@ def test_paste_images_flag_warns_when_display_not_set(monkeypatch, tmp_path: Pat
 
     monkeypatch.delenv("DISPLAY", raising=False)
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True, paste_images=True)
 
@@ -418,6 +422,8 @@ def test_paste_images_false_does_not_add_x11(monkeypatch, tmp_path: Path) -> Non
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -449,7 +455,7 @@ def test_paste_images_false_does_not_add_x11(monkeypatch, tmp_path: Path) -> Non
 
     monkeypatch.setenv("DISPLAY", ":0")
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True, paste_images=False)
 
@@ -593,6 +599,9 @@ class _StubDockerManager:
 
     def pull_image(self, image: str) -> None:
         self.pulled.append(image)
+
+    def pull_if_newer(self, image: str) -> bool:
+        return False
 
     def ensure_proxy(self, **kwargs) -> object:  # type: ignore[no-untyped-def]
         self.ensure_proxy_kwargs = kwargs
@@ -763,6 +772,8 @@ def test_ikwid_appends_args_for_claude(monkeypatch, tmp_path: Path) -> None:
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -793,7 +804,7 @@ def test_ikwid_appends_args_for_claude(monkeypatch, tmp_path: Path) -> None:
             return container
 
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True, ikwid=True)
 
@@ -805,6 +816,8 @@ def test_ikwid_appends_args_for_codex(monkeypatch, tmp_path: Path) -> None:
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -837,7 +850,7 @@ def test_ikwid_appends_args_for_codex(monkeypatch, tmp_path: Path) -> None:
     cfg = _make_config()
     cfg["agents"]["codex"] = {"env": {}, "init": []}
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="codex", workspace=tmp_path, detach=True, ikwid=True)
 
@@ -849,6 +862,8 @@ def test_ikwid_appends_args_for_gemini(monkeypatch, tmp_path: Path) -> None:
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -881,7 +896,7 @@ def test_ikwid_appends_args_for_gemini(monkeypatch, tmp_path: Path) -> None:
     cfg = _make_config()
     cfg["agents"]["gemini"] = {"env": {}, "init": []}
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="gemini", workspace=tmp_path, detach=True, ikwid=True)
 
@@ -899,6 +914,8 @@ def test_ikwid_appends_args_for_copilot(monkeypatch, tmp_path: Path) -> None:
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -931,7 +948,7 @@ def test_ikwid_appends_args_for_copilot(monkeypatch, tmp_path: Path) -> None:
     cfg = _make_config()
     cfg["agents"]["copilot"] = {"env": {}, "init": []}
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="copilot", workspace=tmp_path, detach=True, ikwid=True)
 
@@ -943,6 +960,8 @@ def test_ikwid_appends_args_for_devstral(monkeypatch, tmp_path: Path) -> None:
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -980,7 +999,7 @@ def test_ikwid_appends_args_for_devstral(monkeypatch, tmp_path: Path) -> None:
     cfg = _make_config()
     cfg["agents"]["devstral"] = {"env": {}, "init": []}
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="devstral", workspace=tmp_path, detach=True, ikwid=True)
 
@@ -992,6 +1011,8 @@ def test_ikwid_ignored_for_unsupported_agent(monkeypatch, tmp_path: Path) -> Non
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1024,7 +1045,7 @@ def test_ikwid_ignored_for_unsupported_agent(monkeypatch, tmp_path: Path) -> Non
     cfg = _make_config()
     cfg["agents"]["opencode"] = {"env": {}, "init": []}
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="opencode", workspace=tmp_path, detach=True, ikwid=True)
 
@@ -1037,6 +1058,8 @@ def test_ikwid_false_does_not_modify_command(monkeypatch, tmp_path: Path) -> Non
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1067,7 +1090,7 @@ def test_ikwid_false_does_not_modify_command(monkeypatch, tmp_path: Path) -> Non
             return container
 
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True, ikwid=False)
 
@@ -1079,6 +1102,8 @@ def test_llm_enabled_injects_openai_env_vars(monkeypatch, tmp_path: Path) -> Non
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1116,7 +1141,7 @@ def test_llm_enabled_injects_openai_env_vars(monkeypatch, tmp_path: Path) -> Non
         "model": "llama3",
     }
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
 
@@ -1136,6 +1161,8 @@ def test_llm_enabled_injects_openai_env_vars_for_codex(monkeypatch, tmp_path: Pa
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1174,7 +1201,7 @@ def test_llm_enabled_injects_openai_env_vars_for_codex(monkeypatch, tmp_path: Pa
         "model": "llama3",
     }
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="codex", workspace=tmp_path, detach=True)
 
@@ -1189,6 +1216,8 @@ def test_llm_disabled_does_not_inject_env_vars(monkeypatch, tmp_path: Path) -> N
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1226,7 +1255,7 @@ def test_llm_disabled_does_not_inject_env_vars(monkeypatch, tmp_path: Path) -> N
         "model": "llama3",
     }
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
 
@@ -1245,6 +1274,8 @@ def test_llm_skipped_for_agent_without_mapping(monkeypatch, tmp_path: Path) -> N
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1283,7 +1314,7 @@ def test_llm_skipped_for_agent_without_mapping(monkeypatch, tmp_path: Path) -> N
         "model": "llama3",
     }
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="gemini", workspace=tmp_path, detach=True)
 
@@ -1297,6 +1328,8 @@ def test_llm_empty_model_not_injected(monkeypatch, tmp_path: Path) -> None:
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1334,7 +1367,7 @@ def test_llm_empty_model_not_injected(monkeypatch, tmp_path: Path) -> None:
         "model": "",
     }
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
 
@@ -1351,6 +1384,8 @@ def test_llm_per_agent_env_overrides_llm(monkeypatch, tmp_path: Path) -> None:
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1389,7 +1424,7 @@ def test_llm_per_agent_env_overrides_llm(monkeypatch, tmp_path: Path) -> None:
         "model": "llama3",
     }
     monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
 
@@ -1418,6 +1453,8 @@ def test_run_forwards_host_terminal_env(monkeypatch, tmp_path: Path) -> None:
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1453,7 +1490,7 @@ def test_run_forwards_host_terminal_env(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("TERM_PROGRAM_VERSION", "1.100.0")
     monkeypatch.setenv("LANG", "en_US.UTF-8")
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="gemini", workspace=tmp_path, detach=True)
 
@@ -1469,6 +1506,8 @@ def test_run_sets_default_term_when_host_term_missing(monkeypatch, tmp_path: Pat
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1504,7 +1543,7 @@ def test_run_sets_default_term_when_host_term_missing(monkeypatch, tmp_path: Pat
     monkeypatch.delenv("TERM_PROGRAM_VERSION", raising=False)
     monkeypatch.delenv("LANG", raising=False)
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="gemini", workspace=tmp_path, detach=True)
 
@@ -1523,6 +1562,8 @@ def _make_capturing_docker_manager():
     captured: dict = {}
 
     class _CapturingDockerManager:
+        runtime = "docker"
+
         def ensure_network(self, name: str) -> None:
             pass
 
@@ -1591,7 +1632,7 @@ def test_run_prompts_and_proceeds_when_user_accepts(monkeypatch, tmp_path: Path)
     monkeypatch.setattr(run_cmd, "Confirm", _confirm_yes)
     _CapturingDockerManager, _ = _make_capturing_docker_manager()
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
-    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: _CapturingDockerManager())
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -145,6 +145,48 @@ def test_run_agent_forwards_platform_and_user(tmp_path: Path) -> None:
     assert run_kwargs["user"] == "1000:1000"
 
 
+def test_run_agent_forwards_userns_mode(tmp_path: Path) -> None:
+    class _FakeContainers:
+        def __init__(self) -> None:
+            self.run_kwargs: dict | None = None
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+            return {"id": "agent"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+    manager.runtime = "podman"
+
+    workspace = tmp_path / "workspace"
+    config_dir = tmp_path / "agents" / "claude"
+    workspace.mkdir(parents=True, exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    manager.run_agent(
+        agent="claude",
+        image="vibepod/claude:latest",
+        workspace=workspace,
+        config_dir=config_dir,
+        config_mount_path="/claude",
+        env={},
+        command=["claude"],
+        auto_remove=True,
+        name=None,
+        version="0.2.1",
+        network="vibepod-network",
+        userns_mode="keep-id",
+    )
+
+    run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
+    assert run_kwargs is not None
+    assert run_kwargs["userns_mode"] == "keep-id"
+
+
 def test_run_agent_forwards_entrypoint(tmp_path: Path) -> None:
     class _FakeContainers:
         def __init__(self) -> None:
@@ -427,6 +469,9 @@ class _StubDockerManager:
 
     def __init__(self) -> None:
         self.pulled: list[str] = []
+        self.runtime = "docker"
+        self.ensure_proxy_kwargs: dict | None = None
+        self.run_agent_kwargs: dict | None = None
         self._container = type(
             "_Container",
             (),
@@ -440,6 +485,24 @@ class _StubDockerManager:
                 "logs": lambda self, **kw: b"",
             },
         )()
+        self._proxy = type(
+            "_Proxy",
+            (),
+            {
+                "name": "vibepod-proxy",
+                "status": "running",
+                "attrs": {
+                    "NetworkSettings": {
+                        "Networks": {
+                            "vibepod-network": {
+                                "IPAddress": "172.18.0.2",
+                            }
+                        }
+                    }
+                },
+                "reload": lambda self: None,
+            },
+        )()
 
     def ensure_network(self, name: str) -> None:
         pass
@@ -447,10 +510,12 @@ class _StubDockerManager:
     def pull_image(self, image: str) -> None:
         self.pulled.append(image)
 
-    def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        pass
+    def ensure_proxy(self, **kwargs) -> object:  # type: ignore[no-untyped-def]
+        self.ensure_proxy_kwargs = kwargs
+        return self._proxy
 
     def run_agent(self, **kwargs) -> object:  # type: ignore[no-untyped-def]
+        self.run_agent_kwargs = kwargs
         return self._container
 
     def networks_with_running_containers(self) -> list[str]:
@@ -460,6 +525,7 @@ class _StubDockerManager:
 def _make_config(
     global_auto_pull: bool = False,
     agent_auto_pull: bool | None = None,
+    container_userns_mode: str | None = None,
 ) -> dict:
     agent_cfg: dict = {"env": {}, "init": []}
     if agent_auto_pull is not None:
@@ -468,6 +534,7 @@ def _make_config(
         "default_agent": "claude",
         "auto_pull": global_auto_pull,
         "auto_remove": True,
+        "container_userns_mode": container_userns_mode,
         "network": "vibepod-network",
         "agents": {"claude": agent_cfg},
         "proxy": {"enabled": False},
@@ -535,7 +602,7 @@ def test_auto_pull_global_triggers_pull(monkeypatch, tmp_path: Path) -> None:
     """Global auto_pull=true causes image pull on run."""
     stub = _StubDockerManager()
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config(global_auto_pull=True))
-    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
     assert len(stub.pulled) == 1
@@ -545,7 +612,7 @@ def test_auto_pull_global_false_skips_pull(monkeypatch, tmp_path: Path) -> None:
     """Global auto_pull=false skips image pull."""
     stub = _StubDockerManager()
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config(global_auto_pull=False))
-    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
     assert stub.pulled == []
@@ -559,7 +626,7 @@ def test_auto_pull_per_agent_true_overrides_global_false(monkeypatch, tmp_path: 
         "get_config",
         lambda: _make_config(global_auto_pull=False, agent_auto_pull=True),
     )
-    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
     assert len(stub.pulled) == 1
@@ -573,7 +640,7 @@ def test_auto_pull_per_agent_false_overrides_global_true(monkeypatch, tmp_path: 
         "get_config",
         lambda: _make_config(global_auto_pull=True, agent_auto_pull=False),
     )
-    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
     assert stub.pulled == []
@@ -587,7 +654,7 @@ def test_auto_pull_cli_flag_overrides_config(monkeypatch, tmp_path: Path) -> Non
         "get_config",
         lambda: _make_config(global_auto_pull=False, agent_auto_pull=False),
     )
-    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True, pull=True)
     assert len(stub.pulled) == 1
@@ -601,7 +668,7 @@ def test_auto_pull_per_agent_none_falls_back_to_global(monkeypatch, tmp_path: Pa
         "get_config",
         lambda: _make_config(global_auto_pull=True, agent_auto_pull=None),
     )
-    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
     assert len(stub.pulled) == 1
@@ -1465,3 +1532,57 @@ def test_run_aborts_when_user_declines_prompt(monkeypatch, tmp_path: Path) -> No
 
     assert exc.value.exit_code == 1
     assert added == []
+
+
+def test_run_passes_configured_userns_mode(monkeypatch, tmp_path: Path) -> None:
+    stub = _StubDockerManager()
+    monkeypatch.setattr(
+        run_cmd,
+        "get_config",
+        lambda: _make_config(container_userns_mode="keep-id"),
+    )
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
+
+    run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
+
+    assert stub.run_agent_kwargs is not None
+    assert stub.run_agent_kwargs["userns_mode"] == "keep-id"
+
+
+def test_run_cli_userns_overrides_config(monkeypatch, tmp_path: Path) -> None:
+    stub = _StubDockerManager()
+    monkeypatch.setattr(
+        run_cmd,
+        "get_config",
+        lambda: _make_config(container_userns_mode="host"),
+    )
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
+
+    run_cmd.run(agent="claude", workspace=tmp_path, detach=True, userns="keep-id")
+
+    assert stub.run_agent_kwargs is not None
+    assert stub.run_agent_kwargs["userns_mode"] == "keep-id"
+
+
+def test_run_uses_proxy_container_ip_for_proxy_env(monkeypatch, tmp_path: Path) -> None:
+    stub = _StubDockerManager()
+    monkeypatch.setattr(
+        run_cmd,
+        "get_config",
+        lambda: {
+            **_make_config(),
+            "proxy": {
+                "enabled": True,
+                "image": "vibepod/proxy:latest",
+                "db_path": str(tmp_path / "proxy" / "proxy.db"),
+            },
+        },
+    )
+    monkeypatch.setattr(run_cmd, "get_manager", lambda **kwargs: stub)
+
+    run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
+
+    assert stub.run_agent_kwargs is not None
+    env = stub.run_agent_kwargs["env"]
+    assert env["HTTP_PROXY"] == "http://172.18.0.2:8080"
+    assert env["HTTPS_PROXY"] == "http://172.18.0.2:8080"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,106 @@
+"""Container runtime detection tests."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+from rich.prompt import Prompt
+
+from vibepod.core import runtime
+
+
+def test_probe_socket_uses_default_timeout(monkeypatch) -> None:
+    recorded: dict[str, object] = {}
+
+    class _FakeClient:
+        def __init__(self, *, base_url: str, timeout: float) -> None:
+            recorded["base_url"] = base_url
+            recorded["timeout"] = timeout
+
+        def ping(self) -> None:
+            recorded["pinged"] = True
+
+        def close(self) -> None:
+            recorded["closed"] = True
+
+    monkeypatch.delenv("VP_RUNTIME_PROBE_TIMEOUT", raising=False)
+    monkeypatch.setitem(sys.modules, "docker", SimpleNamespace(DockerClient=_FakeClient))
+
+    assert runtime._probe_socket("unix:///tmp/podman.sock") is True
+    assert recorded == {
+        "base_url": "unix:///tmp/podman.sock",
+        "timeout": 10.0,
+        "pinged": True,
+        "closed": True,
+    }
+
+
+def test_probe_socket_honors_env_timeout(monkeypatch) -> None:
+    recorded: dict[str, float] = {}
+
+    class _FakeClient:
+        def __init__(self, *, base_url: str, timeout: float) -> None:
+            recorded["timeout"] = timeout
+
+        def ping(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setenv("VP_RUNTIME_PROBE_TIMEOUT", "12.5")
+    monkeypatch.setitem(sys.modules, "docker", SimpleNamespace(DockerClient=_FakeClient))
+
+    assert runtime._probe_socket("unix:///tmp/podman.sock") is True
+    assert recorded["timeout"] == 12.5
+
+
+def test_resolve_runtime_prompts_with_detected_choices(monkeypatch) -> None:
+    prompted: dict[str, object] = {}
+
+    def _ask(*args, **kwargs) -> str:
+        del args
+        prompted["choices"] = kwargs["choices"]
+        prompted["default"] = kwargs["default"]
+        return "podman"
+
+    monkeypatch.setattr(
+        runtime,
+        "detect_available_runtimes",
+        lambda: {
+            "docker": "unix:///var/run/docker.sock",
+            "podman": "unix:///run/user/1000/podman/podman.sock",
+        },
+    )
+    monkeypatch.setattr(runtime.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(Prompt, "ask", staticmethod(_ask))
+    monkeypatch.setattr(
+        runtime,
+        "save_runtime_preference",
+        lambda choice: prompted.setdefault("saved", choice),
+    )
+
+    selected = runtime.resolve_runtime()
+
+    assert prompted["choices"] == ["docker", "podman"]
+    assert prompted["default"] == "docker"
+    assert prompted["saved"] == "podman"
+    assert selected == ("podman", "unix:///run/user/1000/podman/podman.sock")
+
+
+def test_resolve_runtime_rejects_unavailable_prompt_choice(monkeypatch) -> None:
+    monkeypatch.setattr(
+        runtime,
+        "detect_available_runtimes",
+        lambda: {
+            "podman": "unix:///run/user/1000/podman/podman.sock",
+            "alt": "unix:///tmp/alt.sock",
+        },
+    )
+    monkeypatch.setattr(runtime.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(Prompt, "ask", staticmethod(lambda *args, **kwargs: "docker"))
+
+    with pytest.raises(RuntimeError, match="not available"):
+        runtime.resolve_runtime()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 from rich.prompt import Prompt
 
+from vibepod.core import docker as docker_core
 from vibepod.core import runtime
 
 
@@ -104,3 +105,18 @@ def test_resolve_runtime_rejects_unavailable_prompt_choice(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="not available"):
         runtime.resolve_runtime()
+
+
+def test_get_manager_wraps_runtime_preference_errors(monkeypatch) -> None:
+    def _raise_runtime_preference_error(**kwargs) -> tuple[str, str]:
+        del kwargs
+        raise ValueError("Global config must contain a YAML mapping: /tmp/config.yaml")
+
+    monkeypatch.setattr(
+        runtime,
+        "resolve_runtime",
+        _raise_runtime_preference_error,
+    )
+
+    with pytest.raises(docker_core.DockerClientError, match="Global config must contain"):
+        docker_core.get_manager()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -6,6 +6,7 @@ import sys
 from types import SimpleNamespace
 
 import pytest
+import yaml
 from rich.prompt import Prompt
 
 from vibepod.core import docker as docker_core
@@ -134,4 +135,26 @@ def test_get_manager_wraps_runtime_preference_errors(monkeypatch) -> None:
     )
 
     with pytest.raises(docker_core.DockerClientError, match="Global config must contain"):
+        docker_core.get_manager()
+
+
+def test_get_manager_wraps_oserror_from_resolve_runtime(monkeypatch) -> None:
+    def _raise_oserror(**kwargs) -> tuple[str, str]:
+        del kwargs
+        raise OSError("Permission denied: '/home/user/.config/vibepod/config.yaml'")
+
+    monkeypatch.setattr(runtime, "resolve_runtime", _raise_oserror)
+
+    with pytest.raises(docker_core.DockerClientError, match="Failed to access runtime config"):
+        docker_core.get_manager()
+
+
+def test_get_manager_wraps_yaml_error_from_resolve_runtime(monkeypatch) -> None:
+    def _raise_yaml_error(**kwargs) -> tuple[str, str]:
+        del kwargs
+        raise yaml.YAMLError("mapping values are not allowed here")
+
+    monkeypatch.setattr(runtime, "resolve_runtime", _raise_yaml_error)
+
+    with pytest.raises(docker_core.DockerClientError, match="Failed to parse runtime config"):
         docker_core.get_manager()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -107,6 +107,21 @@ def test_resolve_runtime_rejects_unavailable_prompt_choice(monkeypatch) -> None:
         runtime.resolve_runtime()
 
 
+def test_resolve_runtime_normalizes_env_value(monkeypatch) -> None:
+    monkeypatch.setattr(
+        runtime,
+        "detect_available_runtimes",
+        lambda: {
+            "podman": "unix:///run/user/1000/podman/podman.sock",
+        },
+    )
+    monkeypatch.setenv("VP_CONTAINER_RUNTIME", " PodMan ")
+
+    selected = runtime.resolve_runtime()
+
+    assert selected == ("podman", "unix:///run/user/1000/podman/podman.sock")
+
+
 def test_get_manager_wraps_runtime_preference_errors(monkeypatch) -> None:
     def _raise_runtime_preference_error(**kwargs) -> tuple[str, str]:
         del kwargs

--- a/tests/test_version_integration.py
+++ b/tests/test_version_integration.py
@@ -1,0 +1,160 @@
+"""Real-runtime integration tests for `vp version`.
+
+These tests are intended for dedicated CI jobs that prepare concrete host
+runtime scenarios. They are skipped unless ``VP_REAL_RUNTIME_SCENARIO`` is set.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCENARIO = os.environ.get("VP_REAL_RUNTIME_SCENARIO")
+
+if SCENARIO is None:
+    pytest.skip(
+        "requires dedicated runtime integration CI",
+        allow_module_level=True,
+    )
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+
+def _run_vp(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["VP_CONFIG_DIR"] = str(tmp_path / "global-config")
+    env["PYTHONPATH"] = (
+        f"{SRC}{os.pathsep}{env['PYTHONPATH']}"
+        if "PYTHONPATH" in env and env["PYTHONPATH"]
+        else str(SRC)
+    )
+    env.pop("VP_CONTAINER_RUNTIME", None)
+    return subprocess.run(
+        [sys.executable, "-m", "vibepod.cli", *args],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=60,
+    )
+
+
+def _assert_ok(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def _runtime_parts(output: str) -> tuple[str, str]:
+    for line in output.splitlines():
+        if not line.startswith("Runtime:"):
+            continue
+        _, runtime_name, runtime_version = line.split(maxsplit=2)
+        return runtime_name, runtime_version
+    raise AssertionError(f"Missing Runtime line in output:\n{output}")
+
+
+def _assert_runtime(
+    result: subprocess.CompletedProcess[str],
+    *,
+    runtime_name: str,
+) -> None:
+    _assert_ok(result)
+    assert "VibePod CLI:" in result.stdout
+    assert "Python:" in result.stdout
+    actual_runtime, actual_version = _runtime_parts(result.stdout)
+    assert actual_runtime == runtime_name
+    assert actual_version not in {"unknown", "unavailable"}
+
+
+def _assert_unavailable(result: subprocess.CompletedProcess[str]) -> None:
+    _assert_ok(result)
+    assert _runtime_parts(result.stdout) == ("unknown", "unavailable")
+
+
+def test_version_with_docker_only(tmp_path: Path) -> None:
+    if SCENARIO != "docker-only":
+        pytest.skip("scenario mismatch")
+
+    result = _run_vp(tmp_path, "version")
+
+    _assert_runtime(result, runtime_name="docker")
+
+
+def test_version_with_podman_only(tmp_path: Path) -> None:
+    if SCENARIO != "podman-only":
+        pytest.skip("scenario mismatch")
+
+    result = _run_vp(tmp_path, "version")
+
+    _assert_runtime(result, runtime_name="podman")
+
+
+def test_version_with_no_runtime_available(tmp_path: Path) -> None:
+    if SCENARIO != "none":
+        pytest.skip("scenario mismatch")
+
+    result = _run_vp(tmp_path, "version")
+
+    _assert_unavailable(result)
+
+
+def test_version_with_both_runtimes_defaults_to_docker_non_interactive(
+    tmp_path: Path,
+) -> None:
+    if SCENARIO != "both-auto":
+        pytest.skip("scenario mismatch")
+
+    result = _run_vp(tmp_path, "version")
+
+    _assert_runtime(result, runtime_name="docker")
+
+
+def test_version_uses_saved_docker_default_when_both_runtimes_are_available(
+    tmp_path: Path,
+) -> None:
+    if SCENARIO != "both-default-docker":
+        pytest.skip("scenario mismatch")
+
+    set_result = _run_vp(tmp_path, "config", "runtime", "docker")
+    result = _run_vp(tmp_path, "version")
+
+    _assert_ok(set_result)
+    assert "Set default container runtime to 'docker'" in set_result.stdout
+    _assert_runtime(result, runtime_name="docker")
+
+
+def test_version_uses_saved_podman_default_when_both_runtimes_are_available(
+    tmp_path: Path,
+) -> None:
+    if SCENARIO != "both-default-podman":
+        pytest.skip("scenario mismatch")
+
+    set_result = _run_vp(tmp_path, "config", "runtime", "podman")
+    result = _run_vp(tmp_path, "version")
+
+    _assert_ok(set_result)
+    assert "Set default container runtime to 'podman'" in set_result.stdout
+    _assert_runtime(result, runtime_name="podman")
+
+
+def test_version_reflects_runtime_switch_command(tmp_path: Path) -> None:
+    if SCENARIO != "both-switch":
+        pytest.skip("scenario mismatch")
+
+    first_set_result = _run_vp(tmp_path, "config", "runtime", "docker")
+    first_version_result = _run_vp(tmp_path, "version")
+    second_set_result = _run_vp(tmp_path, "config", "runtime", "podman")
+    second_version_result = _run_vp(tmp_path, "version")
+
+    _assert_ok(first_set_result)
+    _assert_runtime(first_version_result, runtime_name="docker")
+    _assert_ok(second_set_result)
+    _assert_runtime(second_version_result, runtime_name="podman")


### PR DESCRIPTION
Adds first-class support for Podman as an alternative container runtime to Docker throughout VibePod. It updates documentation, configuration, and CLI commands to allow users to select between Docker and Podman, including auto-detection and explicit selection methods. Additionally, it introduces fixes for rootless Podman compatibility, such as permission handling for bind mounts.

**Documentation updates:**

* Added a dedicated Podman setup and usage guide (`docs/podman.md`), linked from navigation and other docs. Updated Quickstart and main documentation to reflect Podman support and new configuration options. 

**Config and environment variable documentation:**

* Documented the new `container_runtime` config key and `VP_CONTAINER_RUNTIME` environment variable in `docs/configuration.md`, including example usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Podman (rootless) support with runtime selection and persistence (vp config runtime), new CLI options (--runtime, --userns), and env overrides VP_CONTAINER_RUNTIME / VP_CONTAINER_USERNS_MODE; proxy address resolution may use the proxy container IP.

* **Documentation**
  * New "Using Podman" guide; quickstart, configuration, and proxy docs updated; homepage wording generalized to “container”.

* **Tests**
  * Expanded unit and integration tests for runtime detection, selection, proxy and userns behavior.

* **Chores**
  * CI workflow and helper scripts to exercise runtime scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->