### PR TITLE
Replace default openai codex docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains an initial v1 implementation with:
 
 ## Image Namespace
 
-By default, agent images use the `vibepod` namespace for Claude (for example `vibepod/claude:latest`) and `nezhar` for other agents.
+By default, agent images use the `vibepod` namespace for Claude, Codex, and platform services, and `nezhar` for Gemini/OpenCode/Devstral/Auggie/Copilot.
 
 
 Current defaults are aligned to existing container repos:
@@ -43,7 +43,7 @@ Current defaults are aligned to existing container repos:
 - `devstral` -> `nezhar/devstral-cli:latest` ([repo](https://github.com/nezhar/devstral-container))
 - `auggie` -> `nezhar/auggie-cli:latest` ([repo](https://github.com/nezhar/auggie-container))
 - `copilot` -> `nezhar/copilot-cli:latest` ([repo](https://github.com/nezhar/copilot-container))
-- `codex` -> `nezhar/codex-cli:latest` ([repo](https://github.com/nezhar/codex-container))
+- `codex` -> `vibepod/codex:latest`
 - `datasette` -> `vibepod/datasette:latest`
 - `proxy` -> `vibepod/proxy:latest` ([repo](https://github.com/VibePod/vibepod-proxy))
 
@@ -56,6 +56,6 @@ VP_IMAGE_OPENCODE=nezhar/opencode-cli:latest vp run opencode
 VP_IMAGE_DEVSTRAL=nezhar/devstral-cli:latest vp run devstral
 VP_IMAGE_AUGGIE=nezhar/auggie-cli:latest vp run auggie
 VP_IMAGE_COPILOT=nezhar/copilot-cli:latest vp run copilot
-VP_IMAGE_CODEX=nezhar/codex-cli:latest vp run codex
+VP_IMAGE_CODEX=vibepod/codex:latest vp run codex
 VP_DATASETTE_IMAGE=vibepod/datasette:latest vp logs start
 ```

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -12,7 +12,7 @@ VibePod manages each agent as a Docker container. Credentials and config are per
 | `devstral` | Mistral | `vp d` | `nezhar/devstral-cli:latest` |
 | `auggie` | Augment Code | `vp a` | `nezhar/auggie-cli:latest` |
 | `copilot` | GitHub | `vp p` | `nezhar/copilot-cli:latest` |
-| `codex` | OpenAI | `vp x` | `nezhar/codex-cli:latest` |
+| `codex` | OpenAI | `vp x` | `vibepod/codex:latest` |
 
 ## First run & authentication
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ agents:
 
   codex:
     enabled: true
-    image: nezhar/codex-cli:latest
+    image: vibepod/codex:latest
     env: {}
     volumes: []
     init: []

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -61,7 +61,7 @@ DEFAULT_IMAGES: dict[str, str] = {
         f"{os.environ.get('VP_IMAGE_NAMESPACE', 'nezhar')}/copilot-cli:latest",
     ),
     "codex": os.environ.get(
-        "VP_IMAGE_CODEX", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'nezhar')}/codex-cli:latest"
+        "VP_IMAGE_CODEX", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/codex:latest"
     ),
     "datasette": os.environ.get(
         "VP_DATASETTE_IMAGE", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/datasette:latest"


### PR DESCRIPTION
This pull request updates the default container image namespace for the `codex` agent from `nezhar` to `vibepod` across documentation, configuration, and code. This ensures consistency and aligns with the new container repository for Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README and docs to reflect a revised image namespace and the Codex agent container reference.

* **Chores**
  * Changed the default Codex agent container image to the new vibepod/codex:latest reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->