### PR TITLE
Extend ollama connection on linux, extend docs for integration

### DIFF
--- a/docs/llm.md
+++ b/docs/llm.md
@@ -19,6 +19,66 @@ Other agents do not yet have LLM mapping and will not receive any LLM configurat
 ollama pull qwen3:14b
 ```
 
+!!! note "Linux: expose Ollama to Docker"
+    On Linux, Ollama binds to `127.0.0.1` by default. Docker containers reach the host via the Docker bridge gateway (for example `172.17.0.1` on the default Docker bridge), so the default binding will refuse connections.
+
+    **If running Ollama manually:**
+
+    ```bash
+    OLLAMA_HOST=0.0.0.0 ollama serve
+    ```
+
+    **If running Ollama as a systemd service** (the recommended Linux install), create an override:
+
+    ```bash
+    sudo systemctl edit ollama
+    ```
+
+    Add the following and save:
+
+    ```ini
+    [Service]
+    Environment="OLLAMA_HOST=0.0.0.0"
+    ```
+
+    Then reload and restart:
+
+    ```bash
+    sudo systemctl daemon-reload
+    sudo systemctl restart ollama
+    ```
+
+    Verify it is listening on all interfaces:
+
+    ```bash
+    sudo ss -tlnp | grep 11434
+    # Should show 0.0.0.0:11434, not 127.0.0.1:11434
+    # (sudo is required for -p to display process names; omit sudo or drop -p to just check the port)
+    ```
+
+    !!! warning "Security: binding to `0.0.0.0` exposes Ollama on all interfaces"
+        Setting `OLLAMA_HOST=0.0.0.0` makes Ollama reachable on **every** network
+        interface of the host, including public-facing ones. Only do this on trusted
+        networks or when the host is protected by a firewall.
+
+        **Safer alternatives:**
+
+        - **Bind to the Docker bridge gateway only** (e.g., `OLLAMA_HOST=172.17.0.1`)
+          so only containers on the default Docker bridge can reach Ollama while the
+          service remains unreachable from other interfaces. Substitute the actual
+          gateway IP reported by `docker network inspect bridge`.
+        - **Restrict access at the network level** with firewall rules (e.g.,
+          `ufw` or `iptables`) that allow port `11434` only from the Docker bridge
+          subnet before widening the bind address.
+        - **Add authentication** before exposing the service beyond localhost.
+          `OLLAMA_ORIGINS` controls which origins may make cross-origin (CORS)
+          requests to Ollama — it is **not** an authentication mechanism. The
+          local Ollama server has no built-in auth; API-key support is only
+          available for Ollama's cloud API. To protect a locally-exposed
+          instance, place a reverse proxy (e.g., nginx or Traefik) with proper
+          authentication in front of it, or enforce access via network ACLs /
+          firewall rules.
+
 ### 2. Configure VibePod
 
 Add the following to your global or project config:

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -319,6 +319,7 @@ class DockerManager:
             },
             "volumes": volumes,
             "network": network,
+            "extra_hosts": {"host.docker.internal": "host-gateway"},
         }
 
         getuid = getattr(os, "getuid", None)

--- a/tests/test_proxy_permissions.py
+++ b/tests/test_proxy_permissions.py
@@ -84,5 +84,6 @@ def test_ensure_proxy_runs_container_as_current_user(tmp_path: Path, monkeypatch
     assert run_kwargs is not None
     assert run_kwargs["user"] == "1234:2345"
     assert "ports" not in run_kwargs
+    assert run_kwargs["extra_hosts"] == {"host.docker.internal": "host-gateway"}
     assert db_path.parent.exists()
     assert ca_dir.exists()


### PR DESCRIPTION
Improves Docker networking support for Ollama integration and updates related documentation and tests. The main focus is to ensure that Docker containers can reliably connect to Ollama on Linux systems by configuring the correct network interface and adding the necessary Docker options.

**Documentation updates:**

* Added a detailed note explaining how to configure Ollama to listen on all interfaces (`0.0.0.0`) for Linux users, including instructions for both manual and systemd-managed setups. This ensures Docker containers can connect to Ollama, addressing common connectivity issues.

**Docker networking improvements:**

* Updated container run options to include `extra_hosts={"host.docker.internal": "host-gateway"}`, enabling containers to resolve the host machine as `host.docker.internal` and connect to services running on the host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Linux-specific Ollama + Docker setup notes: how to bind the service to 0.0.0.0 for container connectivity, verify the listening address, and warnings about exposure with safer alternatives (bridge gateway, firewall, or authentication).

* **Bug Fixes**
  * Improved container networking so containers can resolve the host (host.docker.internal → host gateway) for reliable host access.

* **Tests**
  * Added test coverage to assert the host-resolution mapping is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->