### PR TITLE
Switch namespace of remaining agent containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ machine.
 
 ## Image Namespace
 
-By default, agent images use the `vibepod` namespace for Claude, Codex, and platform services, and `nezhar` for Gemini/OpenCode/Devstral/Auggie/Copilot.
+All agent images are published under the [`vibepod` namespace on Docker Hub](https://hub.docker.com/u/vibepod). Source Dockerfiles are in [VibePod/vibepod-agents](https://github.com/VibePod/vibepod-agents/tree/main/docker).
 
-Current defaults are aligned to existing container repos:
+Current defaults:
 
 - `claude` -> `vibepod/claude:latest`
-- `gemini` -> `nezhar/gemini-container:latest` ([repo](https://github.com/nezhar/gemini-container))
-- `opencode` -> `nezhar/opencode-cli:latest` ([repo](https://github.com/nezhar/opencode-container))
-- `devstral` -> `nezhar/devstral-cli:latest` ([repo](https://github.com/nezhar/devstral-container))
-- `auggie` -> `nezhar/auggie-cli:latest` ([repo](https://github.com/nezhar/auggie-container))
-- `copilot` -> `nezhar/copilot-cli:latest` ([repo](https://github.com/nezhar/copilot-container))
+- `gemini` -> `vibepod/gemini:latest`
+- `opencode` -> `vibepod/opencode:latest`
+- `devstral` -> `vibepod/devstral:latest`
+- `auggie` -> `vibepod/auggie:latest`
+- `copilot` -> `vibepod/copilot:latest`
 - `codex` -> `vibepod/codex:latest`
 - `datasette` -> `vibepod/datasette:latest`
 - `proxy` -> `vibepod/proxy:latest` ([repo](https://github.com/VibePod/vibepod-proxy))
@@ -91,11 +91,11 @@ You can override any single image directly:
 
 ```bash
 VP_IMAGE_CLAUDE=vibepod/claude:latest vp run claude
-VP_IMAGE_GEMINI=nezhar/gemini-container:latest vp run gemini
-VP_IMAGE_OPENCODE=nezhar/opencode-cli:latest vp run opencode
-VP_IMAGE_DEVSTRAL=nezhar/devstral-cli:latest vp run devstral
-VP_IMAGE_AUGGIE=nezhar/auggie-cli:latest vp run auggie
-VP_IMAGE_COPILOT=nezhar/copilot-cli:latest vp run copilot
+VP_IMAGE_GEMINI=vibepod/gemini:latest vp run gemini
+VP_IMAGE_OPENCODE=vibepod/opencode:latest vp run opencode
+VP_IMAGE_DEVSTRAL=vibepod/devstral:latest vp run devstral
+VP_IMAGE_AUGGIE=vibepod/auggie:latest vp run auggie
+VP_IMAGE_COPILOT=vibepod/copilot:latest vp run copilot
 VP_IMAGE_CODEX=vibepod/codex:latest vp run codex
 VP_DATASETTE_IMAGE=vibepod/datasette:latest vp logs start
 ```

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -60,23 +60,23 @@ def get_default_images() -> dict[str, str]:
         ),
         "gemini": os.environ.get(
             "VP_IMAGE_GEMINI",
-            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'nezhar')}/gemini-container:latest",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/gemini:latest",
         ),
         "opencode": os.environ.get(
             "VP_IMAGE_OPENCODE",
-            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'nezhar')}/opencode-cli:latest",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/opencode:latest",
         ),
         "devstral": os.environ.get(
             "VP_IMAGE_DEVSTRAL",
-            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'nezhar')}/devstral-cli:latest",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/devstral:latest",
         ),
         "auggie": os.environ.get(
             "VP_IMAGE_AUGGIE",
-            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'nezhar')}/auggie-cli:latest",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/auggie:latest",
         ),
         "copilot": os.environ.get(
             "VP_IMAGE_COPILOT",
-            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'nezhar')}/copilot-cli:latest",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/copilot:latest",
         ),
         "codex": os.environ.get(
             "VP_IMAGE_CODEX", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/codex:latest"


### PR DESCRIPTION
This pull request updates the default Docker image namespaces for several agent services to consistently use the `vibepod` namespace instead of `nezhar`. It also updates related documentation and environment variable examples to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Image Namespace section to reflect agent images are now published under the `vibepod` Docker Hub namespace with updated configuration examples.

* **Chores**
  * Updated default image references for gemini, opencode, devstral, auggie, and copilot agents to use the new `vibepod` namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->