### PR TITLE
Implement explicit directory permissions

### DIFF
--- a/src/vibepod/commands/config.py
+++ b/src/vibepod/commands/config.py
@@ -11,6 +11,12 @@ import typer
 import yaml
 
 from vibepod.constants import SUPPORTED_AGENTS
+from vibepod.core.allowed_dirs import (
+    add_allowed_dir,
+    is_protected_dir,
+    load_allowed_dirs,
+    remove_allowed_dir,
+)
 from vibepod.core.config import get_config, get_global_config_path, get_project_config_path
 from vibepod.utils.console import console, error, success
 
@@ -142,3 +148,69 @@ def path(
     print(f"Global:  {global_path}")
     print(f"Project: {project_path}")
     print(f"Logs:    {logs_path}")
+
+
+@app.command("allow-dir")
+def allow_dir(
+    directory: Annotated[
+        Path | None,
+        typer.Argument(help="Directory to allow (defaults to current directory)"),
+    ] = None,
+) -> None:
+    """Add a directory to the vp run allow list."""
+    try:
+        target = (directory or Path.cwd()).expanduser().resolve()
+    except (OSError, ValueError) as exc:
+        error(f"Could not resolve directory path: {exc}")
+        raise typer.Exit(1) from exc
+    if not target.exists() or not target.is_dir():
+        error(f"Not a valid directory: {target}")
+        raise typer.Exit(1)
+    if is_protected_dir(target):
+        error(
+            f"'{target}' is a protected directory (home or root) and cannot be added "
+            "to the allow list."
+        )
+        raise typer.Exit(1)
+    try:
+        add_allowed_dir(target)
+    except OSError as exc:
+        error(f"Could not update allow list: {exc}")
+        raise typer.Exit(1) from exc
+    success(f"Allowed: {target}")
+
+
+@app.command("remove-dir")
+def remove_dir(
+    directory: Annotated[
+        Path | None,
+        typer.Argument(help="Directory to remove (defaults to current directory)"),
+    ] = None,
+) -> None:
+    """Remove a directory from the vp run allow list."""
+    try:
+        target = (directory or Path.cwd()).expanduser().resolve()
+    except (OSError, ValueError) as exc:
+        error(f"Could not resolve directory path: {exc}")
+        raise typer.Exit(1) from exc
+    try:
+        removed = remove_allowed_dir(target)
+    except OSError as exc:
+        error(f"Could not update allow list: {exc}")
+        raise typer.Exit(1) from exc
+    if removed:
+        success(f"Removed: {target}")
+    else:
+        error(f"Directory not in allow list: {target}")
+        raise typer.Exit(1)
+
+
+@app.command("list-allowed-dirs")
+def list_allowed_dirs() -> None:
+    """List all directories in the vp run allow list."""
+    dirs = load_allowed_dirs()
+    if not dirs:
+        console.print("No directories in the allow list.")
+        return
+    for d in dirs:
+        console.print(d)

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -22,6 +22,7 @@ from vibepod.core.agents import (
     get_agent_spec,
     resolve_agent_name,
 )
+from vibepod.core.allowed_dirs import add_allowed_dir, is_dir_allowed, is_protected_dir
 from vibepod.core.config import get_config
 from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag
 from vibepod.core.session_logger import SessionLogger
@@ -261,6 +262,32 @@ def run(
     workspace_path = workspace.expanduser().resolve()
     if not workspace_path.exists() or not workspace_path.is_dir():
         raise typer.BadParameter(f"Workspace not found: {workspace_path}")
+
+    if is_protected_dir(workspace_path):
+        error(
+            f"'{workspace_path}' is a protected directory (home or root) and cannot be "
+            "added to the allow list. Change to a project directory first."
+        )
+        raise typer.Exit(1)
+
+    if not is_dir_allowed(workspace_path):
+        if not sys.stdin.isatty():
+            error(
+                f"'{workspace_path}' is not in the allowed directories list. "
+                "Run `vp config allow-dir` to add it."
+            )
+            raise typer.Exit(1)
+        if not Confirm.ask(
+            f"'{workspace_path}' is not allowed for `vp run`. Would you like to allow it?",
+            default=True,
+        ):
+            error("Directory not allowed. Aborting.")
+            raise typer.Exit(1)
+        try:
+            add_allowed_dir(workspace_path)
+        except OSError as exc:
+            error(f"Could not update allow list for '{workspace_path}': {exc}")
+            raise typer.Exit(1) from exc
 
     agent_cfg = config.get("agents", {}).get(selected_agent, {})
     spec = get_agent_spec(selected_agent)

--- a/src/vibepod/core/allowed_dirs.py
+++ b/src/vibepod/core/allowed_dirs.py
@@ -1,0 +1,77 @@
+"""Allowed directories management for vp run."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from vibepod.core.config import get_config_root
+
+
+def get_allowed_dirs_path() -> Path:
+    """Return path to the allowed-directories JSON file."""
+    return get_config_root() / "allowed_dirs.json"
+
+
+def load_allowed_dirs() -> list[str]:
+    """Load and return the list of allowed directory paths."""
+    path = get_allowed_dirs_path()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return [str(d) for d in data if isinstance(d, str)]
+    except (json.JSONDecodeError, OSError):
+        pass
+    return []
+
+
+def save_allowed_dirs(dirs: list[str]) -> None:
+    """Persist the list of allowed directory paths."""
+    path = get_allowed_dirs_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(sorted(set(dirs)), indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def is_protected_dir(path: Path) -> bool:
+    """Return True if *path* is the filesystem root or the current user's home directory."""
+    try:
+        resolved = path.expanduser().resolve()
+    except OSError:
+        return False
+    home = Path.home().resolve()
+    root = Path("/").resolve()
+    return resolved == home or resolved == root
+
+
+def is_dir_allowed(path: Path) -> bool:
+    """Return True if *path* is in the allow list."""
+    try:
+        resolved = str(path.expanduser().resolve())
+    except OSError:
+        return False
+    return resolved in load_allowed_dirs()
+
+
+def add_allowed_dir(path: Path) -> None:
+    """Add *path* to the allow list (no-op if already present)."""
+    resolved = str(path.expanduser().resolve())
+    dirs = load_allowed_dirs()
+    if resolved not in dirs:
+        dirs.append(resolved)
+        save_allowed_dirs(dirs)
+
+
+def remove_allowed_dir(path: Path) -> bool:
+    """Remove *path* from the allow list. Returns True if it was present."""
+    resolved = str(path.expanduser().resolve())
+    dirs = load_allowed_dirs()
+    if resolved in dirs:
+        dirs.remove(resolved)
+        save_allowed_dirs(dirs)
+        return True
+    return False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -163,3 +163,91 @@ def test_llm_env_overrides(monkeypatch, tmp_path: Path) -> None:
     assert llm["base_url"] == "http://localhost:11434/v1"
     assert llm["api_key"] == "sk-test"
     assert llm["model"] == "llama3"
+
+
+
+# ---------------------------------------------------------------------------
+# allow-dir / remove-dir / list-allowed-dirs subcommand tests
+# ---------------------------------------------------------------------------
+
+
+def test_allow_dir_adds_current_directory(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["config", "allow-dir"])
+    assert result.exit_code == 0, result.stdout
+    assert str(tmp_path) in result.stdout
+
+
+def test_allow_dir_accepts_explicit_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+    target = tmp_path / "myproject"
+    target.mkdir()
+
+    result = runner.invoke(app, ["config", "allow-dir", str(target)])
+    assert result.exit_code == 0, result.stdout
+    assert str(target) in result.stdout
+
+
+def test_allow_dir_rejects_nonexistent_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+
+    result = runner.invoke(app, ["config", "allow-dir", str(tmp_path / "nonexistent")])
+    assert result.exit_code == 1
+
+
+def test_allow_dir_rejects_home_directory(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+    home = str(Path.home())
+
+    result = runner.invoke(app, ["config", "allow-dir", home])
+    assert result.exit_code == 1
+    assert "protected" in result.stdout
+
+
+def test_allow_dir_rejects_root_directory(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+
+    result = runner.invoke(app, ["config", "allow-dir", "/"])
+    assert result.exit_code == 1
+    assert "protected" in result.stdout
+
+
+def test_remove_dir_removes_allowed_directory(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+    target = tmp_path / "myproject"
+    target.mkdir()
+
+    runner.invoke(app, ["config", "allow-dir", str(target)])
+    result = runner.invoke(app, ["config", "remove-dir", str(target)])
+    assert result.exit_code == 0, result.stdout
+    assert str(target) in result.stdout
+
+
+def test_remove_dir_fails_when_not_in_list(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+    target = tmp_path / "myproject"
+    target.mkdir()
+
+    result = runner.invoke(app, ["config", "remove-dir", str(target)])
+    assert result.exit_code == 1
+
+
+def test_list_allowed_dirs_shows_added_directories(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+    target = tmp_path / "myproject"
+    target.mkdir()
+
+    runner.invoke(app, ["config", "allow-dir", str(target)])
+    result = runner.invoke(app, ["config", "list-allowed-dirs"])
+    assert result.exit_code == 0, result.stdout
+    assert str(target) in result.stdout
+
+
+def test_list_allowed_dirs_empty(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "cfg"))
+
+    result = runner.invoke(app, ["config", "list-allowed-dirs"])
+    assert result.exit_code == 0
+    assert "No directories" in result.stdout

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,16 @@ import typer
 from vibepod.commands import run as run_cmd
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
 from vibepod.core.docker import DockerClientError, DockerManager
+
+# ---------------------------------------------------------------------------
+# Autouse fixture: allow workspace dirs by default so existing tests still pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _allow_all_dirs(monkeypatch):
+    """Patch is_dir_allowed to return True so permission prompts don't break unrelated tests."""
+    monkeypatch.setattr(run_cmd, "is_dir_allowed", lambda p: True)
 
 
 def test_agent_extra_volumes_for_auggie(tmp_path: Path) -> None:
@@ -1288,3 +1299,109 @@ def test_run_sets_default_term_when_host_term_missing(monkeypatch, tmp_path: Pat
 
     env = captured["env"]
     assert env["TERM"] == "xterm-256color"
+
+
+
+# ---------------------------------------------------------------------------
+# Directory permission tests
+# ---------------------------------------------------------------------------
+
+
+def _make_capturing_docker_manager():
+    """Return a Docker manager stub that records run_agent kwargs."""
+    captured: dict = {}
+
+    class _CapturingDockerManager:
+        def ensure_network(self, name: str) -> None:
+            pass
+
+        def networks_with_running_containers(self) -> list[str]:
+            return []
+
+        def pull_image(self, image: str) -> None:
+            pass
+
+        def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+        def run_agent(self, **kwargs) -> object:  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+            return type(
+                "_Container",
+                (),
+                {
+                    "name": "vibepod-claude-test",
+                    "id": "abc123",
+                    "status": "running",
+                    "attrs": {"NetworkSettings": {"Networks": {}}},
+                    "reload": lambda self: None,
+                    "labels": {},
+                    "logs": lambda self, **kw: b"",
+                },
+            )()
+
+    return _CapturingDockerManager, captured
+
+
+def test_run_aborts_when_dir_not_allowed_and_non_interactive(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Non-interactive stdin + disallowed dir → Exit(1) with no prompt."""
+    monkeypatch.setattr(run_cmd, "is_dir_allowed", lambda p: False)
+    monkeypatch.setattr(run_cmd, "is_protected_dir", lambda p: False)
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    with pytest.raises(typer.Exit) as exc:
+        run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
+    assert exc.value.exit_code == 1
+
+
+def test_run_aborts_on_protected_dir(monkeypatch, tmp_path: Path) -> None:
+    """Protected directory (home/root) → Exit(1) without prompt."""
+    monkeypatch.setattr(run_cmd, "is_dir_allowed", lambda p: False)
+    monkeypatch.setattr(run_cmd, "is_protected_dir", lambda p: True)
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
+
+    with pytest.raises(typer.Exit) as exc:
+        run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
+    assert exc.value.exit_code == 1
+
+
+def test_run_prompts_and_proceeds_when_user_accepts(monkeypatch, tmp_path: Path) -> None:
+    """Interactive: user accepts the prompt → dir is added and run proceeds."""
+    added: list[Path] = []
+    monkeypatch.setattr(run_cmd, "is_dir_allowed", lambda p: False)
+    monkeypatch.setattr(run_cmd, "is_protected_dir", lambda p: False)
+    monkeypatch.setattr(run_cmd, "add_allowed_dir", lambda p: added.append(p))
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    # Patch Confirm.ask to always return True (user presses Y)
+    _confirm_yes = type("_C", (), {"ask": staticmethod(lambda *a, **kw: True)})()
+    monkeypatch.setattr(run_cmd, "Confirm", _confirm_yes)
+    _CapturingDockerManager, _ = _make_capturing_docker_manager()
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
+    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+
+    run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
+
+    assert len(added) == 1
+    assert added[0] == tmp_path.resolve()
+
+
+def test_run_aborts_when_user_declines_prompt(monkeypatch, tmp_path: Path) -> None:
+    """Interactive: user declines the prompt → Exit(1) and dir NOT added."""
+    added: list[Path] = []
+    monkeypatch.setattr(run_cmd, "is_dir_allowed", lambda p: False)
+    monkeypatch.setattr(run_cmd, "is_protected_dir", lambda p: False)
+    monkeypatch.setattr(run_cmd, "add_allowed_dir", lambda p: added.append(p))
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    # Patch Confirm.ask to return False (user presses N)
+    _confirm_no = type("_C", (), {"ask": staticmethod(lambda *a, **kw: False)})()
+    monkeypatch.setattr(run_cmd, "Confirm", _confirm_no)
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
+
+    with pytest.raises(typer.Exit) as exc:
+        run_cmd.run(agent="claude", workspace=tmp_path, detach=True)
+
+    assert exc.value.exit_code == 1
+    assert added == []


### PR DESCRIPTION
Introduces a directory allowlist mechanism for the `vp run` command, improving security and user control over which directories can be used as workspaces. It adds new CLI subcommands for managing the allowlist, enforces directory checks in `vp run`, and includes comprehensive tests for these features.

**Directory allowlist management:**

* Added a new module `vibepod/core/allowed_dirs.py` with functions to manage a JSON-based list of allowed directories, including checks for protected directories (home/root), and functions to add, remove, and list allowed directories.
* Introduced new CLI subcommands to `vp config`: `allow-dir`, `remove-dir`, and `list-allowed-dirs`, enabling users to manage the directory allowlist directly from the command line.

**Integration with `vp run`:**

* Updated `vp run` to check if the workspace directory is in the allowlist before proceeding. If not, and if running interactively, the user is prompted to allow the directory; otherwise, the command aborts with an error. Protected directories (home/root) are never allowed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added config commands: allow-dir, remove-dir, and list-allowed-dirs (lists “No directories” when empty). The run command now enforces an allowlist for workspaces, rejects protected system directories, and can prompt to approve unapproved paths.

* **Tests**
  * Added CLI and runtime tests covering allowlist commands, interactive approval flows, and protected-directory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->