### PR TITLE
Replace default claude code docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ This repository contains an initial v1 implementation with:
 
 ## Image Namespace
 
-By default, agent images use the `nezhar` namespace (for example `nezhar/claude-container:latest`).
+By default, agent images use the `vibepod` namespace for Claude (for example `vibepod/claude:latest`) and `nezhar` for other agents.
 
 
 Current defaults are aligned to existing container repos:
 
-- `claude` -> `nezhar/claude-container:latest` ([repo](https://github.com/nezhar/claude-container))
+- `claude` -> `vibepod/claude:latest`
 - `gemini` -> `nezhar/gemini-container:latest` ([repo](https://github.com/nezhar/gemini-container))
 - `opencode` -> `nezhar/opencode-cli:latest` ([repo](https://github.com/nezhar/opencode-container))
 - `devstral` -> `nezhar/devstral-cli:latest` ([repo](https://github.com/nezhar/devstral-container))
@@ -50,7 +50,7 @@ Current defaults are aligned to existing container repos:
 You can override any single image directly:
 
 ```bash
-VP_IMAGE_CLAUDE=nezhar/claude-container:latest vp run claude
+VP_IMAGE_CLAUDE=vibepod/claude:latest vp run claude
 VP_IMAGE_GEMINI=nezhar/gemini-container:latest vp run gemini
 VP_IMAGE_OPENCODE=nezhar/opencode-cli:latest vp run opencode
 VP_IMAGE_DEVSTRAL=nezhar/devstral-cli:latest vp run devstral

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -6,7 +6,7 @@ VibePod manages each agent as a Docker container. Credentials and config are per
 
 | Agent | Provider | Shortcut | Image |
 |-------|----------|----------|-------|
-| `claude` | Anthropic | `vp c` | `nezhar/claude-container:latest` |
+| `claude` | Anthropic | `vp c` | `vibepod/claude:latest` |
 | `gemini` | Google | `vp g` | `nezhar/gemini-container:latest` |
 | `opencode` | OpenAI | `vp o` | `nezhar/opencode-cli:latest` |
 | `devstral` | Mistral | `vp d` | `nezhar/devstral-cli:latest` |
@@ -81,7 +81,7 @@ Example: add tools to the default Claude image.
 
 ```dockerfile
 # Dockerfile.claude
-FROM nezhar/claude-container:latest
+FROM vibepod/claude:latest
 
 # Add project-specific utilities.
 RUN apt-get update \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,7 @@ no_color: false
 agents:
   claude:
     enabled: true
-    image: nezhar/claude-container:latest
+    image: vibepod/claude:latest
     auto_pull: null  # Per-agent override: true/false, or null to use global auto_pull
     env: {}       # Extra environment variables passed to the container
     volumes: []   # Reserved for future use
@@ -133,7 +133,7 @@ Set `VP_IMAGE_NAMESPACE` to change the prefix for all default images at once:
 
 ```bash
 VP_IMAGE_NAMESPACE=myorg vp run claude
-# pulls myorg/claude-container:latest
+# pulls myorg/claude:latest
 ```
 
 For end-to-end examples (extending a base image and assigning a brand-new image to an agent), see [Agents > Image customization workflows](agents/index.md#image-customization-workflows).

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -41,7 +41,7 @@ AGENT_SHORTCUTS: dict[str, str] = {
 DEFAULT_IMAGES: dict[str, str] = {
     "claude": os.environ.get(
         "VP_IMAGE_CLAUDE",
-        f"{os.environ.get('VP_IMAGE_NAMESPACE', 'nezhar')}/claude-container:latest",
+        f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/claude:latest",
     ),
     "gemini": os.environ.get(
         "VP_IMAGE_GEMINI",

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -153,7 +153,7 @@ def test_run_agent_forwards_entrypoint(tmp_path: Path) -> None:
 
     manager.run_agent(
         agent="claude",
-        image="nezhar/claude-container:latest",
+        image="vibepod/claude:latest",
         workspace=workspace,
         config_dir=config_dir,
         config_mount_path="/claude",


### PR DESCRIPTION
This pull request updates the default Docker image namespace for the Claude agent from `nezhar` to `vibepod` across documentation, configuration, code, and tests. This change ensures consistency and reflects the new official image location for Claude. Other agents remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Claude agent's default container image namespace to vibepod and added new default image mappings for additional agents (auggie, copilot, codex, datasette, proxy).
* **Documentation**
  * Updated configuration and agent docs to show the new image references and example usage.
* **Tests**
  * Adjusted tests to reflect the updated default image mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->