### PR TITLE
Add skill managers and skills cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 - ⚡ **Zero config** — no setup required; `vp run <agent>` just works. Optional YAML for custom configuration
 - 🐳 **Isolated agents** — each agent runs in its own Docker container
 - 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie & more
+- 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics
 - ⚖️ **Agent comparison** — benchmark multiple agents against each other in the dashboard
 - 🔒 **Privacy-first** — all metrics collected and stored locally, never sent to the cloud
@@ -139,6 +140,7 @@ VP_IMAGE_AUGGIE=vibepod/auggie:latest vp run auggie
 VP_IMAGE_COPILOT=vibepod/copilot:latest vp run copilot
 VP_IMAGE_CODEX=vibepod/codex:latest vp run codex
 VP_DATASETTE_IMAGE=vibepod/datasette:latest vp logs start
+VP_SKILLS_ENGINE_IMAGE=vibepod/skills-engine:latest vp skills list
 ```
 
 ## License

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,7 @@ Each agent image can be overridden individually:
 | `VP_IMAGE_CODEX` | codex |
 | `VP_DATASETTE_IMAGE` | datasette (logs UI) |
 | `VP_PROXY_IMAGE` | proxy |
+| `VP_SKILLS_ENGINE_IMAGE` | skills-engine (used by `vp skills`) |
 
 Set `VP_IMAGE_NAMESPACE` to change the prefix for all default images at once:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -114,6 +114,22 @@ vp stop claude
 
 For more details on detached mode workflows, see [Agents > Detached mode](agents/index.md#detached-mode).
 
+## Add reusable skills
+
+Skills are reusable prompt/recipe folders that supported agents can discover at
+runtime. Install one with:
+
+```bash
+vp skills add github:vibepod/vibepod-skills//skills/researcher --scope user
+```
+
+Use `--scope local` to install into the current project, or omit it to use the
+normal scope auto-detection. See [Skills](skills/index.md) for scopes, GitHub
+URL installs, bundles, and update/sync behavior.
+
+Browse example skills and future VibePod-specific skills in
+[`VibePod/vibepod-skills`](https://github.com/VibePod/vibepod-skills).
+
 ## View the session log UI
 
 VibePod records every session and proxied HTTP request. Open the Datasette UI with:
@@ -127,5 +143,6 @@ This starts a Datasette container and opens `http://localhost:8001` in your brow
 ## Next Steps
 
 - [Configure an agent](agents/index.md) — set API keys and per-agent options.
+- [Install skills](skills/index.md) — add reusable prompts/recipes to agents.
 - [Configuration reference](configuration.md) — tune defaults, the proxy, and logging.
 - [CLI Reference](cli-reference.md) — every command and flag.

--- a/docs/skills/authoring.md
+++ b/docs/skills/authoring.md
@@ -1,0 +1,59 @@
+# Authoring a skill
+
+A skill is a folder with a `SKILL.md`. Everything else is optional.
+
+## SKILL.md
+
+```markdown
+---
+name: Researcher
+version: 0.1.0
+description: Investigate a topic and produce a source-cited brief.
+tags: [research, summarization]
+permissions: [read_workspace, net_read]
+---
+
+# Researcher
+
+You are a focused research assistant. ...
+```
+
+### Required frontmatter
+
+- `name` — human-readable; slugified to the install ID.
+- `description` — one sentence shown by `vp skills list`.
+
+### Optional frontmatter
+
+- `version` — semver, stored in the lock.
+- `tags` — string array for discovery.
+- `requires.tools` — external CLI tools the skill expects (`ffmpeg`, `git`, ...).
+- `permissions` — capability hints (`read_workspace`, `write_workspace`, `net_read`, ...). Coarse, advisory.
+
+### Body
+
+Free-form markdown instructions. Must not be empty.
+
+## Authoring loop
+
+```bash
+mkdir -p ./skills/my-skill
+$EDITOR ./skills/my-skill/SKILL.md
+
+# install as a symlink so edits show up immediately
+vp skills add ./skills/my-skill --link
+
+# iterate, then validate:
+docker run --rm -v "$PWD/skills/my-skill:/in" \
+  vibepod/skills-engine:latest validate /in
+```
+
+## Publishing
+
+| Channel    | How                                                                  |
+|------------|----------------------------------------------------------------------|
+| GitHub     | Drop the skill folder anywhere; share `github:org/repo//path` locator |
+| GitLab     | Same as GitHub with `gitlab:` prefix                                  |
+| npm        | Publish as `vibepod-skill-<id>` or `@scope/vibepod-skill-<id>`        |
+
+For npm publication, the package root should be the skill folder itself (`SKILL.md` at the top level).

--- a/docs/skills/authoring.md
+++ b/docs/skills/authoring.md
@@ -41,7 +41,7 @@ mkdir -p ./skills/my-skill
 $EDITOR ./skills/my-skill/SKILL.md
 
 # install as a symlink so edits show up immediately
-vp skills add ./skills/my-skill --link
+vp skills add ./skills/my-skill --link --scope local
 
 # iterate, then validate:
 docker run --rm -v "$PWD/skills/my-skill:/in" \
@@ -55,5 +55,8 @@ docker run --rm -v "$PWD/skills/my-skill:/in" \
 | GitHub     | Drop the skill folder anywhere; share `github:org/repo//path` locator |
 | GitLab     | Same as GitHub with `gitlab:` prefix                                  |
 | npm        | Publish as `vibepod-skill-<id>` or `@scope/vibepod-skill-<id>`        |
+
+For GitHub, users can also paste a browser `tree` URL for the skill folder;
+VibePod normalizes it to the canonical `github:org/repo//path#ref` locator.
 
 For npm publication, the package root should be the skill folder itself (`SKILL.md` at the top level).

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -69,6 +69,57 @@ For concrete examples, see the
 [`VibePod/vibepod-skills`](https://github.com/VibePod/vibepod-skills)
 repository.
 
+## Example skill repositories
+
+These repositories are useful places to browse existing skills and authoring
+patterns. Third-party skills can contain instructions and executable helper
+scripts, so review the source and license before installing them.
+
+- [`VibePod/vibepod-skills`][vibepod-skills] — VibePod examples and
+  future VibePod-specific skills.
+- [`anthropics/skills`][anthropic-skills] — Anthropic's public Agent Skills
+  examples and templates.
+- [`anthropics/claude-plugins-official`][anthropic-plugins] — official
+  Claude Code plugins that include nested skills.
+- [`openai/skills`][openai-skills] — Codex skills catalog using the same
+  `SKILL.md` pattern.
+- [`microsoft/skills`][microsoft-skills] — Microsoft and Azure SDK skills for
+  coding agents.
+- [`addyosmani/agent-skills`][addy-agent-skills] — production engineering
+  workflow skills.
+- [`obra/superpowers`][obra-superpowers] — agentic software development
+  methodology skills.
+- [`alirezarezvani/claude-skills`][alireza-claude-skills] — large multi-domain
+  Claude/agent skills catalog.
+- [`jezweb/claude-skills`][jezweb-claude-skills] — Claude Code plugin skills
+  for web/product workflows.
+- [`ericgandrade/claude-superskills`][claude-superskills] — universal AI
+  skills for planning, research, and content.
+
+Example installs from external repositories:
+
+```bash
+vp skills add github:anthropics/skills//skills/claude-api --scope user
+vp skills add github:addyosmani/agent-skills//skills/code-review-and-quality --scope user
+vp skills add \
+  https://github.com/obra/superpowers/tree/main/skills/systematic-debugging \
+  --scope user
+vp skills add \
+  https://github.com/alirezarezvani/claude-skills/tree/main/product-team/skills/spec-to-repo \
+  --scope user
+```
+
+[vibepod-skills]: https://github.com/VibePod/vibepod-skills
+[anthropic-skills]: https://github.com/anthropics/skills
+[anthropic-plugins]: https://github.com/anthropics/claude-plugins-official
+[openai-skills]: https://github.com/openai/skills
+[microsoft-skills]: https://github.com/microsoft/skills
+[addy-agent-skills]: https://github.com/addyosmani/agent-skills
+[obra-superpowers]: https://github.com/obra/superpowers
+[alireza-claude-skills]: https://github.com/alirezarezvani/claude-skills
+[jezweb-claude-skills]: https://github.com/jezweb/claude-skills
+[claude-superskills]: https://github.com/ericgandrade/claude-superskills
+
 ## How agents see skills
 
 When you run a supported agent, VibePod reads the local and user skill lockfiles,

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,0 +1,45 @@
+# Skills
+
+Skills are reusable prompt/recipe folders agents can opt into. `vp skills` manages them through the `vibepod-skills-engine` container, so you don't need Node, npm, pnpm, git, or skill-specific tooling installed locally.
+
+## Quick start
+
+```bash
+# add the canonical researcher skill into your current project
+vp skills add github:vibepod/vibepod-skills//skills/researcher
+
+# show what's installed (local + user)
+vp skills list
+
+# remove it
+vp skills delete researcher
+```
+
+## Scopes
+
+| Scope    | Lives in                                              | Default when                                       |
+|----------|-------------------------------------------------------|----------------------------------------------------|
+| `local`  | `<project>/.vibepod/skills/`                          | invoked inside a project (`.vibepod/` present)     |
+| `user`   | `${XDG_CONFIG_HOME:-~/.config}/vibepod/skills/`        | invoked outside any project                        |
+
+Local skills shadow user skills when the same ID is installed in both — `vp skills list` shows which one wins.
+
+## Commands
+
+| Command                                  | What it does                                                |
+|------------------------------------------|-------------------------------------------------------------|
+| `vp skills add <locator> [--id] [--scope]` | Install a skill                                            |
+| `vp skills list [--scope] [--json]`      | Show installed skills with shadowing                        |
+| `vp skills delete <id> [--scope]`        | Uninstall a skill                                           |
+| `vp skills sync [--scope]`               | Reconcile `installed/` with the lockfile (no re-resolve)    |
+| `vp skills update [<id>] [--scope]`      | Re-resolve locators and rewrite the lockfile                |
+
+All commands accept `--json` for machine-readable output. The host CLI is a thin wrapper around the engine container — see [`vibepod-skills-engine`](https://github.com/VibePod/vibepod-skills-engine) for what runs inside.
+
+## Configuration
+
+| Env var                       | Effect                                                                 |
+|-------------------------------|------------------------------------------------------------------------|
+| `VP_SKILLS_ENGINE_IMAGE`      | Override the engine image (defaults to `${VP_IMAGE_NAMESPACE}/skills-engine:latest`) |
+| `VP_IMAGE_NAMESPACE`          | Used to derive the default engine image                                |
+| `VIBEPOD_TRUSTED_SOURCES`     | Comma-separated locator prefixes; if set, all other locators are rejected |

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,18 +1,34 @@
 # Skills
 
-Skills are reusable prompt/recipe folders agents can opt into. `vp skills` manages them through the `vibepod-skills-engine` container, so you don't need Node, npm, pnpm, git, or skill-specific tooling installed locally.
+Skills are reusable prompt/recipe folders that agents can discover at runtime.
+Each skill is a directory with a `SKILL.md` file plus any supporting files it
+needs.
+
+`vp skills` installs, lists, updates, and removes skills through the
+`vibepod-skills-engine` container, so you don't need Node, npm, pnpm, git, or
+skill-specific tooling installed locally.
+
+Browse example skills and future VibePod-specific skills in the
+[`VibePod/vibepod-skills`](https://github.com/VibePod/vibepod-skills)
+repository.
 
 ## Quick start
 
 ```bash
-# add the canonical researcher skill into your current project
-vp skills add github:vibepod/vibepod-skills//skills/researcher
+# install a skill globally for your user
+vp skills add github:vibepod/vibepod-skills//skills/researcher --scope user
 
-# show what's installed (local + user)
+# paste a GitHub tree URL directly
+vp skills add https://github.com/org/repo/tree/main/skills/researcher --scope user
+
+# install into the current project instead
+vp skills add github:vibepod/vibepod-skills//skills/researcher --scope local
+
+# show what's installed across local + user scopes
 vp skills list
 
 # remove it
-vp skills delete researcher
+vp skills delete researcher --scope user
 ```
 
 ## Scopes
@@ -22,7 +38,54 @@ vp skills delete researcher
 | `local`  | `<project>/.vibepod/skills/`                          | invoked inside a project (`.vibepod/` present)     |
 | `user`   | `${XDG_CONFIG_HOME:-~/.config}/vibepod/skills/`        | invoked outside any project                        |
 
-Local skills shadow user skills when the same ID is installed in both — `vp skills list` shows which one wins.
+If you want a project install, pass `--scope local` explicitly. This creates
+`<project>/.vibepod/skills/` when needed. Without `--scope local`, a command run
+outside a directory tree that already contains `.vibepod/` defaults to `user`.
+
+Local skills shadow user skills when the same ID is installed in both.
+`vp skills list` shows which one wins.
+
+## Locator examples
+
+Use canonical locators when you know them:
+
+```bash
+vp skills add github:org/repo//skills/researcher#v1.0.0
+vp skills add gitlab:org/repo//skills/sql#main
+vp skills add npm:@acme/vibepod-skill-researcher
+vp skills add ./skills/my-skill --link --scope local
+```
+
+For GitHub, you can also paste the browser URL for a folder:
+
+```bash
+vp skills add https://github.com/org/repo/tree/main/skills/researcher
+```
+
+See [Locator format](locators.md) for the full grammar, bundle installs, and
+reproducibility details.
+
+For concrete examples, see the
+[`VibePod/vibepod-skills`](https://github.com/VibePod/vibepod-skills)
+repository.
+
+## How agents see skills
+
+When you run a supported agent, VibePod reads the local and user skill lockfiles,
+merges them, and mounts each installed skill into that agent's skill discovery
+directory. Local skills win over user skills with the same ID.
+
+Current SKILL.md auto-discovery support:
+
+| Agent | Skill mount target inside the container |
+|-------|-----------------------------------------|
+| `claude` | `/claude/skills/<id>` |
+| `codex` | `/config/.agents/skills/<id>` |
+| `opencode` | `/config/.agents/skills/<id>` |
+| `auggie` | `/config/.agents/skills/<id>` |
+
+Other agents can still run normally, but VibePod does not currently mount
+SKILL.md folders into an auto-discovery location for them.
 
 ## Commands
 
@@ -34,7 +97,14 @@ Local skills shadow user skills when the same ID is installed in both — `vp sk
 | `vp skills sync [--scope]`               | Reconcile `installed/` with the lockfile (no re-resolve)    |
 | `vp skills update [<id>] [--scope]`      | Re-resolve locators and rewrite the lockfile                |
 
-All commands accept `--json` for machine-readable output. The host CLI is a thin wrapper around the engine container — see [`vibepod-skills-engine`](https://github.com/VibePod/vibepod-skills-engine) for what runs inside.
+All commands accept `--json` for machine-readable output. The host CLI is a thin
+wrapper around the engine container — see
+[`vibepod-skills-engine`](https://github.com/VibePod/vibepod-skills-engine) for
+what runs inside.
+
+Use `sync` when you want to restore the exact installed contents from the
+lockfile. Use `update` when you want to re-resolve moving refs such as branches
+or package ranges and rewrite the lockfile.
 
 ## Configuration
 

--- a/docs/skills/locators.md
+++ b/docs/skills/locators.md
@@ -1,0 +1,99 @@
+# Locator format
+
+VibePod skill locators use one of three grammars depending on the source.
+
+## Git-based (GitHub, GitLab, generic HTTPS Git)
+
+```
+<source>:<repo>[//<subpath>][#<ref>]
+```
+
+| Part        | Meaning                                                              | Example          |
+|-------------|----------------------------------------------------------------------|------------------|
+| `<source>`  | `github`, `gitlab`, or a full `https://...` URL                      | `github`         |
+| `<repo>`    | `org/repo` for github/gitlab; `host/path.git` for generic            | `vibepod/vibepod-skills` |
+| `//<subpath>` | optional path inside the repo                                      | `//skills/researcher` |
+| `#<ref>`    | optional branch, tag, or commit (resolved commit goes in the lock)  | `#v1.0.0`        |
+
+Examples:
+
+```text
+github:vibepod/vibepod-skills//skills/researcher#v1.0.0
+gitlab:acme/agent-skills//skills/sql#main
+https://git.example.com/org/repo.git//skills/foo#abc123
+```
+
+## npm
+
+```
+npm:<package>[@<version>]
+```
+
+`//subpath` and `#ref` do **not** apply — rely on the npm package's own version range.
+
+Examples:
+
+```text
+npm:@acme/vibepod-skill-researcher
+npm:@acme/vibepod-skill-researcher@1.2.0
+```
+
+The recommended naming convention for the curated channel is `vibepod-skill-<id>` or `@scope/vibepod-skill-<id>`, so it's greppable on the npm registry.
+
+## Local
+
+```
+<relative-or-absolute-path>
+```
+
+There is no `file:` scheme — bare paths only. Distinguished from other sources by a leading `.` or `/`.
+
+Examples:
+
+```text
+./skills/researcher
+/abs/path/to/skill
+```
+
+Use `--link` for symlink installs while authoring a skill:
+
+```bash
+vp skills add ./skills/researcher --link
+```
+
+## Bundle install
+
+If the resolved source has **no `SKILL.md`** at its root, the engine looks for skills in one of two places:
+
+1. Immediate subdirectories that each contain a `SKILL.md`.
+2. A conventional `skills/` subdirectory whose subdirectories each contain a `SKILL.md` — this is what repos like [`obra/superpowers`](https://github.com/obra/superpowers) ship.
+
+In either case, all matching skills are installed in a single call. The fetch happens once; each skill ends up in the lockfile with its own expanded per-skill locator, so `vp skills update <id>` and `vp skills sync` work normally afterward.
+
+```bash
+# whole repo — finds skills/ and installs all 14
+vp skills add github:obra/superpowers
+
+# equivalent, explicit subpath
+vp skills add github:obra/superpowers//skills
+
+# one specific skill
+vp skills add github:obra/superpowers//skills/test-driven-development
+```
+
+Directories without a `SKILL.md` (e.g. `docs/`, `assets/`, `tests/`) are skipped silently.
+
+`--id` is rejected with bundle installs since it'd apply to all skills at once. npm bundles aren't supported (npm locators don't carry a subpath).
+
+## Reproducibility
+
+The registry (`skills.json`) records what you asked for; the lockfile (`skills-lock.json`) records what got resolved.
+
+For git-based locators:
+
+- `#<branch>` may move on `vp skills update`.
+- `#<tag>` or `#<commit>` stay pinned.
+- The lockfile's `source.locator` is **always** pinned to the resolved commit (`…#<sha>`), even if you installed without a `#ref` or pinned a branch. That guarantees `vp skills sync` restores the exact tree that was installed, regardless of where the upstream branch points later.
+- The lockfile also keeps `source.commit` and the original `source.ref` as separate fields for inspection.
+
+For npm locators the same rule applies: the lockfile pins `npm:<pkg>@<exact-resolved-version>` even when the registry tracks `npm:<pkg>` or a range like `npm:<pkg>@^1.0.0`.

--- a/docs/skills/locators.md
+++ b/docs/skills/locators.md
@@ -23,6 +23,14 @@ gitlab:acme/agent-skills//skills/sql#main
 https://git.example.com/org/repo.git//skills/foo#abc123
 ```
 
+You can also paste common GitHub `tree` URLs; VibePod normalizes them to
+the canonical `github:` locator before invoking the skills engine:
+
+```text
+https://github.com/org/repo/tree/main/skills/researcher
+# becomes github:org/repo//skills/researcher#main
+```
+
 ## npm
 
 ```

--- a/docs/skills/locators.md
+++ b/docs/skills/locators.md
@@ -23,13 +23,17 @@ gitlab:acme/agent-skills//skills/sql#main
 https://git.example.com/org/repo.git//skills/foo#abc123
 ```
 
-You can also paste common GitHub `tree` URLs; VibePod normalizes them to
-the canonical `github:` locator before invoking the skills engine:
+You can also paste common GitHub `tree` URLs from your browser; VibePod
+normalizes them to the canonical `github:` locator before invoking the skills
+engine:
 
 ```text
 https://github.com/org/repo/tree/main/skills/researcher
 # becomes github:org/repo//skills/researcher#main
 ```
+
+For branches with `/` in the name, prefer the canonical `github:` form so the
+branch/ref and subpath are unambiguous.
 
 ## npm
 
@@ -54,7 +58,8 @@ The recommended naming convention for the curated channel is `vibepod-skill-<id>
 <relative-or-absolute-path>
 ```
 
-There is no `file:` scheme — bare paths only. Distinguished from other sources by a leading `.` or `/`.
+There is no `file:` scheme — bare paths only. Local locators are distinguished
+from other sources by a leading `.` or `/`.
 
 Examples:
 
@@ -66,8 +71,12 @@ Examples:
 Use `--link` for symlink installs while authoring a skill:
 
 ```bash
-vp skills add ./skills/researcher --link
+vp skills add ./skills/researcher --link --scope local
 ```
+
+Relative local locators are resolved from the directory where you run
+`vp skills add`. The original locator string is kept in the registry so later
+`sync` and `update` commands can reproduce what you asked for.
 
 ## Bundle install
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,10 @@ nav:
   - Quickstart: quickstart.md
   - Development: development.md
   - Agents: agents/index.md
+  - Skills:
+    - Overview: skills/index.md
+    - Locator format: skills/locators.md
+    - Authoring: skills/authoring.md
   - Configuration: configuration.md
   - LLM Integration: llm.md
   - CLI Reference: cli-reference.md

--- a/src/vibepod/cli.py
+++ b/src/vibepod/cli.py
@@ -7,7 +7,18 @@ from typing import Annotated
 
 import typer
 
-from vibepod.commands import attach, config, doctor, list_cmd, logs, proxy, run, stop, update
+from vibepod.commands import (
+    attach,
+    config,
+    doctor,
+    list_cmd,
+    logs,
+    proxy,
+    run,
+    skills,
+    stop,
+    update,
+)
 from vibepod.constants import AGENT_SHORTCUTS, SUPPORTED_AGENTS
 
 app = typer.Typer(
@@ -30,6 +41,7 @@ app.add_typer(logs.app, name="logs")
 app.add_typer(config.app, name="config")
 app.add_typer(proxy.app, name="proxy")
 app.add_typer(doctor.app, name="doctor")
+app.add_typer(skills.app, name="skills")
 
 
 def _register_run_alias(command_name: str, agent_name: str) -> None:

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -168,14 +168,24 @@ def _update_container_mapping(
 def _agent_skill_paths(agent: str) -> list[str]:
     """Container paths where each agent auto-discovers SKILL.md folders.
 
-    Claude's entrypoint sets `CLAUDE_CONFIG_DIR=/claude`, and Claude Code uses
-    `$CLAUDE_CONFIG_DIR/skills/` (not `$HOME/.claude/skills/`) as the skills
-    discovery path when that env var is set. Mounting under `/claude/skills/`
-    nests inside the existing `/claude` config mount, which Docker handles.
+    All paths assume the in-container HOME or CONFIG_DIR conventions wired by
+    vibepod-agents entrypoints. The SKILL.md format (Anthropic spec — frontmatter
+    `name` + `description` + markdown body) is shared verbatim across claude,
+    codex, opencode, and auggie. They differ only in which directory they scan.
+
+      - claude   reads $CLAUDE_CONFIG_DIR/skills/   → /claude/skills/
+      - codex    reads ~/.agents/skills/            → /config/.agents/skills/
+      - opencode reads ~/.agents/skills/ (also ~/.claude/skills/, ~/.config/opencode/skills/)
+      - auggie   reads ~/.agents/skills/ (also ~/.augment/skills/, ~/.claude/skills/)
+
+    Gemini wraps skills inside an extension manifest and would need a generated
+    gemini-extension.json — handled separately when we add that support.
+    Copilot CLI and Devstral Vibe have no documented SKILL.md auto-discovery.
     """
     if agent == "claude":
         return ["/claude/skills"]
-    # Other agents don't have a documented skills discovery path yet.
+    if agent in ("codex", "opencode", "auggie"):
+        return ["/config/.agents/skills"]
     return []
 
 
@@ -187,11 +197,21 @@ def _resolved_skill_paths(workspace: Path) -> dict[str, Path]:
     """
     from vibepod.core.skills_engine import local_skills_dir, user_skills_dir
 
+    def _string_keyed_dict(value: object) -> dict[str, object] | None:
+        if not isinstance(value, dict):
+            return None
+        result: dict[str, object] = {}
+        for key, item in value.items():
+            if isinstance(key, str):
+                result[key] = item
+        return result
+
     def _read_lock(path: Path) -> dict[str, object]:
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
+            raw: object = json.loads(path.read_text(encoding="utf-8"))
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             return {"skills": {}}
+        return _string_keyed_dict(raw) or {"skills": {}}
 
     local_root = local_skills_dir(workspace).resolve()
     user_root = user_skills_dir().resolve()
@@ -199,10 +219,15 @@ def _resolved_skill_paths(workspace: Path) -> dict[str, Path]:
     merged: dict[str, Path] = {}
     for scope_root in (user_root, local_root):  # local processed second → wins
         lock = _read_lock(scope_root / "skills-lock.json")
-        for sid, entry in (lock.get("skills") or {}).items():
-            if not isinstance(entry, dict):
+        skills = _string_keyed_dict(lock.get("skills"))
+        if skills is None:
+            continue
+        for sid, raw_entry in skills.items():
+            entry = _string_keyed_dict(raw_entry)
+            if entry is None:
                 continue
-            rel = entry.get("path") or f"installed/{sid}"
+            path_value = entry.get("path")
+            rel = path_value if isinstance(path_value, str) and path_value else f"installed/{sid}"
             abs_path = scope_root / rel
             if abs_path.exists():
                 merged[sid] = abs_path

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -213,6 +213,16 @@ def _resolved_skill_paths(workspace: Path) -> dict[str, Path]:
             return {"skills": {}}
         return _string_keyed_dict(raw) or {"skills": {}}
 
+    def _safe_skill_path(scope_root: Path, skill_id: str, path_value: object) -> Path | None:
+        rel = path_value if isinstance(path_value, str) and path_value else f"installed/{skill_id}"
+        rel_path = Path(rel)
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            rel_path = Path("installed") / skill_id
+        abs_path = (scope_root / rel_path).resolve(strict=False)
+        if not abs_path.is_relative_to(scope_root) or not abs_path.is_dir():
+            return None
+        return abs_path
+
     local_root = local_skills_dir(workspace).resolve()
     user_root = user_skills_dir().resolve()
 
@@ -226,10 +236,8 @@ def _resolved_skill_paths(workspace: Path) -> dict[str, Path]:
             entry = _string_keyed_dict(raw_entry)
             if entry is None:
                 continue
-            path_value = entry.get("path")
-            rel = path_value if isinstance(path_value, str) and path_value else f"installed/{sid}"
-            abs_path = scope_root / rel
-            if abs_path.exists():
+            abs_path = _safe_skill_path(scope_root, sid, entry.get("path"))
+            if abs_path is not None:
                 merged[sid] = abs_path
     return merged
 

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import time
 from datetime import datetime, timezone
@@ -30,6 +31,12 @@ from vibepod.core.session_logger import SessionLogger
 from vibepod.utils.console import error, info, success, warning
 
 CLAUDE_TOKEN_FILENAME = "oauth-token"
+_SAFE_SKILL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+def _is_safe_skill_id(skill_id: str) -> bool:
+    """Return True for skill IDs safe to use as one container path segment."""
+    return bool(_SAFE_SKILL_ID_RE.fullmatch(skill_id))
 
 
 def _claude_stored_token_path(config_dir: Path) -> Path:
@@ -233,6 +240,8 @@ def _resolved_skill_paths(workspace: Path) -> dict[str, Path]:
         if skills is None:
             continue
         for sid, raw_entry in skills.items():
+            if not _is_safe_skill_id(sid):
+                continue
             entry = _string_keyed_dict(raw_entry)
             if entry is None:
                 continue

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -165,6 +165,62 @@ def _update_container_mapping(
     return True
 
 
+def _agent_skill_paths(agent: str) -> list[str]:
+    """Container paths where each agent auto-discovers SKILL.md folders.
+
+    Claude's entrypoint sets `CLAUDE_CONFIG_DIR=/claude`, and Claude Code uses
+    `$CLAUDE_CONFIG_DIR/skills/` (not `$HOME/.claude/skills/`) as the skills
+    discovery path when that env var is set. Mounting under `/claude/skills/`
+    nests inside the existing `/claude` config mount, which Docker handles.
+    """
+    if agent == "claude":
+        return ["/claude/skills"]
+    # Other agents don't have a documented skills discovery path yet.
+    return []
+
+
+def _resolved_skill_paths(workspace: Path) -> dict[str, Path]:
+    """Merge installed skills from local + user scope (local wins).
+
+    Returns id → absolute host path to the skill folder. Reads the lockfiles
+    directly so this stays cheap during `vp run` (no engine container call).
+    """
+    from vibepod.core.skills_engine import local_skills_dir, user_skills_dir
+
+    def _read_lock(path: Path) -> dict[str, object]:
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {"skills": {}}
+
+    local_root = local_skills_dir(workspace).resolve()
+    user_root = user_skills_dir().resolve()
+
+    merged: dict[str, Path] = {}
+    for scope_root in (user_root, local_root):  # local processed second → wins
+        lock = _read_lock(scope_root / "skills-lock.json")
+        for sid, entry in (lock.get("skills") or {}).items():
+            if not isinstance(entry, dict):
+                continue
+            rel = entry.get("path") or f"installed/{sid}"
+            abs_path = scope_root / rel
+            if abs_path.exists():
+                merged[sid] = abs_path
+    return merged
+
+
+def _skills_mounts_for_agent(agent: str, workspace: Path) -> list[tuple[str, str, str]]:
+    """One bind-mount per resolved skill into the agent's discovery path(s)."""
+    targets = _agent_skill_paths(agent)
+    if not targets:
+        return []
+    mounts: list[tuple[str, str, str]] = []
+    for skill_id, host_path in _resolved_skill_paths(workspace).items():
+        for base in targets:
+            mounts.append((str(host_path), f"{base}/{skill_id}", "ro"))
+    return mounts
+
+
 def _agent_extra_volumes(agent: str, config_dir: Path) -> list[tuple[str, str, str]]:
     """Return agent-specific bind mounts as (host_path, container_path, mode)."""
     if agent == "auggie":
@@ -445,6 +501,8 @@ def run(
     extra_volumes = _agent_extra_volumes(selected_agent, config_dir)
     for host_path, _, _ in extra_volumes:
         Path(host_path).mkdir(parents=True, exist_ok=True)
+
+    extra_volumes.extend(_skills_mounts_for_agent(selected_agent, workspace_path))
 
     if paste_images:
         display = os.environ.get("DISPLAY", "")

--- a/src/vibepod/commands/skills.py
+++ b/src/vibepod/commands/skills.py
@@ -25,6 +25,13 @@ def _resolve_scope(scope: str | None) -> Scope:
     return skills_engine.detect_scope_default()
 
 
+def _emit_diagnostic(message: str, json_out: bool) -> None:
+    if json_out:
+        typer.echo(message, err=True)
+    else:
+        error(message)
+
+
 def _emit_or_raise(result: skills_engine.EngineResult, json_out: bool) -> None:
     if json_out:
         if result.data is not None:
@@ -33,7 +40,7 @@ def _emit_or_raise(result: skills_engine.EngineResult, json_out: bool) -> None:
             typer.echo(result.stdout, nl=False)
     if result.exit_code != 0:
         if result.stderr:
-            error(result.stderr.strip())
+            _emit_diagnostic(result.stderr.strip(), json_out)
         raise typer.Exit(result.exit_code)
 
 
@@ -56,11 +63,12 @@ def add_cmd(
 ) -> None:
     """Install a skill from a locator."""
     resolved_scope = _resolve_scope(scope)
-    info(f"Adding {locator} → scope={resolved_scope}")
+    if not json_out:
+        info(f"Adding {locator} → scope={resolved_scope}")
     try:
         result = skills_engine.add(locator, scope=resolved_scope, skill_id=skill_id, link=link)
     except SkillsEngineError as exc:
-        error(str(exc))
+        _emit_diagnostic(str(exc), json_out)
         raise typer.Exit(1) from exc
 
     if not json_out and result.exit_code == 0 and result.data:
@@ -96,7 +104,7 @@ def delete_cmd(
     try:
         result = skills_engine.delete(skill_id, scope=resolved_scope)
     except SkillsEngineError as exc:
-        error(str(exc))
+        _emit_diagnostic(str(exc), json_out)
         raise typer.Exit(1) from exc
 
     if not json_out and result.exit_code == 0:
@@ -117,7 +125,7 @@ def list_cmd(
     try:
         result = skills_engine.list_skills(scope)  # type: ignore[arg-type]
     except SkillsEngineError as exc:
-        error(str(exc))
+        _emit_diagnostic(str(exc), json_out)
         raise typer.Exit(1) from exc
 
     if json_out:
@@ -171,7 +179,7 @@ def sync_cmd(
     try:
         result = skills_engine.sync(resolved_scope)
     except SkillsEngineError as exc:
-        error(str(exc))
+        _emit_diagnostic(str(exc), json_out)
         raise typer.Exit(1) from exc
 
     if not json_out and result.exit_code == 0 and result.data:
@@ -195,7 +203,7 @@ def update_cmd(
     try:
         result = skills_engine.update(resolved_scope, skill_id)
     except SkillsEngineError as exc:
-        error(str(exc))
+        _emit_diagnostic(str(exc), json_out)
         raise typer.Exit(1) from exc
 
     if not json_out and result.exit_code == 0:

--- a/src/vibepod/commands/skills.py
+++ b/src/vibepod/commands/skills.py
@@ -1,0 +1,196 @@
+"""`vp skills` — manage installed skills via the skills-engine container."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+import typer
+from rich.table import Table
+
+from vibepod.core import skills_engine
+from vibepod.core.skills_engine import Scope, SkillsEngineError
+from vibepod.utils.console import console, error, info, success, warning
+
+_VALID_SCOPES = {"local", "user"}
+
+app = typer.Typer(help="Manage VibePod skills", no_args_is_help=True)
+
+
+def _resolve_scope(scope: str | None) -> Scope:
+    if scope is not None:
+        if scope not in _VALID_SCOPES:
+            raise typer.BadParameter(f"--scope must be local|user, got {scope!r}")
+        return scope  # type: ignore[return-value]
+    return skills_engine.detect_scope_default()
+
+
+def _emit_or_raise(result: skills_engine.EngineResult, json_out: bool) -> None:
+    if json_out:
+        if result.data is not None:
+            typer.echo(json.dumps(result.data, indent=2))
+        else:
+            typer.echo(result.stdout, nl=False)
+    if result.exit_code != 0:
+        if result.stderr:
+            error(result.stderr.strip())
+        raise typer.Exit(result.exit_code)
+
+
+@app.command("add")
+def add_cmd(
+    locator: Annotated[str, typer.Argument(help="Skill locator (github:..., npm:..., ./path, ...)")],
+    skill_id: Annotated[
+        str | None, typer.Option("--id", help="Override the derived skill ID")
+    ] = None,
+    scope: Annotated[
+        str | None,
+        typer.Option("--scope", help="local|user (defaults to local inside a project, else user)"),
+    ] = None,
+    link: Annotated[
+        bool, typer.Option("--link", help="Symlink instead of copy (local sources only)")
+    ] = False,
+    json_out: Annotated[bool, typer.Option("--json", help="Emit JSON to stdout")] = False,
+) -> None:
+    """Install a skill from a locator."""
+    resolved_scope = _resolve_scope(scope)
+    info(f"Adding {locator} → scope={resolved_scope}")
+    try:
+        result = skills_engine.add(locator, scope=resolved_scope, skill_id=skill_id, link=link)
+    except SkillsEngineError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
+
+    if not json_out and result.exit_code == 0 and result.data:
+        for record in result.data:
+            if record.get("command") != "add":
+                continue
+            if record.get("bundle"):
+                installed = record.get("installed", [])
+                success(f"Installed {len(installed)} skill(s) from bundle {record.get('locator', '')}")
+                for item in installed:
+                    info(f"  + {item.get('id', '?')} ({item.get('name', '')})")
+                for fail in record.get("failed", []) or []:
+                    error(f"  ! {fail.get('subpath', '?')}: {fail.get('error', 'unknown error')}")
+            else:
+                success(
+                    f"Installed {record.get('id', '?')} "
+                    f"({record.get('name', '')}) → {record.get('path', '')}"
+                )
+    _emit_or_raise(result, json_out)
+
+
+@app.command("delete")
+def delete_cmd(
+    skill_id: Annotated[str, typer.Argument(help="Skill ID to remove")],
+    scope: Annotated[str | None, typer.Option("--scope", help="local|user")] = None,
+    json_out: Annotated[bool, typer.Option("--json")] = False,
+) -> None:
+    """Remove an installed skill."""
+    resolved_scope = _resolve_scope(scope)
+    try:
+        result = skills_engine.delete(skill_id, scope=resolved_scope)
+    except SkillsEngineError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
+
+    if not json_out and result.exit_code == 0:
+        success(f"Deleted {skill_id} from {resolved_scope}")
+    _emit_or_raise(result, json_out)
+
+
+@app.command("list")
+def list_cmd(
+    scope: Annotated[str | None, typer.Option("--scope", help="Filter by scope (local|user)")] = None,
+    json_out: Annotated[bool, typer.Option("--json")] = False,
+) -> None:
+    """List installed skills across both scopes."""
+    if scope is not None and scope not in _VALID_SCOPES:
+        raise typer.BadParameter(f"--scope must be local|user, got {scope!r}")
+    try:
+        result = skills_engine.list_skills(scope)  # type: ignore[arg-type]
+    except SkillsEngineError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
+
+    if json_out:
+        _emit_or_raise(result, json_out=True)
+        return
+
+    if result.exit_code != 0:
+        error(result.stderr.strip())
+        raise typer.Exit(result.exit_code)
+
+    rows: list[dict[str, Any]] = []
+    if result.data:
+        for record in result.data:
+            if record.get("command") == "list":
+                rows = record.get("skills", [])
+                break
+
+    if not rows:
+        warning("No skills installed.")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID")
+    table.add_column("Name")
+    table.add_column("Version")
+    table.add_column("Scope")
+    table.add_column("Status")
+    for row in rows:
+        status = row.get("status", "active")
+        if status == "shadowed" and row.get("shadowedBy"):
+            status = f"shadowed by {row['shadowedBy']}"
+        elif row.get("shadows"):
+            status = f"active (shadows {','.join(row['shadows'])})"
+        table.add_row(
+            row.get("id", ""),
+            row.get("name", ""),
+            str(row.get("version", "-")),
+            row.get("scope", ""),
+            status,
+        )
+    console.print(table)
+
+
+@app.command("sync")
+def sync_cmd(
+    scope: Annotated[str | None, typer.Option("--scope", help="local|user")] = None,
+    json_out: Annotated[bool, typer.Option("--json")] = False,
+) -> None:
+    """Reconcile installed/ with the lockfile (no re-resolve)."""
+    resolved_scope = _resolve_scope(scope)
+    try:
+        result = skills_engine.sync(resolved_scope)
+    except SkillsEngineError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
+
+    if not json_out and result.exit_code == 0 and result.data:
+        for record in result.data:
+            if record.get("command") == "sync":
+                success(
+                    f"Synced {resolved_scope}: restored={len(record.get('restored', []))}, "
+                    f"unchanged={len(record.get('unchanged', []))}"
+                )
+    _emit_or_raise(result, json_out)
+
+
+@app.command("update")
+def update_cmd(
+    skill_id: Annotated[str | None, typer.Argument(help="Skill ID (omit to update all)")] = None,
+    scope: Annotated[str | None, typer.Option("--scope", help="local|user")] = None,
+    json_out: Annotated[bool, typer.Option("--json")] = False,
+) -> None:
+    """Re-resolve locators and rewrite the lockfile."""
+    resolved_scope = _resolve_scope(scope)
+    try:
+        result = skills_engine.update(resolved_scope, skill_id)
+    except SkillsEngineError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
+
+    if not json_out and result.exit_code == 0:
+        success(f"Updated skills in {resolved_scope}")
+    _emit_or_raise(result, json_out)

--- a/src/vibepod/commands/skills.py
+++ b/src/vibepod/commands/skills.py
@@ -39,7 +39,9 @@ def _emit_or_raise(result: skills_engine.EngineResult, json_out: bool) -> None:
 
 @app.command("add")
 def add_cmd(
-    locator: Annotated[str, typer.Argument(help="Skill locator (github:..., npm:..., ./path, ...)")],
+    locator: Annotated[
+        str, typer.Argument(help="Skill locator (github:..., npm:..., ./path, ...)")
+    ],
     skill_id: Annotated[
         str | None, typer.Option("--id", help="Override the derived skill ID")
     ] = None,
@@ -67,7 +69,10 @@ def add_cmd(
                 continue
             if record.get("bundle"):
                 installed = record.get("installed", [])
-                success(f"Installed {len(installed)} skill(s) from bundle {record.get('locator', '')}")
+                success(
+                    f"Installed {len(installed)} skill(s) from bundle "
+                    f"{record.get('locator', '')}"
+                )
                 for item in installed:
                     info(f"  + {item.get('id', '?')} ({item.get('name', '')})")
                 for fail in record.get("failed", []) or []:
@@ -101,7 +106,9 @@ def delete_cmd(
 
 @app.command("list")
 def list_cmd(
-    scope: Annotated[str | None, typer.Option("--scope", help="Filter by scope (local|user)")] = None,
+    scope: Annotated[
+        str | None, typer.Option("--scope", help="Filter by scope (local|user)")
+    ] = None,
     json_out: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
     """List installed skills across both scopes."""

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -53,7 +53,23 @@ IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (
     "VP_IMAGE_CODEX",
     "VP_DATASETTE_IMAGE",
     "VP_PROXY_IMAGE",
+    "VP_SKILLS_ENGINE_IMAGE",
 )
+
+
+def get_skills_engine_image() -> str:
+    return os.environ.get(
+        "VP_SKILLS_ENGINE_IMAGE",
+        f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/skills-engine:latest",
+    )
+
+
+SKILLS_ENGINE_IMAGE: str = get_skills_engine_image()
+
+# Skill storage paths
+USER_SKILLS_DIR = CONFIG_DIR / "skills"
+PROJECT_SKILLS_DIR = Path(".vibepod") / "skills"
+SKILLS_CACHE_DIR = CONFIG_DIR / "skills-cache"
 
 
 def get_default_images() -> dict[str, str]:
@@ -91,6 +107,10 @@ def get_default_images() -> dict[str, str]:
         ),
         "proxy": os.environ.get(
             "VP_PROXY_IMAGE", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/proxy:latest"
+        ),
+        "skills-engine": os.environ.get(
+            "VP_SKILLS_ENGINE_IMAGE",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/skills-engine:latest",
         ),
     }
 

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -108,10 +108,7 @@ def get_default_images() -> dict[str, str]:
         "proxy": os.environ.get(
             "VP_PROXY_IMAGE", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/proxy:latest"
         ),
-        "skills-engine": os.environ.get(
-            "VP_SKILLS_ENGINE_IMAGE",
-            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/skills-engine:latest",
-        ),
+        "skills-engine": get_skills_engine_image(),
     }
 
 

--- a/src/vibepod/core/skills_engine.py
+++ b/src/vibepod/core/skills_engine.py
@@ -20,7 +20,7 @@ Scope = Literal["local", "user"]
 
 
 class SkillsEngineError(RuntimeError):
-    """Raised when the skills engine container exits non-zero or output is malformed."""
+    """Raised when the driver cannot return an engine result."""
 
 
 @dataclass(frozen=True)
@@ -75,7 +75,7 @@ def run_engine(
     *,
     json_output: bool = True,
     cwd: Path | None = None,
-    extra_mounts: list[tuple[Path, str]] | None = None,
+    extra_mounts: list[tuple[Path, str, str]] | None = None,
 ) -> EngineResult:
     """Invoke the engine container with the standard mount layout.
 
@@ -95,8 +95,8 @@ def run_engine(
         "-v",
         f"{cache}:/vibepod/cache",
     ]
-    for host_path, container_path in extra_mounts or []:
-        cmd.extend(["-v", f"{host_path}:{container_path}"])
+    for host_path, container_path, mode in extra_mounts or []:
+        cmd.extend(["-v", f"{host_path}:{container_path}:{mode}"])
 
     # Pass through trusted-source allowlist if set on host.
     if "VIBEPOD_TRUSTED_SOURCES" in os.environ:
@@ -140,10 +140,14 @@ def add(
     if link:
         args.append("--link")
 
-    extra: list[tuple[Path, str]] = []
+    extra: list[tuple[Path, str, str]] = []
     if _is_local_locator(locator):
-        host = Path(locator).resolve()
-        extra.append((host, "/vibepod/source-in"))
+        locator_path = Path(locator)
+        base = Path(cwd) if cwd is not None else Path.cwd()
+        host = (locator_path if locator_path.is_absolute() else base / locator_path).resolve()
+        if not host.exists():
+            raise SkillsEngineError(f"Local skill locator not found: {host}")
+        extra.append((host, "/vibepod/source-in", "ro"))
         # Replace user-facing locator with the in-container mount path so the
         # engine sees a bare absolute path it can read.
         args[1] = "/vibepod/source-in"

--- a/src/vibepod/core/skills_engine.py
+++ b/src/vibepod/core/skills_engine.py
@@ -8,6 +8,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import unquote, urlparse
 
 from vibepod.constants import (
     PROJECT_SKILLS_DIR,
@@ -33,19 +34,22 @@ class EngineResult:
 
 def detect_scope_default(cwd: Path | None = None) -> Scope:
     """Local when invoked from inside a `.vibepod` project, else user."""
+    return "local" if _project_root(cwd) is not None else "user"
+
+
+def _project_root(cwd: Path | None = None) -> Path | None:
     here = Path(cwd or Path.cwd()).resolve()
     for parent in [here, *here.parents]:
         if (parent / ".vibepod").is_dir():
-            return "local"
-    return "user"
+            return parent
+    return None
 
 
 def local_skills_dir(cwd: Path | None = None) -> Path:
-    here = Path(cwd or Path.cwd()).resolve()
-    for parent in [here, *here.parents]:
-        if (parent / ".vibepod").is_dir():
-            return parent / PROJECT_SKILLS_DIR
-    return here / PROJECT_SKILLS_DIR
+    root = _project_root(cwd)
+    if root is not None:
+        return root / PROJECT_SKILLS_DIR
+    return Path(cwd or Path.cwd()).resolve() / PROJECT_SKILLS_DIR
 
 
 def user_skills_dir() -> Path:
@@ -56,11 +60,18 @@ def cache_dir() -> Path:
     return SKILLS_CACHE_DIR
 
 
-def _ensure_dirs(scope: Scope, cwd: Path | None = None) -> tuple[Path, Path, Path]:
-    local = local_skills_dir(cwd)
+def _local_mount_dir(cwd: Path | None, *, local_required: bool) -> Path:
+    if _project_root(cwd) is not None or local_required:
+        return local_skills_dir(cwd)
+    return cache_dir() / "empty-local-skills"
+
+
+def _ensure_dirs(
+    cwd: Path | None = None, *, local_required: bool = False
+) -> tuple[Path, Path, Path]:
+    local = _local_mount_dir(cwd, local_required=local_required)
     user = user_skills_dir()
     cache = cache_dir()
-    # Only the relevant scope must exist, but mounting both is fine.
     for d in (local, user, cache):
         d.mkdir(parents=True, exist_ok=True)
     return local, user, cache
@@ -70,19 +81,41 @@ def _is_local_locator(locator: str) -> bool:
     return locator.startswith("./") or locator.startswith("../") or locator.startswith("/")
 
 
+def _normalize_locator(locator: str) -> str:
+    """Accept common GitHub web URLs by converting them to skill locators."""
+    parsed = urlparse(locator)
+    if parsed.scheme not in {"http", "https"}:
+        return locator
+    if parsed.netloc.lower() not in {"github.com", "www.github.com"}:
+        return locator
+
+    parts = [unquote(part) for part in parsed.path.split("/") if part]
+    if len(parts) < 4 or parts[2] != "tree":
+        return locator
+
+    owner, repo, _, ref, *subpath = parts
+    repo = repo.removesuffix(".git")
+    normalized = f"github:{owner}/{repo}"
+    if subpath:
+        normalized += f"//{'/'.join(subpath)}"
+    return f"{normalized}#{ref}"
+
+
 def run_engine(
     args: list[str],
     *,
     json_output: bool = True,
     cwd: Path | None = None,
     extra_mounts: list[tuple[Path, str, str]] | None = None,
+    local_required: bool = False,
+    working_dir: Path | None = None,
 ) -> EngineResult:
     """Invoke the engine container with the standard mount layout.
 
     Returns the parsed JSON payload if ``json_output`` is True. Stderr from the
     engine (human-readable progress) is always captured but never parsed.
     """
-    local, user, cache = _ensure_dirs("local", cwd)
+    local, user, cache = _ensure_dirs(cwd, local_required=local_required)
 
     cmd: list[str] = [
         "docker",
@@ -97,6 +130,8 @@ def run_engine(
     ]
     for host_path, container_path, mode in extra_mounts or []:
         cmd.extend(["-v", f"{host_path}:{container_path}:{mode}"])
+    if working_dir is not None:
+        cmd.extend(["-w", str(working_dir)])
 
     # Pass through trusted-source allowlist if set on host.
     if "VIBEPOD_TRUSTED_SOURCES" in os.environ:
@@ -134,6 +169,7 @@ def add(
     link: bool = False,
     cwd: Path | None = None,
 ) -> EngineResult:
+    locator = _normalize_locator(locator)
     args = ["add", locator, "--scope", scope]
     if skill_id:
         args.extend(["--id", skill_id])
@@ -141,32 +177,39 @@ def add(
         args.append("--link")
 
     extra: list[tuple[Path, str, str]] = []
+    working_dir: Path | None = None
     if _is_local_locator(locator):
         locator_path = Path(locator)
         base = Path(cwd) if cwd is not None else Path.cwd()
         host = (locator_path if locator_path.is_absolute() else base / locator_path).resolve()
         if not host.exists():
             raise SkillsEngineError(f"Local skill locator not found: {host}")
-        extra.append((host, "/vibepod/source-in", "ro"))
-        # Replace user-facing locator with the in-container mount path so the
-        # engine sees a bare absolute path it can read.
-        args[1] = "/vibepod/source-in"
-    return run_engine(args, cwd=cwd, extra_mounts=extra)
+        extra.append((host, str(host), "ro"))
+        working_dir = base.resolve()
+    return run_engine(
+        args,
+        cwd=cwd,
+        extra_mounts=extra,
+        local_required=scope == "local",
+        working_dir=working_dir,
+    )
 
 
 def delete(skill_id: str, *, scope: Scope, cwd: Path | None = None) -> EngineResult:
-    return run_engine(["delete", skill_id, "--scope", scope], cwd=cwd)
+    return run_engine(
+        ["delete", skill_id, "--scope", scope], cwd=cwd, local_required=scope == "local"
+    )
 
 
 def list_skills(scope: Scope | None = None, *, cwd: Path | None = None) -> EngineResult:
     args = ["list"]
     if scope:
         args.extend(["--scope", scope])
-    return run_engine(args, cwd=cwd)
+    return run_engine(args, cwd=cwd, local_required=scope == "local")
 
 
 def sync(scope: Scope, *, cwd: Path | None = None) -> EngineResult:
-    return run_engine(["sync", "--scope", scope], cwd=cwd)
+    return run_engine(["sync", "--scope", scope], cwd=cwd, local_required=scope == "local")
 
 
 def update(scope: Scope, skill_id: str | None = None, *, cwd: Path | None = None) -> EngineResult:
@@ -174,11 +217,11 @@ def update(scope: Scope, skill_id: str | None = None, *, cwd: Path | None = None
     if skill_id:
         args.append(skill_id)
     args.extend(["--scope", scope])
-    return run_engine(args, cwd=cwd)
+    return run_engine(args, cwd=cwd, local_required=scope == "local")
 
 
 def resolve(scope: Scope | None = None, *, cwd: Path | None = None) -> EngineResult:
     args = ["resolve"]
     if scope:
         args.extend(["--scope", scope])
-    return run_engine(args, cwd=cwd)
+    return run_engine(args, cwd=cwd, local_required=scope == "local")

--- a/src/vibepod/core/skills_engine.py
+++ b/src/vibepod/core/skills_engine.py
@@ -1,0 +1,180 @@
+"""Driver that calls the vibepod-skills-engine container."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from vibepod.constants import (
+    PROJECT_SKILLS_DIR,
+    SKILLS_CACHE_DIR,
+    SKILLS_ENGINE_IMAGE,
+    USER_SKILLS_DIR,
+)
+
+Scope = Literal["local", "user"]
+
+
+class SkillsEngineError(RuntimeError):
+    """Raised when the skills engine container exits non-zero or output is malformed."""
+
+
+@dataclass(frozen=True)
+class EngineResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    data: Any | None  # parsed --json payload, when present
+
+
+def detect_scope_default(cwd: Path | None = None) -> Scope:
+    """Local when invoked from inside a `.vibepod` project, else user."""
+    here = Path(cwd or Path.cwd()).resolve()
+    for parent in [here, *here.parents]:
+        if (parent / ".vibepod").is_dir():
+            return "local"
+    return "user"
+
+
+def local_skills_dir(cwd: Path | None = None) -> Path:
+    here = Path(cwd or Path.cwd()).resolve()
+    for parent in [here, *here.parents]:
+        if (parent / ".vibepod").is_dir():
+            return parent / PROJECT_SKILLS_DIR
+    return here / PROJECT_SKILLS_DIR
+
+
+def user_skills_dir() -> Path:
+    return USER_SKILLS_DIR
+
+
+def cache_dir() -> Path:
+    return SKILLS_CACHE_DIR
+
+
+def _ensure_dirs(scope: Scope, cwd: Path | None = None) -> tuple[Path, Path, Path]:
+    local = local_skills_dir(cwd)
+    user = user_skills_dir()
+    cache = cache_dir()
+    # Only the relevant scope must exist, but mounting both is fine.
+    for d in (local, user, cache):
+        d.mkdir(parents=True, exist_ok=True)
+    return local, user, cache
+
+
+def _is_local_locator(locator: str) -> bool:
+    return locator.startswith("./") or locator.startswith("../") or locator.startswith("/")
+
+
+def run_engine(
+    args: list[str],
+    *,
+    json_output: bool = True,
+    cwd: Path | None = None,
+    extra_mounts: list[tuple[Path, str]] | None = None,
+) -> EngineResult:
+    """Invoke the engine container with the standard mount layout.
+
+    Returns the parsed JSON payload if ``json_output`` is True. Stderr from the
+    engine (human-readable progress) is always captured but never parsed.
+    """
+    local, user, cache = _ensure_dirs("local", cwd)
+
+    cmd: list[str] = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{local}:/vibepod/local-skills",
+        "-v",
+        f"{user}:/vibepod/user-skills",
+        "-v",
+        f"{cache}:/vibepod/cache",
+    ]
+    for host_path, container_path in extra_mounts or []:
+        cmd.extend(["-v", f"{host_path}:{container_path}"])
+
+    # Pass through trusted-source allowlist if set on host.
+    if "VIBEPOD_TRUSTED_SOURCES" in os.environ:
+        cmd.extend(["-e", f"VIBEPOD_TRUSTED_SOURCES={os.environ['VIBEPOD_TRUSTED_SOURCES']}"])
+
+    cmd.append(SKILLS_ENGINE_IMAGE)
+    if json_output:
+        cmd.append("--json")
+    cmd.extend(args)
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        raise SkillsEngineError(f"docker not found on PATH: {exc}") from exc
+
+    payload: Any | None = None
+    if json_output and proc.stdout.strip():
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise SkillsEngineError(
+                f"Engine returned non-JSON output (exit={proc.returncode}): {proc.stdout!r}"
+            ) from exc
+
+    return EngineResult(
+        exit_code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr, data=payload
+    )
+
+
+def add(
+    locator: str,
+    *,
+    scope: Scope,
+    skill_id: str | None = None,
+    link: bool = False,
+    cwd: Path | None = None,
+) -> EngineResult:
+    args = ["add", locator, "--scope", scope]
+    if skill_id:
+        args.extend(["--id", skill_id])
+    if link:
+        args.append("--link")
+
+    extra: list[tuple[Path, str]] = []
+    if _is_local_locator(locator):
+        host = Path(locator).resolve()
+        extra.append((host, "/vibepod/source-in"))
+        # Replace user-facing locator with the in-container mount path so the
+        # engine sees a bare absolute path it can read.
+        args[1] = "/vibepod/source-in"
+    return run_engine(args, cwd=cwd, extra_mounts=extra)
+
+
+def delete(skill_id: str, *, scope: Scope, cwd: Path | None = None) -> EngineResult:
+    return run_engine(["delete", skill_id, "--scope", scope], cwd=cwd)
+
+
+def list_skills(scope: Scope | None = None, *, cwd: Path | None = None) -> EngineResult:
+    args = ["list"]
+    if scope:
+        args.extend(["--scope", scope])
+    return run_engine(args, cwd=cwd)
+
+
+def sync(scope: Scope, *, cwd: Path | None = None) -> EngineResult:
+    return run_engine(["sync", "--scope", scope], cwd=cwd)
+
+
+def update(scope: Scope, skill_id: str | None = None, *, cwd: Path | None = None) -> EngineResult:
+    args = ["update"]
+    if skill_id:
+        args.append(skill_id)
+    args.extend(["--scope", scope])
+    return run_engine(args, cwd=cwd)
+
+
+def resolve(scope: Scope | None = None, *, cwd: Path | None = None) -> EngineResult:
+    args = ["resolve"]
+    if scope:
+        args.extend(["--scope", scope])
+    return run_engine(args, cwd=cwd)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from typer.testing import CliRunner
 from vibepod.cli import app
 from vibepod.commands import run as run_cmd
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
+from vibepod.core import skills_engine
 from vibepod.core.docker import DockerClientError, DockerManager
 
 # ---------------------------------------------------------------------------
@@ -49,6 +51,22 @@ def test_agent_extra_volumes_for_copilot(tmp_path: Path) -> None:
         (str(config_host), "/home/node/.copilot", "rw"),
         (str(config_host), "/home/coder/.copilot", "rw"),
     ]
+
+
+def test_skills_mounts_for_agent_ignores_malformed_lockfiles(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    local_root = tmp_path / "local-skills"
+    user_root = tmp_path / "user-skills"
+    local_root.mkdir()
+    user_root.mkdir()
+    (local_root / "skills-lock.json").write_text(json.dumps({"skills": []}), encoding="utf-8")
+    (user_root / "skills-lock.json").write_text(json.dumps([]), encoding="utf-8")
+
+    monkeypatch.setattr(skills_engine, "local_skills_dir", lambda workspace: local_root)
+    monkeypatch.setattr(skills_engine, "user_skills_dir", lambda: user_root)
+
+    assert run_cmd._skills_mounts_for_agent("codex", tmp_path) == []
 
 
 def test_run_agent_supports_duplicate_host_mounts(tmp_path: Path) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -87,6 +87,13 @@ def test_skills_mounts_for_agent_requires_skill_directories_under_scope_root(
             {
                 "skills": {
                     "valid": {"path": "installed/valid"},
+                    "valid-name_2": {"path": "installed/valid"},
+                    "bad.name": {"path": "installed/valid"},
+                    "Upper": {"path": "installed/valid"},
+                    "../config": {"path": "installed/valid"},
+                    "nested/name": {"path": "installed/valid"},
+                    "nested\\name": {"path": "installed/valid"},
+                    "bad..name": {"path": "installed/valid"},
                     "traversal": {"path": "../outside"},
                     "absolute": {"path": str(outside_root)},
                     "file": {"path": "installed/file-skill"},
@@ -102,7 +109,8 @@ def test_skills_mounts_for_agent_requires_skill_directories_under_scope_root(
     monkeypatch.setattr(skills_engine, "user_skills_dir", lambda: user_root)
 
     assert run_cmd._skills_mounts_for_agent("codex", tmp_path) == [
-        (str(valid_skill.resolve()), "/config/.agents/skills/valid", "ro")
+        (str(valid_skill.resolve()), "/config/.agents/skills/valid", "ro"),
+        (str(valid_skill.resolve()), "/config/.agents/skills/valid-name_2", "ro"),
     ]
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -69,6 +69,43 @@ def test_skills_mounts_for_agent_ignores_malformed_lockfiles(
     assert run_cmd._skills_mounts_for_agent("codex", tmp_path) == []
 
 
+def test_skills_mounts_for_agent_requires_skill_directories_under_scope_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    local_root = tmp_path / "local-skills"
+    user_root = tmp_path / "user-skills"
+    outside_root = tmp_path / "outside"
+    valid_skill = local_root / "installed" / "valid"
+    file_skill = local_root / "installed" / "file-skill"
+    symlink_skill = local_root / "installed" / "symlink-skill"
+    for path in (local_root, user_root, outside_root, valid_skill):
+        path.mkdir(parents=True)
+    file_skill.write_text("not a directory", encoding="utf-8")
+    symlink_skill.symlink_to(outside_root, target_is_directory=True)
+    (local_root / "skills-lock.json").write_text(
+        json.dumps(
+            {
+                "skills": {
+                    "valid": {"path": "installed/valid"},
+                    "traversal": {"path": "../outside"},
+                    "absolute": {"path": str(outside_root)},
+                    "file": {"path": "installed/file-skill"},
+                    "symlink": {"path": "installed/symlink-skill"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (user_root / "skills-lock.json").write_text(json.dumps({"skills": {}}), encoding="utf-8")
+
+    monkeypatch.setattr(skills_engine, "local_skills_dir", lambda workspace: local_root)
+    monkeypatch.setattr(skills_engine, "user_skills_dir", lambda: user_root)
+
+    assert run_cmd._skills_mounts_for_agent("codex", tmp_path) == [
+        (str(valid_skill.resolve()), "/config/.agents/skills/valid", "ro")
+    ]
+
+
 def test_run_agent_supports_duplicate_host_mounts(tmp_path: Path) -> None:
     class _FakeContainers:
         def __init__(self) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,117 @@
+"""Tests for `vp skills` — exercise the host-side driver with the engine mocked."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from vibepod.cli import app
+from vibepod.core import skills_engine
+
+runner = CliRunner()
+
+
+def _fake_result(exit_code: int = 0, data: Any | None = None, stderr: str = "") -> skills_engine.EngineResult:
+    return skills_engine.EngineResult(
+        exit_code=exit_code,
+        stdout=json.dumps(data) if data is not None else "",
+        stderr=stderr,
+        data=data,
+    )
+
+
+def test_skills_help_lists_subcommands() -> None:
+    result = runner.invoke(app, ["skills", "--help"])
+    assert result.exit_code == 0
+    for sub in ("add", "delete", "list", "sync", "update"):
+        assert sub in result.stdout
+
+
+def test_skills_add_invokes_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def fake_add(locator: str, *, scope: str, skill_id: str | None = None, link: bool = False, cwd: Path | None = None) -> skills_engine.EngineResult:
+        seen.update(locator=locator, scope=scope, skill_id=skill_id, link=link)
+        return _fake_result(
+            data=[{"command": "add", "id": "researcher", "name": "Researcher", "path": "/x"}]
+        )
+
+    monkeypatch.setattr(skills_engine, "add", fake_add)
+    result = runner.invoke(app, ["skills", "add", "./skills/researcher", "--scope", "local"])
+    assert result.exit_code == 0, result.stdout
+    assert seen["locator"] == "./skills/researcher"
+    assert seen["scope"] == "local"
+    assert seen["link"] is False
+
+
+def test_skills_list_renders_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = [
+        {
+            "command": "list",
+            "skills": [
+                {"id": "sql", "name": "SQL Helper", "version": "1.0.0", "scope": "local", "status": "active"},
+                {
+                    "id": "sql",
+                    "name": "SQL Helper",
+                    "version": "0.9.0",
+                    "scope": "user",
+                    "status": "shadowed",
+                    "shadowedBy": "local",
+                },
+            ],
+        }
+    ]
+
+    def fake_list(scope: Any = None, *, cwd: Any = None) -> skills_engine.EngineResult:
+        return _fake_result(data=data)
+
+    monkeypatch.setattr(skills_engine, "list_skills", fake_list)
+    result = runner.invoke(app, ["skills", "list"])
+    assert result.exit_code == 0
+    assert "sql" in result.stdout
+    assert "shadowed by local" in result.stdout
+
+
+def test_skills_list_json_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = [{"command": "list", "skills": []}]
+    monkeypatch.setattr(skills_engine, "list_skills", lambda scope=None, *, cwd=None: _fake_result(data=data))
+    result = runner.invoke(app, ["skills", "list", "--json"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == data
+
+
+def test_skills_delete_propagates_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_delete(skill_id: str, *, scope: str, cwd: Path | None = None) -> skills_engine.EngineResult:
+        return _fake_result(exit_code=1, stderr="not found")
+
+    monkeypatch.setattr(skills_engine, "delete", fake_delete)
+    result = runner.invoke(app, ["skills", "delete", "missing", "--scope", "local"])
+    assert result.exit_code == 1
+
+
+def test_skills_sync_invokes_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, Any] = {}
+
+    def fake_sync(scope: str, *, cwd: Path | None = None) -> skills_engine.EngineResult:
+        called["scope"] = scope
+        return _fake_result(data=[{"command": "sync", "restored": [], "unchanged": ["foo"]}])
+
+    monkeypatch.setattr(skills_engine, "sync", fake_sync)
+    result = runner.invoke(app, ["skills", "sync", "--scope", "user"])
+    assert result.exit_code == 0, result.stdout
+    assert called["scope"] == "user"
+
+
+def test_detect_scope_default_outside_project(tmp_path: Path) -> None:
+    assert skills_engine.detect_scope_default(tmp_path) == "user"
+
+
+def test_detect_scope_default_inside_project(tmp_path: Path) -> None:
+    (tmp_path / ".vibepod").mkdir()
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    assert skills_engine.detect_scope_default(sub) == "local"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -103,6 +103,39 @@ def test_skills_list_json_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
     assert json.loads(result.stdout) == data
 
 
+def test_skills_add_json_stdout_is_json_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = [{"command": "add", "id": "researcher", "name": "Researcher", "path": "/x"}]
+    monkeypatch.setattr(
+        skills_engine,
+        "add",
+        lambda locator, *, scope, skill_id=None, link=False, cwd=None: _fake_result(data=data),
+    )
+
+    result = runner.invoke(app, ["skills", "add", "./skills/researcher", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == data
+    assert "Adding" not in result.stdout
+
+
+def test_skills_json_failure_keeps_stdout_parseable_and_stderr_human(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = [{"command": "list", "skills": []}]
+    monkeypatch.setattr(
+        skills_engine,
+        "list_skills",
+        lambda scope=None, *, cwd=None: _fake_result(exit_code=2, data=data, stderr="not found"),
+    )
+
+    result = runner.invoke(app, ["skills", "list", "--json"])
+
+    assert result.exit_code == 2
+    assert json.loads(result.stdout) == data
+    assert "not found" in result.stderr
+    assert "not found" not in result.stdout
+
+
 def test_skills_delete_propagates_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_delete(
         skill_id: str, *, scope: str, cwd: Path | None = None

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -15,7 +15,9 @@ from vibepod.core import skills_engine
 runner = CliRunner()
 
 
-def _fake_result(exit_code: int = 0, data: Any | None = None, stderr: str = "") -> skills_engine.EngineResult:
+def _fake_result(
+    exit_code: int = 0, data: Any | None = None, stderr: str = ""
+) -> skills_engine.EngineResult:
     return skills_engine.EngineResult(
         exit_code=exit_code,
         stdout=json.dumps(data) if data is not None else "",
@@ -34,7 +36,14 @@ def test_skills_help_lists_subcommands() -> None:
 def test_skills_add_invokes_engine(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, Any] = {}
 
-    def fake_add(locator: str, *, scope: str, skill_id: str | None = None, link: bool = False, cwd: Path | None = None) -> skills_engine.EngineResult:
+    def fake_add(
+        locator: str,
+        *,
+        scope: str,
+        skill_id: str | None = None,
+        link: bool = False,
+        cwd: Path | None = None,
+    ) -> skills_engine.EngineResult:
         seen.update(locator=locator, scope=scope, skill_id=skill_id, link=link)
         return _fake_result(
             data=[{"command": "add", "id": "researcher", "name": "Researcher", "path": "/x"}]
@@ -53,7 +62,13 @@ def test_skills_list_renders_table(monkeypatch: pytest.MonkeyPatch) -> None:
         {
             "command": "list",
             "skills": [
-                {"id": "sql", "name": "SQL Helper", "version": "1.0.0", "scope": "local", "status": "active"},
+                {
+                    "id": "sql",
+                    "name": "SQL Helper",
+                    "version": "1.0.0",
+                    "scope": "local",
+                    "status": "active",
+                },
                 {
                     "id": "sql",
                     "name": "SQL Helper",
@@ -78,14 +93,20 @@ def test_skills_list_renders_table(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_skills_list_json_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
     data = [{"command": "list", "skills": []}]
-    monkeypatch.setattr(skills_engine, "list_skills", lambda scope=None, *, cwd=None: _fake_result(data=data))
+    monkeypatch.setattr(
+        skills_engine,
+        "list_skills",
+        lambda scope=None, *, cwd=None: _fake_result(data=data),
+    )
     result = runner.invoke(app, ["skills", "list", "--json"])
     assert result.exit_code == 0
     assert json.loads(result.stdout) == data
 
 
 def test_skills_delete_propagates_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_delete(skill_id: str, *, scope: str, cwd: Path | None = None) -> skills_engine.EngineResult:
+    def fake_delete(
+        skill_id: str, *, scope: str, cwd: Path | None = None
+    ) -> skills_engine.EngineResult:
         return _fake_result(exit_code=1, stderr="not found")
 
     monkeypatch.setattr(skills_engine, "delete", fake_delete)

--- a/tests/test_skills_engine_driver.py
+++ b/tests/test_skills_engine_driver.py
@@ -76,3 +76,33 @@ def test_run_engine_raises_on_non_json(monkeypatch: pytest.MonkeyPatch, tmp_path
 
     with pytest.raises(skills_engine.SkillsEngineError):
         skills_engine.list_skills()
+
+
+def test_add_mounts_local_locator_from_cwd_read_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cwd = tmp_path / "project"
+    process_cwd = tmp_path / "process-cwd"
+    source = cwd / "skills" / "researcher"
+    source.mkdir(parents=True)
+    process_cwd.mkdir()
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+    monkeypatch.chdir(process_cwd)
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    skills_engine.add("./skills/researcher", scope="local", cwd=cwd)
+
+    cmd = captured["cmd"]
+    mount_args = [arg for i, arg in enumerate(cmd) if cmd[i - 1] == "-v"]
+    assert f"{source.resolve()}:/vibepod/source-in:ro" in mount_args
+    assert "add" in cmd
+    assert "/vibepod/source-in" in cmd
+    assert "./skills/researcher" not in cmd
+
+
+def test_add_rejects_missing_local_locator(tmp_path: Path) -> None:
+    with pytest.raises(skills_engine.SkillsEngineError, match="Local skill locator not found"):
+        skills_engine.add("./missing", scope="user", cwd=tmp_path)

--- a/tests/test_skills_engine_driver.py
+++ b/tests/test_skills_engine_driver.py
@@ -24,7 +24,9 @@ def _fake_run_factory(stdout: str = "", exit_code: int = 0) -> Any:
     return fake_run, captured
 
 
-def test_run_engine_builds_expected_docker_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_run_engine_builds_expected_docker_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
     monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
     monkeypatch.setattr(skills_engine, "SKILLS_ENGINE_IMAGE", "vibepod/skills-engine:test")
@@ -48,7 +50,9 @@ def test_run_engine_builds_expected_docker_command(monkeypatch: pytest.MonkeyPat
     assert any("/vibepod/cache" in m for m in mount_args)
 
 
-def test_run_engine_propagates_trusted_sources_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_run_engine_propagates_trusted_sources_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
     monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
     monkeypatch.setenv("VIBEPOD_TRUSTED_SOURCES", "github:vibepod/")

--- a/tests/test_skills_engine_driver.py
+++ b/tests/test_skills_engine_driver.py
@@ -45,9 +45,30 @@ def test_run_engine_builds_expected_docker_command(
     assert "list" in cmd
     # all three mount sources are present
     mount_args = [arg for i, arg in enumerate(cmd) if cmd[i - 1] == "-v"]
-    assert any("/vibepod/local-skills" in m for m in mount_args)
+    empty_local = tmp_path / "cache" / "empty-local-skills"
+    assert f"{empty_local}:/vibepod/local-skills" in mount_args
     assert any("/vibepod/user-skills" in m for m in mount_args)
     assert any("/vibepod/cache" in m for m in mount_args)
+    assert not (tmp_path / ".vibepod").exists()
+
+
+def test_run_engine_explicit_local_scope_creates_local_skills_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    skills_engine.list_skills("local", cwd=tmp_path)
+
+    local = tmp_path / ".vibepod" / "skills"
+    mount_args = [
+        arg for i, arg in enumerate(captured["cmd"]) if captured["cmd"][i - 1] == "-v"
+    ]
+    assert local.is_dir()
+    assert f"{local}:/vibepod/local-skills" in mount_args
 
 
 def test_run_engine_propagates_trusted_sources_env(
@@ -97,10 +118,31 @@ def test_add_mounts_local_locator_from_cwd_read_only(
 
     cmd = captured["cmd"]
     mount_args = [arg for i, arg in enumerate(cmd) if cmd[i - 1] == "-v"]
-    assert f"{source.resolve()}:/vibepod/source-in:ro" in mount_args
+    assert f"{source.resolve()}:{source.resolve()}:ro" in mount_args
     assert "add" in cmd
-    assert "/vibepod/source-in" in cmd
-    assert "./skills/researcher" not in cmd
+    assert "-w" in cmd
+    assert str(cwd.resolve()) in cmd
+    assert "./skills/researcher" in cmd
+    assert "/vibepod/source-in" not in cmd
+
+
+def test_add_accepts_github_tree_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    url = (
+        "https://github.com/alirezarezvani/claude-skills/tree/main/"
+        "product-team/skills/spec-to-repo"
+    )
+    skills_engine.add(url, scope="user", cwd=tmp_path)
+
+    cmd = captured["cmd"]
+    expected = "github:alirezarezvani/claude-skills//product-team/skills/spec-to-repo#main"
+    assert expected in cmd
+    assert url not in cmd
 
 
 def test_add_rejects_missing_local_locator(tmp_path: Path) -> None:

--- a/tests/test_skills_engine_driver.py
+++ b/tests/test_skills_engine_driver.py
@@ -1,0 +1,74 @@
+"""Driver-level tests: ensure run_engine emits the right docker invocation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vibepod.core import skills_engine
+
+
+def _fake_run_factory(stdout: str = "", exit_code: int = 0) -> Any:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=exit_code, stdout=stdout, stderr="")
+
+    return fake_run, captured
+
+
+def test_run_engine_builds_expected_docker_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(skills_engine, "SKILLS_ENGINE_IMAGE", "vibepod/skills-engine:test")
+    monkeypatch.chdir(tmp_path)
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([{"command": "list", "skills": []}]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = skills_engine.list_skills()
+
+    assert result.exit_code == 0
+    cmd = captured["cmd"]
+    assert cmd[0:3] == ["docker", "run", "--rm"]
+    assert "vibepod/skills-engine:test" in cmd
+    assert "--json" in cmd
+    assert "list" in cmd
+    # all three mount sources are present
+    mount_args = [arg for i, arg in enumerate(cmd) if cmd[i - 1] == "-v"]
+    assert any("/vibepod/local-skills" in m for m in mount_args)
+    assert any("/vibepod/user-skills" in m for m in mount_args)
+    assert any("/vibepod/cache" in m for m in mount_args)
+
+
+def test_run_engine_propagates_trusted_sources_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setenv("VIBEPOD_TRUSTED_SOURCES", "github:vibepod/")
+    monkeypatch.chdir(tmp_path)
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    skills_engine.list_skills()
+    flat = " ".join(captured["cmd"])
+    assert "VIBEPOD_TRUSTED_SOURCES=github:vibepod/" in flat
+
+
+def test_run_engine_raises_on_non_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+    monkeypatch.chdir(tmp_path)
+
+    fake_run, _ = _fake_run_factory(stdout="not json at all")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(skills_engine.SkillsEngineError):
+        skills_engine.list_skills()


### PR DESCRIPTION
This pull request introduces first-class support for "skills"—reusable prompt recipes that can be installed, managed, and mounted into agents—across the VibePod CLI, documentation, and configuration. It adds a new `vp skills` subcommand, integrates skill mounting into agent containers (starting with Claude), and provides comprehensive documentation for authoring, installing, and managing skills. Configuration options for the skills engine image are also added.

**Skills feature and CLI integration:**

- Added a new `vp skills` command group with subcommands (`add`, `delete`, `list`, `sync`, `update`) to manage skills, backed by a skills engine container. This includes user-friendly output, JSON support, scope handling, and bundle install logic. (`src/vibepod/cli.py` [[1]](diffhunk://#diff-ea9b03cdb63ede14d6783c6b6e806b11ce72cc4f1347e5741bee6dfe5e5a6188L10-R21) [[2]](diffhunk://#diff-ea9b03cdb63ede14d6783c6b6e806b11ce72cc4f1347e5741bee6dfe5e5a6188R44); `src/vibepod/commands/skills.py` [[3]](diffhunk://#diff-643b9874cbd8238e808d59db7dc1bb63edf5b024ff6041d74510be4bfa70ed79R1-R196)

- Implemented logic to discover, merge, and mount installed skills into agent containers (currently for Claude), ensuring skills from both user and project scopes are available at runtime. (`src/vibepod/commands/run.py` [[1]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaR168-R223) [[2]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaR505-R506)

**Configuration and environment:**

- Introduced the `VP_SKILLS_ENGINE_IMAGE` environment variable to override the skills engine container image, with updates to configuration docs and code to support it. (`src/vibepod/constants.py` [[1]](diffhunk://#diff-cc108532588326dbd91ffbb0582d36d11b0f6d995cf506b66c690cc760e182a2R56-R74) [[2]](diffhunk://#diff-cc108532588326dbd91ffbb0582d36d11b0f6d995cf506b66c690cc760e182a2R111-R114); `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R143); `docs/configuration.md` [[4]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R143)

**Documentation:**

- Added comprehensive documentation for the skills system, including an overview, locator formats (github, gitlab, npm, local), authoring guide, and usage examples. Navigation is updated to include these docs. (`docs/skills/index.md` [[1]](diffhunk://#diff-355148627439c2d94fc0a78e6cdb78e4e590228da98508a642cd06712a3cf0a7R1-R45) `docs/skills/locators.md` [[2]](diffhunk://#diff-91d62f067b3530ce362e4962d80a2aeb5e4a905a59d73d6fdea25b7cb4491deeR1-R99) `docs/skills/authoring.md` [[3]](diffhunk://#diff-bc77376e6ed1b88baeaeeac1f17582645ab2e42e39acd46071936793038f52c9R1-R59) `mkdocs.yml` [[4]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R55-R58)

**User experience and discoverability:**

- Updated the project README to advertise skills as a first-class feature, including a new highlight and example usage. (`README.md` [README.mdR25](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25))

---

**Skills feature and CLI integration**
- Added `vp skills` subcommand with full CRUD and sync/update functionality, supporting both project-local and user-global scopes, with bundle install and shadowing logic. [[1]](diffhunk://#diff-ea9b03cdb63ede14d6783c6b6e806b11ce72cc4f1347e5741bee6dfe5e5a6188L10-R21) [[2]](diffhunk://#diff-ea9b03cdb63ede14d6783c6b6e806b11ce72cc4f1347e5741bee6dfe5e5a6188R44) [[3]](diffhunk://#diff-643b9874cbd8238e808d59db7dc1bb63edf5b024ff6041d74510be4bfa70ed79R1-R196)
- Skills are now automatically mounted into supported agent containers (starting with Claude) at runtime, merging local and user skill installs. [[1]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaR168-R223) [[2]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaR505-R506)

**Configuration and environment**
- Added `VP_SKILLS_ENGINE_IMAGE` environment variable and associated logic to override the skills engine container image; documented in both code and configuration docs. [[1]](diffhunk://#diff-cc108532588326dbd91ffbb0582d36d11b0f6d995cf506b66c690cc760e182a2R56-R74) [[2]](diffhunk://#diff-cc108532588326dbd91ffbb0582d36d11b0f6d995cf506b66c690cc760e182a2R111-R114) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R143) [[4]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R143)

**Documentation**
- Created new documentation sections: skills overview, locator format reference, and authoring guide, and linked them in the navigation. [[1]](diffhunk://#diff-355148627439c2d94fc0a78e6cdb78e4e590228da98508a642cd06712a3cf0a7R1-R45) [[2]](diffhunk://#diff-91d62f067b3530ce362e4962d80a2aeb5e4a905a59d73d6fdea25b7cb4491deeR1-R99) [[3]](diffhunk://#diff-bc77376e6ed1b88baeaeeac1f17582645ab2e42e39acd46071936793038f52c9R1-R59) [[4]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R55-R58)

**User experience and discoverability**
- Updated README to highlight skills as a feature and provide usage examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `vp skills` command suite (add, delete, list, sync, update) with local/user scopes.
  * Installed skills are auto-mounted into agent containers at runtime.
  * Configurable skills-engine image via VP_SKILLS_ENGINE_IMAGE environment variable.

* **Documentation**
  * New comprehensive Skills docs: overview, locator format, authoring, install/publishing, and config.
  * README and site navigation updated to surface Skills and example commands.

* **Tests**
  * Added CLI, driver, and run tests covering skills commands, engine interactions, and mount behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VibePod/vibepod-cli/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->