### PR TITLE
Fixes gemini cli start issues

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -7,11 +7,11 @@ VibePod manages each agent as a Docker container. Credentials and config are per
 | Agent | Provider | Shortcut | Image |
 |-------|----------|----------|-------|
 | `claude` | Anthropic | `vp c` | `vibepod/claude:latest` |
-| `gemini` | Google | `vp g` | `nezhar/gemini-container:latest` |
-| `opencode` | OpenAI | `vp o` | `nezhar/opencode-cli:latest` |
-| `devstral` | Mistral | `vp d` | `nezhar/devstral-cli:latest` |
-| `auggie` | Augment Code | `vp a` | `nezhar/auggie-cli:latest` |
-| `copilot` | GitHub | `vp p` | `nezhar/copilot-cli:latest` |
+| `gemini` | Google | `vp g` | `vibepod/gemini:latest` |
+| `opencode` | OpenAI | `vp o` | `vibepod/opencode:latest` |
+| `devstral` | Mistral | `vp d` | `vibepod/devstral:latest` |
+| `auggie` | Augment Code | `vp a` | `vibepod/auggie:latest` |
+| `copilot` | GitHub | `vp p` | `vibepod/copilot:latest` |
 | `codex` | OpenAI | `vp x` | `vibepod/codex:latest` |
 
 ## First run & authentication

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,35 +45,35 @@ agents:
 
   gemini:
     enabled: true
-    image: nezhar/gemini-container:latest
+    image: vibepod/gemini:latest
     env: {}
     volumes: []
     init: []
 
   opencode:
     enabled: true
-    image: nezhar/opencode-cli:latest
+    image: vibepod/opencode:latest
     env: {}
     volumes: []
     init: []
 
   devstral:
     enabled: true
-    image: nezhar/devstral-cli:latest
+    image: vibepod/devstral:latest
     env: {}
     volumes: []
     init: []
 
   auggie:
     enabled: true
-    image: nezhar/auggie-cli:latest
+    image: vibepod/auggie:latest
     env: {}
     volumes: []
     init: []
 
   copilot:
     enabled: true
-    image: nezhar/copilot-cli:latest
+    image: vibepod/copilot:latest
     env: {}
     volumes: []
     init: []

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -165,6 +165,14 @@ def _host_user() -> str | None:
     return f"{getuid()}:{getgid()}"
 
 
+def _terminal_env_defaults() -> dict[str, str]:
+    """Return host terminal-related env vars for interactive container apps."""
+    keys = ("TERM", "COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "LANG")
+    values = {key: value for key in keys if (value := os.environ.get(key))}
+    values.setdefault("TERM", "xterm-256color")
+    return values
+
+
 def _compose_file_present(workspace: Path) -> bool:
     return (workspace / "docker-compose.yml").exists() or (workspace / "compose.yml").exists()
 
@@ -260,6 +268,7 @@ def run(
     merged_env = {
         "USER_UID": str(os.getuid()),
         "USER_GID": str(os.getgid()),
+        **_terminal_env_defaults(),
         **spec.extra_env,
         **{str(k): str(v) for k, v in agent_cfg.get("env", {}).items()},
         **_parse_env_pairs(env or []),

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -53,7 +53,9 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         "google",
         DEFAULT_IMAGES["gemini"],
         "gemini",
-        ["gemini"],
+        # Run via node to bypass shebang parsing in Alpine BusyBox (/usr/bin/env has no -S),
+        # and force HOME to the mounted config path expected by VibePod.
+        ["env", "HOME=/config", "node", "/usr/local/bin/gemini"],
         "/config",
         {"HOME": "/config"},
     ),

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -64,6 +64,11 @@ def test_codex_spec_has_ikwid_args() -> None:
     assert spec.ikwid_args == ["--dangerously-bypass-approvals-and-sandbox"]
 
 
+def test_gemini_spec_runs_via_node_wrapper() -> None:
+    spec = get_agent_spec("gemini")
+    assert spec.command == ["env", "HOME=/config", "node", "/usr/local/bin/gemini"]
+
+
 def test_unsupported_agents_have_no_ikwid_args() -> None:
     for agent in ("gemini", "opencode", "devstral", "auggie", "copilot"):
         spec = get_agent_spec(agent)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,33 @@
+"""Constants and default-image mapping tests."""
+
+from __future__ import annotations
+
+from vibepod.constants import get_default_images
+
+
+def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
+    for key in (
+        "VP_IMAGE_NAMESPACE",
+        "VP_IMAGE_CLAUDE",
+        "VP_IMAGE_GEMINI",
+        "VP_IMAGE_OPENCODE",
+        "VP_IMAGE_DEVSTRAL",
+        "VP_IMAGE_AUGGIE",
+        "VP_IMAGE_COPILOT",
+        "VP_IMAGE_CODEX",
+        "VP_DATASETTE_IMAGE",
+        "VP_PROXY_IMAGE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    images = get_default_images()
+
+    assert images["claude"] == "vibepod/claude:latest"
+    assert images["gemini"] == "vibepod/gemini:latest"
+    assert images["opencode"] == "vibepod/opencode:latest"
+    assert images["devstral"] == "vibepod/devstral:latest"
+    assert images["auggie"] == "vibepod/auggie:latest"
+    assert images["copilot"] == "vibepod/copilot:latest"
+    assert images["codex"] == "vibepod/codex:latest"
+    assert images["datasette"] == "vibepod/datasette:latest"
+    assert images["proxy"] == "vibepod/proxy:latest"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -62,7 +62,7 @@ def test_run_agent_supports_duplicate_host_mounts(tmp_path: Path) -> None:
 
     manager.run_agent(
         agent="auggie",
-        image="nezhar/auggie-cli:latest",
+        image="vibepod/auggie:latest",
         workspace=workspace,
         config_dir=config_dir,
         config_mount_path="/config",
@@ -110,7 +110,7 @@ def test_run_agent_forwards_platform_and_user(tmp_path: Path) -> None:
 
     manager.run_agent(
         agent="devstral",
-        image="nezhar/devstral-cli:latest",
+        image="vibepod/devstral:latest",
         workspace=workspace,
         config_dir=config_dir,
         config_mount_path="/config",
@@ -663,7 +663,7 @@ def test_ikwid_ignored_for_unsupported_agent(monkeypatch, tmp_path: Path) -> Non
     run_cmd.run(agent="gemini", workspace=tmp_path, detach=True, ikwid=True)
 
     # Command should be unchanged (no ikwid args appended)
-    assert captured["command"] == ["gemini"]
+    assert captured["command"] == ["env", "HOME=/config", "node", "/usr/local/bin/gemini"]
 
 
 def test_ikwid_false_does_not_modify_command(monkeypatch, tmp_path: Path) -> None:
@@ -1047,3 +1047,101 @@ def test_run_accepts_short_agent_name(monkeypatch, tmp_path: Path) -> None:
         run_cmd.run(agent="c", workspace=tmp_path)
 
     assert exc.value.exit_code == EXIT_DOCKER_NOT_RUNNING
+
+
+def test_run_forwards_host_terminal_env(monkeypatch, tmp_path: Path) -> None:
+    captured: dict = {}
+
+    class _CapturingDockerManager:
+        def ensure_network(self, name: str) -> None:
+            pass
+
+        def networks_with_running_containers(self) -> list[str]:
+            return []
+
+        def pull_image(self, image: str) -> None:
+            pass
+
+        def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+        def run_agent(self, **kwargs) -> object:  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+            container = type(
+                "_Container",
+                (),
+                {
+                    "name": "vibepod-gemini-test",
+                    "id": "abc123",
+                    "status": "running",
+                    "attrs": {"NetworkSettings": {"Networks": {}}},
+                    "reload": lambda self: None,
+                    "labels": {},
+                    "logs": lambda self, **kw: b"",
+                },
+            )()
+            return container
+
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    monkeypatch.setenv("TERM_PROGRAM", "vscode")
+    monkeypatch.setenv("TERM_PROGRAM_VERSION", "1.100.0")
+    monkeypatch.setenv("LANG", "en_US.UTF-8")
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
+    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+
+    run_cmd.run(agent="gemini", workspace=tmp_path, detach=True)
+
+    env = captured["env"]
+    assert env["TERM"] == "xterm-256color"
+    assert env["COLORTERM"] == "truecolor"
+    assert env["TERM_PROGRAM"] == "vscode"
+    assert env["TERM_PROGRAM_VERSION"] == "1.100.0"
+    assert env["LANG"] == "en_US.UTF-8"
+
+
+def test_run_sets_default_term_when_host_term_missing(monkeypatch, tmp_path: Path) -> None:
+    captured: dict = {}
+
+    class _CapturingDockerManager:
+        def ensure_network(self, name: str) -> None:
+            pass
+
+        def networks_with_running_containers(self) -> list[str]:
+            return []
+
+        def pull_image(self, image: str) -> None:
+            pass
+
+        def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+        def run_agent(self, **kwargs) -> object:  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+            container = type(
+                "_Container",
+                (),
+                {
+                    "name": "vibepod-gemini-test",
+                    "id": "abc123",
+                    "status": "running",
+                    "attrs": {"NetworkSettings": {"Networks": {}}},
+                    "reload": lambda self: None,
+                    "labels": {},
+                    "logs": lambda self, **kw: b"",
+                },
+            )()
+            return container
+
+    monkeypatch.delenv("TERM", raising=False)
+    monkeypatch.delenv("COLORTERM", raising=False)
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
+    monkeypatch.delenv("TERM_PROGRAM_VERSION", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
+    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+
+    run_cmd.run(agent="gemini", workspace=tmp_path, detach=True)
+
+    env = captured["env"]
+    assert env["TERM"] == "xterm-256color"


### PR DESCRIPTION
This pull request updates the default Docker images for several agents to use the official `vibepod` namespace, improves how the Gemini agent is launched, and enhances environment variable handling for interactive containers. It also adds new tests to ensure these changes work as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent containers now inherit host terminal environment variables (TERM, COLORTERM, TERM_PROGRAM, TERM_PROGRAM_VERSION, LANG) with a sensible TERM default for better terminal behavior.

* **Updates**
  * Default Docker image references changed to the new vibepod/* registry for gemini, opencode, devstral, auggie, and copilot.
  * Gemini agent launch updated to run via the Node wrapper to ensure the correct runtime environment.

* **Tests**
  * Added tests covering terminal env handling, default images, and the updated gemini launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->