### PR TITLE
Fixes required flags for ikwid on codex

### DIFF
--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -103,7 +103,7 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         ["codex"],
         "/config",
         {"HOME": "/config"},
-        ikwid_args=["--full-auto"],
+        ikwid_args=["--dangerously-bypass-approvals-and-sandbox"],
         llm_env_map={
             "base_url": "CODEX_OSS_BASE_URL",
         },

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -61,7 +61,7 @@ def test_claude_spec_has_ikwid_args() -> None:
 
 def test_codex_spec_has_ikwid_args() -> None:
     spec = get_agent_spec("codex")
-    assert spec.ikwid_args == ["--full-auto"]
+    assert spec.ikwid_args == ["--dangerously-bypass-approvals-and-sandbox"]
 
 
 def test_unsupported_agents_have_no_ikwid_args() -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -578,7 +578,7 @@ def test_ikwid_appends_args_for_claude(monkeypatch, tmp_path: Path) -> None:
 
 
 def test_ikwid_appends_args_for_codex(monkeypatch, tmp_path: Path) -> None:
-    """--ikwid appends --full-auto to codex command."""
+    """--ikwid appends --dangerously-bypass-approvals-and-sandbox to codex command."""
     captured: dict = {}
 
     class _CapturingDockerManager:
@@ -618,7 +618,7 @@ def test_ikwid_appends_args_for_codex(monkeypatch, tmp_path: Path) -> None:
 
     run_cmd.run(agent="codex", workspace=tmp_path, detach=True, ikwid=True)
 
-    assert captured["command"] == ["codex", "--full-auto"]
+    assert captured["command"] == ["codex", "--dangerously-bypass-approvals-and-sandbox"]
 
 
 def test_ikwid_ignored_for_unsupported_agent(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
This pull request updates the way the `codex` agent is configured and tested by replacing the `--full-auto` argument with a more explicit and potentially less restrictive `--dangerously-bypass-approvals-and-sandbox` argument. All related tests and documentation strings have been updated to reflect this change.

**Agent configuration update:**

* Changed the `ikwid_args` for the `codex` agent in `AgentSpec` from `["--full-auto"]` to `["--dangerously-bypass-approvals-and-sandbox"]` to alter the agent's startup behavior.

**Testing updates:**

* Updated the assertion in `test_codex_spec_has_ikwid_args` to expect the new argument for the `codex` agent.
* Updated the docstring in `test_ikwid_appends_args_for_codex` and the corresponding command assertion to reflect the new argument. [[1]](diffhunk://#diff-24e9fd3e8410789608ff4fea84ccb736745b65b0b02a0cb5316e14a560a28257L581-R581) [[2]](diffhunk://#diff-24e9fd3e8410789608ff4fea84ccb736745b65b0b02a0cb5316e14a560a28257L621-R621)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated codex agent configuration parameters to reflect new operational settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->