### PR TITLE
Fix I/O error on exit by closing urlopen response (#72)

### DIFF
--- a/src/vibepod/commands/logs.py
+++ b/src/vibepod/commands/logs.py
@@ -28,7 +28,8 @@ def _wait_for_datasette(port: int) -> bool:
     deadline = time.monotonic() + _HEALTH_TIMEOUT
     while time.monotonic() < deadline:
         try:
-            urllib.request.urlopen(url, timeout=2)  # noqa: S310
+            with urllib.request.urlopen(url, timeout=2) as _resp:  # noqa: S310
+                pass
             return True
         except urllib.error.HTTPError:
             return True  # server responded — healthy enough


### PR DESCRIPTION
This pull request makes a minor improvement to the `_wait_for_datasette` function in `src/vibepod/commands/logs.py` by ensuring that the HTTP response object is properly closed after opening the URL.

- Resource management improvement:
  * Changed to use a `with` statement when opening the URL in `_wait_for_datasette`, ensuring the response object is properly closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and resource management for internal health-check probes to ensure proper cleanup of resources during background monitoring operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VibePod/vibepod-cli/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->