### PR TITLE
Handle Docker client close errors

### DIFF
--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -9,7 +9,9 @@ import signal
 import sys
 import termios
 import tty
+import weakref
 from pathlib import Path
+from types import TracebackType
 from typing import Any
 from uuid import uuid4
 
@@ -41,6 +43,94 @@ class DockerClientError(RuntimeError):
     """Raised for Docker availability or lifecycle errors."""
 
 
+def _close_docker_client(client: Any | None) -> None:
+    close = getattr(client, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            pass
+
+
+def _discard_response_file_pointer(response: Any | None) -> None:
+    raw = getattr(response, "raw", response)
+    for candidate in (raw, response):
+        if candidate is None or not hasattr(candidate, "_fp"):
+            continue
+        try:
+            candidate._fp = None
+        except Exception:
+            pass
+
+
+def _close_response(response: Any | None) -> None:
+    close_response = getattr(response, "close", None)
+    if callable(close_response):
+        try:
+            close_response()
+        except Exception:
+            pass
+    _discard_response_file_pointer(response)
+
+
+def _docker_stream_response(stream: Any) -> Any | None:
+    response = getattr(stream, "_response", None)
+    if response is not None:
+        return response
+
+    frame = getattr(stream, "gi_frame", None)
+    if frame is None:
+        return None
+    return frame.f_locals.get("response")
+
+
+def _consume_docker_stream(stream: Any) -> None:
+    response = _docker_stream_response(stream)
+    try:
+        for _ in stream:
+            pass
+    finally:
+        close_stream = getattr(stream, "close", None)
+        if callable(close_stream):
+            try:
+                close_stream()
+            except Exception:
+                pass
+        _close_response(response)
+
+
+def _close_attach_resources(sock_wrapper: Any | None, response: Any | None) -> None:
+    _close_response(response)
+    close_socket = getattr(sock_wrapper, "close", None)
+    if callable(close_socket):
+        try:
+            close_socket()
+        except Exception:
+            pass
+
+
+def _attach_socket_with_response(
+    api: Any,
+    container_id: str,
+    params: dict[str, Any],
+) -> tuple[Any, Any]:
+    request_params = dict(params)
+    general_configs = getattr(api, "_general_configs", {}) or {}
+    if "detachKeys" not in request_params and "detachKeys" in general_configs:
+        request_params["detachKeys"] = general_configs["detachKeys"]
+
+    headers = {"Connection": "Upgrade", "Upgrade": "tcp"}
+    url = api._url("/containers/{0}/attach", container_id)
+    response = api.post(
+        url,
+        None,
+        params=api._attach_params(request_params),
+        stream=True,
+        headers=headers,
+    )
+    return api._get_raw_response_socket(response), response
+
+
 def _is_latest_tag(image: str) -> bool:
     """Return True when *image* uses the ``latest`` tag (explicitly or by omission)."""
     name = image.split("/")[-1]
@@ -66,13 +156,41 @@ class DockerManager:
             raise DockerClientError("Docker SDK not installed")
         try:
             self.client = docker.from_env()
+            self._client_finalizer = weakref.finalize(
+                self,
+                _close_docker_client,
+                self.client,
+            )
             self.client.ping()
         except DockerException as exc:
+            self.close()
             raise DockerClientError(f"Docker is not available: {exc}") from exc
+
+    def __enter__(self) -> DockerManager:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, traceback
+        self.close()
+
+    def close(self) -> None:
+        finalizer = getattr(self, "_client_finalizer", None)
+        if finalizer is not None:
+            try:
+                finalizer()
+            except Exception:
+                pass
+            return
+        _close_docker_client(getattr(self, "client", None))
 
     def pull_image(self, image: str) -> None:
         try:
-            self.client.images.pull(image)
+            _consume_docker_stream(self.client.api.pull(image, stream=True))
         except APIError as exc:
             raise DockerClientError(f"Failed to pull image {image}: {exc}") from exc
 
@@ -90,7 +208,7 @@ class DockerManager:
             except NotFound:
                 old_id = None
 
-            self.client.images.pull(image)
+            _consume_docker_stream(self.client.api.pull(image, stream=True))
 
             try:
                 new_id = self.client.images.get(image).id
@@ -394,9 +512,10 @@ class DockerManager:
                 pass
 
         try:
-            sock_wrapper = self.client.api.attach_socket(
+            sock_wrapper, response = _attach_socket_with_response(
+                self.client.api,
                 container.id,
-                params={
+                {
                     "stdin": 1,
                     "stdout": 1,
                     "stderr": 1,
@@ -448,10 +567,7 @@ class DockerManager:
                         logger.log_input(user_data)
                     sock.sendall(user_data)
         finally:
-            try:
-                sock_wrapper.close()
-            except Exception:
-                pass
+            _close_attach_resources(sock_wrapper, response)
             if old_winch_handler is not None:
                 signal.signal(signal.SIGWINCH, old_winch_handler)
             if stdin_fd is not None and old_tty is not None:

--- a/tests/test_docker_manager.py
+++ b/tests/test_docker_manager.py
@@ -1,0 +1,211 @@
+"""Docker manager lifecycle tests."""
+
+from __future__ import annotations
+
+import weakref
+
+import pytest
+
+from vibepod.core import docker as docker_mod
+from vibepod.core.docker import DockerClientError, DockerManager
+
+
+class _FakeClient:
+    def __init__(self, *, fail_ping: bool = False, fail_close: bool = False) -> None:
+        self.close_calls = 0
+        self.fail_close = fail_close
+        self.fail_ping = fail_ping
+
+    def ping(self) -> None:
+        if self.fail_ping:
+            raise RuntimeError("docker unavailable")
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.fail_close:
+            raise ValueError("I/O operation on closed file.")
+
+
+def test_close_closes_docker_client_once() -> None:
+    client = _FakeClient()
+    manager = object.__new__(DockerManager)
+    manager.client = client
+    manager._client_finalizer = weakref.finalize(manager, client.close)  # type: ignore[attr-defined]
+
+    manager.close()
+    manager.close()
+
+    assert client.close_calls == 1
+
+
+def test_init_closes_client_when_ping_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeClient(fail_ping=True)
+
+    class _FakeDockerModule:
+        def from_env(self) -> _FakeClient:
+            return client
+
+    monkeypatch.setattr(docker_mod, "docker", _FakeDockerModule())
+    monkeypatch.setattr(docker_mod, "DockerException", RuntimeError)
+
+    with pytest.raises(DockerClientError):
+        DockerManager()
+
+    assert client.close_calls == 1
+
+
+def test_close_suppresses_docker_client_cleanup_errors() -> None:
+    client = _FakeClient(fail_close=True)
+    manager = object.__new__(DockerManager)
+    manager.client = client
+    manager._client_finalizer = weakref.finalize(manager, client.close)  # type: ignore[attr-defined]
+
+    manager.close()
+
+    assert client.close_calls == 1
+
+
+def test_consume_docker_stream_closes_generator_response() -> None:
+    class _Response:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    response = _Response()
+
+    def _stream(response: _Response = response):
+        yield "layer 1"
+        yield "layer 2"
+
+    stream = _stream()
+
+    docker_mod._consume_docker_stream(stream)
+
+    assert response.close_calls == 1
+    assert list(stream) == []
+
+
+def test_pull_image_consumes_and_closes_low_level_stream() -> None:
+    class _Response:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    response = _Response()
+
+    def _stream(response: _Response = response):
+        yield {"status": "Pulling"}
+        yield {"status": "Done"}
+
+    stream = _stream()
+
+    class _API:
+        def __init__(self) -> None:
+            self.pull_kwargs: dict[str, object] = {}
+
+        def pull(self, image: str, **kwargs: object):
+            self.pull_kwargs = {"image": image, **kwargs}
+            return stream
+
+    class _Client:
+        def __init__(self) -> None:
+            self.api = _API()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _Client()
+
+    manager.pull_image("vibepod/copilot:latest")
+
+    assert manager.client.api.pull_kwargs == {
+        "image": "vibepod/copilot:latest",
+        "stream": True,
+    }
+    assert response.close_calls == 1
+
+
+def test_attach_socket_with_response_retains_streaming_response() -> None:
+    class _FakeAPI:
+        def __init__(self) -> None:
+            self._general_configs = {"detachKeys": "ctrl-p,ctrl-q"}
+            self.response = object()
+            self.socket = object()
+            self.post_kwargs: dict[str, object] = {}
+            self.attach_params: dict[str, object] = {}
+
+        def _url(self, pathfmt: str, container_id: str) -> str:
+            return pathfmt.format(container_id)
+
+        def _attach_params(self, params: dict[str, object]) -> dict[str, object]:
+            self.attach_params = params
+            return params
+
+        def post(self, url: str, data: object, **kwargs: object) -> object:
+            self.post_kwargs = {"url": url, "data": data, **kwargs}
+            return self.response
+
+        def _get_raw_response_socket(self, response: object) -> object:
+            assert response is self.response
+            return self.socket
+
+    api = _FakeAPI()
+
+    sock, response = docker_mod._attach_socket_with_response(
+        api,
+        "abc123",
+        {"stdin": 1, "stdout": 1, "stderr": 1, "stream": 1, "logs": 1},
+    )
+
+    assert sock is api.socket
+    assert response is api.response
+    assert api.attach_params["detachKeys"] == "ctrl-p,ctrl-q"
+    assert api.post_kwargs["url"] == "/containers/abc123/attach"
+    assert api.post_kwargs["data"] is None
+    assert api.post_kwargs["stream"] is True
+    assert api.post_kwargs["headers"] == {"Connection": "Upgrade", "Upgrade": "tcp"}
+
+
+def test_close_attach_resources_closes_response_before_socket() -> None:
+    calls: list[str] = []
+
+    class _Response:
+        def close(self) -> None:
+            calls.append("response")
+
+    class _Socket:
+        def close(self) -> None:
+            calls.append("socket")
+
+    docker_mod._close_attach_resources(_Socket(), _Response())
+
+    assert calls == ["response", "socket"]
+
+
+def test_close_attach_resources_suppresses_closed_file_response_errors() -> None:
+    class _Raw:
+        def __init__(self) -> None:
+            self._fp = object()
+
+    class _Response:
+        def __init__(self) -> None:
+            self.raw = _Raw()
+
+        def close(self) -> None:
+            raise ValueError("I/O operation on closed file.")
+
+    class _Socket:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = _Response()
+    socket = _Socket()
+
+    docker_mod._close_attach_resources(socket, response)
+
+    assert response.raw._fp is None
+    assert socket.closed is True


### PR DESCRIPTION
This pull request improves the resource management and test coverage for the `DockerManager` class, ensuring Docker client connections are properly closed and making the class easier to use with context managers. The changes also add tests to verify that client lifecycle management works as expected.

**Resource management improvements:**

* Added a `close` method and a `weakref.finalize`-based finalizer to `DockerManager` to ensure the Docker client is closed exactly once, even if initialization fails. (`src/vibepod/core/docker.py`) [[1]](diffhunk://#diff-261077742cc6453cbf6e8cfcde31fa96d63c26f5e30af5569232276b3b0b99acR12-R14) [[2]](diffhunk://#diff-261077742cc6453cbf6e8cfcde31fa96d63c26f5e30af5569232276b3b0b99acR46-R51) [[3]](diffhunk://#diff-261077742cc6453cbf6e8cfcde31fa96d63c26f5e30af5569232276b3b0b99acR77-R105)
* Implemented context manager support (`__enter__` and `__exit__`) for `DockerManager`, so it can be used with the `with` statement for automatic cleanup. (`src/vibepod/core/docker.py`)

**Testing improvements:**

* Added `tests/test_docker_manager.py` with tests to verify that the Docker client is closed only once and that failed initialization also closes the client.