### PR TITLE
Add Pi agent to CLI

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -13,6 +13,7 @@ VibePod manages each agent as a Docker container. Credentials and config are per
 | `auggie` | Augment Code | `vp a` | `vibepod/auggie:latest` |
 | `copilot` | GitHub | `vp p` | `vibepod/copilot:latest` |
 | `codex` | OpenAI | `vp x` | `vibepod/codex:latest` |
+| `pi` | Earendil | `vp pi` | `vibepod/pi:latest` |
 
 Alias note: `vp run vibe` resolves to `vp run devstral`.
 
@@ -73,7 +74,7 @@ agents:
 
 ## Image customization workflows
 
-VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`). The CLI also supports the alias `vibe`, which resolves to `devstral`. Image customization means changing the image used for one of those IDs.
+VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`). The CLI also supports the alias `vibe`, which resolves to `devstral`. Image customization means changing the image used for one of those IDs.
 
 ### 1. Extend an existing image for an agent
 
@@ -197,6 +198,7 @@ Use `--ikwid` to enable each agent's built-in auto-approval / permission-skip mo
 | `codex` | `--dangerously-bypass-approvals-and-sandbox` |
 | `opencode` | Not supported |
 | `auggie` | Not supported |
+| `pi` | Not supported |
 
 Example:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,13 @@ agents:
     volumes: []
     init: []
 
+  pi:
+    enabled: true
+    image: vibepod/pi:latest
+    env: {}
+    volumes: []
+    init: []
+
 # Connect agents to a local or remote LLM server (Ollama, vLLM, etc.)
 llm:
   enabled: false
@@ -138,6 +145,7 @@ Each agent image can be overridden individually:
 | `VP_IMAGE_AUGGIE` | auggie |
 | `VP_IMAGE_COPILOT` | copilot |
 | `VP_IMAGE_CODEX` | codex |
+| `VP_IMAGE_PI` | pi |
 | `VP_DATASETTE_IMAGE` | datasette (logs UI) |
 | `VP_PROXY_IMAGE` | proxy |
 | `VP_SKILLS_ENGINE_IMAGE` | skills-engine (used by `vp skills`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker 
 | `auggie` | Augment Code | `vp a` |
 | `copilot` | GitHub | `vp p` |
 | `codex` | OpenAI | `vp x` |
+| `pi` | Earendil | `vp pi` |
 
 ## Next Steps
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,7 +40,8 @@ Press **Ctrl+C** to stop the container when you are done.
 
 ## Shortcuts
 
-You can start agents with either the full name or a single-letter shortcut:
+You can start agents with the full agent command. Most agents also have a single-letter
+shortcut; Pi uses `vp pi` because `vp p` is assigned to Copilot.
 
 ```bash
 vp claude   # full name

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -134,7 +134,7 @@ Current SKILL.md auto-discovery support:
 | `codex` | `/config/.agents/skills/<id>` |
 | `opencode` | `/config/.agents/skills/<id>` |
 | `auggie` | `/config/.agents/skills/<id>` |
-| `pi` | `/config/.agents/skills/<id>` |
+| `pi` | `/config/.pi/agent/skills/<id>` |
 
 Other agents can still run normally, but VibePod does not currently mount
 SKILL.md folders into an auto-discovery location for them.

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -134,6 +134,7 @@ Current SKILL.md auto-discovery support:
 | `codex` | `/config/.agents/skills/<id>` |
 | `opencode` | `/config/.agents/skills/<id>` |
 | `auggie` | `/config/.agents/skills/<id>` |
+| `pi` | `/config/.agents/skills/<id>` |
 
 Other agents can still run normally, but VibePod does not currently mount
 SKILL.md folders into an auto-discovery location for them.

--- a/src/vibepod/cli.py
+++ b/src/vibepod/cli.py
@@ -28,10 +28,64 @@ app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 
+
+def _context_args(ctx: typer.Context) -> list[str]:
+    return list(ctx.args) if ctx.args else []
+
+
+def run_command(
+    ctx: typer.Context,
+    agent: Annotated[str | None, typer.Argument(help="Agent to run")] = None,
+    workspace: Annotated[
+        Path, typer.Option("-w", "--workspace", help="Workspace directory")
+    ] = Path("."),
+    pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    detach: Annotated[
+        bool, typer.Option("-d", "--detach", help="Run container in background")
+    ] = False,
+    env: Annotated[
+        list[str] | None,
+        typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
+    ] = None,
+    name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
+    network: Annotated[
+        str | None,
+        typer.Option("--network", help="Additional Docker network to connect the container to"),
+    ] = None,
+    paste_images: Annotated[
+        bool,
+        typer.Option(
+            "--paste-images",
+            help="Enable image pasting via X11 clipboard (requires DISPLAY to be set)",
+        ),
+    ] = False,
+    ikwid: Annotated[
+        bool,
+        typer.Option(
+            "--ikwid",
+            help="I Know What I'm Doing: enable auto-approval / skip permission prompts",
+        ),
+    ] = False,
+) -> None:
+    """Start an agent container."""
+    run.run(
+        agent=agent,
+        workspace=workspace,
+        pull=pull,
+        detach=detach,
+        env=env,
+        name=name,
+        network=network,
+        paste_images=paste_images,
+        ikwid=ikwid,
+        passthrough_args=_context_args(ctx),
+    )
+
+
 app.command(
     name="run",
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
-)(run.run)
+)(run_command)
 app.command(name="stop")(stop.stop)
 app.command(name="attach")(attach.attach)
 app.command(name="list")(list_cmd.list_agents)
@@ -46,6 +100,7 @@ app.add_typer(skills.app, name="skills")
 
 def _register_run_alias(command_name: str, agent_name: str) -> None:
     def _alias(
+        ctx: typer.Context,
         workspace: Annotated[
             Path, typer.Option("-w", "--workspace", help="Workspace directory")
         ] = Path("."),
@@ -94,6 +149,7 @@ def _register_run_alias(command_name: str, agent_name: str) -> None:
             network=network,
             paste_images=paste_images,
             ikwid=ikwid,
+            passthrough_args=_context_args(ctx),
         )
 
     _alias.__name__ = f"alias_{command_name}"

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -178,10 +178,11 @@ def _agent_skill_paths(agent: str) -> list[str]:
     All paths assume the in-container HOME or CONFIG_DIR conventions wired by
     vibepod-agents entrypoints. The SKILL.md format (Anthropic spec — frontmatter
     `name` + `description` + markdown body) is shared verbatim across claude,
-    codex, opencode, and auggie. They differ only in which directory they scan.
+    codex, pi, opencode, and auggie. They differ only in which directory they scan.
 
       - claude   reads $CLAUDE_CONFIG_DIR/skills/   → /claude/skills/
       - codex    reads ~/.agents/skills/            → /config/.agents/skills/
+      - pi       reads ~/.agents/skills/            → /config/.agents/skills/
       - opencode reads ~/.agents/skills/ (also ~/.claude/skills/, ~/.config/opencode/skills/)
       - auggie   reads ~/.agents/skills/ (also ~/.augment/skills/, ~/.claude/skills/)
 
@@ -191,7 +192,7 @@ def _agent_skill_paths(agent: str) -> list[str]:
     """
     if agent == "claude":
         return ["/claude/skills"]
-    if agent in ("codex", "opencode", "auggie"):
+    if agent in ("codex", "opencode", "auggie", "pi"):
         return ["/config/.agents/skills"]
     return []
 

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -11,7 +11,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any
 
-import click
 import typer
 from rich.prompt import Confirm, Prompt
 
@@ -376,6 +375,7 @@ def run(
             help="I Know What I'm Doing: enable auto-approval / skip permission prompts",
         ),
     ] = False,
+    passthrough_args: list[str] | None = None,
 ) -> None:
     """Start an agent container.
 
@@ -383,10 +383,7 @@ def run(
     command inside the container. Use `--` before agent flags when they could
     be parsed as VibePod flags.
     """
-    click_ctx = click.get_current_context(silent=True)
-    passthrough_args: list[str] = (
-        list(click_ctx.args) if click_ctx is not None and click_ctx.args else []
-    )
+    passthrough_args = passthrough_args or []
     config = get_config()
     selected_agent_input = agent or str(config.get("default_agent", "claude"))
     selected_agent = resolve_agent_name(selected_agent_input)

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -181,7 +181,7 @@ def _agent_skill_paths(agent: str) -> list[str]:
 
       - claude   reads $CLAUDE_CONFIG_DIR/skills/   → /claude/skills/
       - codex    reads ~/.agents/skills/            → /config/.agents/skills/
-      - pi       reads ~/.agents/skills/            → /config/.agents/skills/
+      - pi       reads ~/.pi/agent/skills/          → /config/.pi/agent/skills/
       - opencode reads ~/.agents/skills/ (also ~/.claude/skills/, ~/.config/opencode/skills/)
       - auggie   reads ~/.agents/skills/ (also ~/.augment/skills/, ~/.claude/skills/)
 
@@ -191,7 +191,9 @@ def _agent_skill_paths(agent: str) -> list[str]:
     """
     if agent == "claude":
         return ["/claude/skills"]
-    if agent in ("codex", "opencode", "auggie", "pi"):
+    if agent == "pi":
+        return ["/config/.pi/agent/skills"]
+    if agent in ("codex", "opencode", "auggie"):
         return ["/config/.agents/skills"]
     return []
 

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -26,6 +26,7 @@ SUPPORTED_AGENTS = (
     "auggie",
     "copilot",
     "codex",
+    "pi",
 )
 
 AGENT_SHORTCUTS: dict[str, str] = {
@@ -51,6 +52,7 @@ IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (
     "VP_IMAGE_AUGGIE",
     "VP_IMAGE_COPILOT",
     "VP_IMAGE_CODEX",
+    "VP_IMAGE_PI",
     "VP_DATASETTE_IMAGE",
     "VP_PROXY_IMAGE",
     "VP_SKILLS_ENGINE_IMAGE",
@@ -100,6 +102,9 @@ def get_default_images() -> dict[str, str]:
         ),
         "codex": os.environ.get(
             "VP_IMAGE_CODEX", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/codex:latest"
+        ),
+        "pi": os.environ.get(
+            "VP_IMAGE_PI", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/pi:latest"
         ),
         "datasette": os.environ.get(
             "VP_DATASETTE_IMAGE",

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -114,6 +114,15 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         },
         llm_model_args=["--oss", "-m"],
     ),
+    "pi": AgentSpec(
+        "pi",
+        "earendil",
+        DEFAULT_IMAGES["pi"],
+        "pi",
+        ["pi"],
+        "/config",
+        {"HOME": "/config"},
+    ),
 }
 
 _SHORTCUT_BY_AGENT = {agent: shortcut for shortcut, agent in AGENT_SHORTCUTS.items()}

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -121,7 +121,7 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         "pi",
         ["pi"],
         "/config",
-        {"HOME": "/config"},
+        {"HOME": "/config", "PI_CODING_AGENT_DIR": "/config/.pi/agent"},
     ),
 }
 

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -91,6 +91,14 @@ def _default_config() -> dict[str, Any]:
                 "volumes": [],
                 "init": [],
             },
+            "pi": {
+                "enabled": True,
+                "image": DEFAULT_IMAGES["pi"],
+                "auto_pull": None,
+                "env": {},
+                "volumes": [],
+                "init": [],
+            },
         },
         "logging": {
             "enabled": True,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -48,6 +48,7 @@ def test_pi_spec_matches_container_contract() -> None:
     assert spec.command == ["pi"]
     assert spec.config_mount_path == "/config"
     assert spec.extra_env["HOME"] == "/config"
+    assert spec.extra_env["PI_CODING_AGENT_DIR"] == "/config/.pi/agent"
 
 
 def test_get_agent_spec_unknown() -> None:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -39,6 +39,17 @@ def test_devstral_spec_matches_container_contract() -> None:
     assert spec.run_as_host_user is True
 
 
+def test_pi_spec_matches_container_contract() -> None:
+    spec = get_agent_spec("pi")
+    assert spec.id == "pi"
+    assert spec.provider == "earendil"
+    assert spec.image == "vibepod/pi:latest"
+    assert spec.config_subdir == "pi"
+    assert spec.command == ["pi"]
+    assert spec.config_mount_path == "/config"
+    assert spec.extra_env["HOME"] == "/config"
+
+
 def test_get_agent_spec_unknown() -> None:
     with pytest.raises(ValueError):
         get_agent_spec("unknown")
@@ -87,17 +98,19 @@ def test_gemini_spec_runs_via_node_wrapper() -> None:
 
 
 def test_unsupported_agents_have_no_ikwid_args() -> None:
-    for agent in ("opencode", "auggie"):
+    for agent in ("opencode", "auggie", "pi"):
         spec = get_agent_spec(agent)
         assert spec.ikwid_args is None, f"{agent} should not have ikwid_args"
 
 
 def test_get_agent_shortcut_known_agent() -> None:
     expected_by_agent = {agent: shortcut for shortcut, agent in AGENT_SHORTCUTS.items()}
-    assert set(expected_by_agent.keys()) == set(SUPPORTED_AGENTS)
-    for agent in SUPPORTED_AGENTS:
-        assert get_agent_shortcut(agent) == expected_by_agent[agent]
-        assert get_agent_shortcut(f" {agent.upper()} ") == expected_by_agent[agent]
+    assert set(expected_by_agent.keys()) == set(SUPPORTED_AGENTS) - {"pi"}
+    for agent, shortcut in expected_by_agent.items():
+        assert get_agent_shortcut(agent) == shortcut
+        assert get_agent_shortcut(f" {agent.upper()} ") == shortcut
+    assert get_agent_shortcut("pi") is None
+    assert get_agent_shortcut(" PI ") is None
     assert get_agent_shortcut("unknown") is None
 
 
@@ -125,6 +138,6 @@ def test_codex_spec_has_llm_env_map() -> None:
 
 
 def test_agents_without_llm_env_map() -> None:
-    for agent in ("gemini", "opencode", "devstral", "auggie", "copilot"):
+    for agent in ("gemini", "opencode", "devstral", "auggie", "copilot", "pi"):
         spec = get_agent_spec(agent)
         assert spec.llm_env_map is None, f"{agent} should not have llm_env_map"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,11 +26,8 @@ def test_full_agent_name_alias_runs_agent(monkeypatch) -> None:
     called: dict[str, object] = {"agent": None, "passthrough": None}
 
     def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
-        import click
-
-        ctx = click.get_current_context(silent=True)
         called["agent"] = agent
-        called["passthrough"] = list(ctx.args) if ctx and ctx.args else []
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
 
     monkeypatch.setattr(run_cmd, "run", _fake_run)
 
@@ -44,11 +41,8 @@ def test_pi_alias_runs_agent(monkeypatch) -> None:
     called: dict[str, object] = {"agent": None, "passthrough": None}
 
     def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
-        import click
-
-        ctx = click.get_current_context(silent=True)
         called["agent"] = agent
-        called["passthrough"] = list(ctx.args) if ctx and ctx.args else []
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
 
     monkeypatch.setattr(run_cmd, "run", _fake_run)
 
@@ -62,11 +56,8 @@ def test_copilot_shortcut_still_runs_copilot(monkeypatch) -> None:
     called: dict[str, object] = {"agent": None, "passthrough": None}
 
     def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
-        import click
-
-        ctx = click.get_current_context(silent=True)
         called["agent"] = agent
-        called["passthrough"] = list(ctx.args) if ctx and ctx.args else []
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
 
     monkeypatch.setattr(run_cmd, "run", _fake_run)
 
@@ -80,11 +71,8 @@ def test_alias_forwards_extra_args(monkeypatch) -> None:
     called: dict[str, object] = {"agent": None, "passthrough": None}
 
     def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
-        import click
-
-        ctx = click.get_current_context(silent=True)
         called["agent"] = agent
-        called["passthrough"] = list(ctx.args) if ctx and ctx.args else []
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
 
     monkeypatch.setattr(run_cmd, "run", _fake_run)
 
@@ -98,11 +86,8 @@ def test_alias_forwards_extra_option_args_after_delimiter(monkeypatch) -> None:
     called: dict[str, object] = {"agent": None, "passthrough": None}
 
     def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
-        import click
-
-        ctx = click.get_current_context(silent=True)
         called["agent"] = agent
-        called["passthrough"] = list(ctx.args) if ctx and ctx.args else []
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
 
     monkeypatch.setattr(run_cmd, "run", _fake_run)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,42 @@ def test_full_agent_name_alias_runs_agent(monkeypatch) -> None:
     assert called["passthrough"] == []
 
 
+def test_pi_alias_runs_agent(monkeypatch) -> None:
+    called: dict[str, object] = {"agent": None, "passthrough": None}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        import click
+
+        ctx = click.get_current_context(silent=True)
+        called["agent"] = agent
+        called["passthrough"] = list(ctx.args) if ctx and ctx.args else []
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["pi"])
+    assert result.exit_code == 0
+    assert called["agent"] == "pi"
+    assert called["passthrough"] == []
+
+
+def test_copilot_shortcut_still_runs_copilot(monkeypatch) -> None:
+    called: dict[str, object] = {"agent": None, "passthrough": None}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        import click
+
+        ctx = click.get_current_context(silent=True)
+        called["agent"] = agent
+        called["passthrough"] = list(ctx.args) if ctx and ctx.args else []
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["p"])
+    assert result.exit_code == 0
+    assert called["agent"] == "copilot"
+    assert called["passthrough"] == []
+
+
 def test_alias_forwards_extra_args(monkeypatch) -> None:
     called: dict[str, object] = {"agent": None, "passthrough": None}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,89 +21,99 @@ def test_deep_merge() -> None:
     assert merged == {"a": 1, "b": 2, "nested": {"x": 1, "y": 999, "z": 3}}
 
 
-def test_config_init_creates_project_config() -> None:
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["config", "init"])
-        assert result.exit_code == 0
-        project_config = Path(".vibepod/config.yaml")
-        assert project_config.exists()
-        assert project_config.read_text(encoding="utf-8") == "version: 1\n"
+def test_config_init_creates_project_config(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["config", "init"])
+    assert result.exit_code == 0
+    project_config = Path(".vibepod/config.yaml")
+    assert project_config.exists()
+    assert project_config.read_text(encoding="utf-8") == "version: 1\n"
 
 
-def test_config_init_does_not_overwrite_existing_config_without_force() -> None:
-    with runner.isolated_filesystem():
-        project_config = Path(".vibepod/config.yaml")
-        project_config.parent.mkdir(parents=True, exist_ok=True)
-        project_config.write_text("default_agent: codex\n", encoding="utf-8")
+def test_config_init_does_not_overwrite_existing_config_without_force(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    project_config = Path(".vibepod/config.yaml")
+    project_config.parent.mkdir(parents=True, exist_ok=True)
+    project_config.write_text("default_agent: codex\n", encoding="utf-8")
 
-        result = runner.invoke(app, ["config", "init"])
-        assert result.exit_code == 1
-        assert "already exists" in result.stdout
-        assert project_config.read_text(encoding="utf-8") == "default_agent: codex\n"
-
-
-def test_config_init_force_overwrites_existing_config() -> None:
-    with runner.isolated_filesystem():
-        project_config = Path(".vibepod/config.yaml")
-        project_config.parent.mkdir(parents=True, exist_ok=True)
-        project_config.write_text("default_agent: codex\n", encoding="utf-8")
-
-        result = runner.invoke(app, ["config", "init", "--force"])
-        assert result.exit_code == 0
-        assert project_config.read_text(encoding="utf-8") == "version: 1\n"
+    result = runner.invoke(app, ["config", "init"])
+    assert result.exit_code == 1
+    assert "already exists" in result.stdout
+    assert project_config.read_text(encoding="utf-8") == "default_agent: codex\n"
 
 
-def test_config_init_with_agent_creates_project_config_with_agent_block() -> None:
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["config", "init", "claude"])
-        assert result.exit_code == 0
+def test_config_init_force_overwrites_existing_config(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    project_config = Path(".vibepod/config.yaml")
+    project_config.parent.mkdir(parents=True, exist_ok=True)
+    project_config.write_text("default_agent: codex\n", encoding="utf-8")
 
-        project_config = Path(".vibepod/config.yaml")
-        loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
-        assert isinstance(loaded, dict)
-        assert loaded["version"] == 1
-        assert isinstance(loaded.get("agents"), dict)
-        assert isinstance(loaded["agents"].get("claude"), dict)
-        assert loaded["agents"]["claude"]["enabled"] is True
-        assert loaded["agents"]["claude"]["env"] == {}
-        assert loaded["agents"]["claude"]["volumes"] == []
-        assert loaded["agents"]["claude"]["init"] == []
-        assert isinstance(loaded["agents"]["claude"]["image"], str)
+    result = runner.invoke(app, ["config", "init", "--force"])
+    assert result.exit_code == 0
+    assert project_config.read_text(encoding="utf-8") == "version: 1\n"
 
 
-def test_config_init_with_agent_appends_to_existing_project_config() -> None:
-    with runner.isolated_filesystem():
-        project_config = Path(".vibepod/config.yaml")
-        project_config.parent.mkdir(parents=True, exist_ok=True)
-        project_config.write_text("version: 1\ndefault_agent: codex\n", encoding="utf-8")
+def test_config_init_with_agent_creates_project_config_with_agent_block(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
 
-        result = runner.invoke(app, ["config", "init", "gemini"])
-        assert result.exit_code == 0
+    result = runner.invoke(app, ["config", "init", "claude"])
+    assert result.exit_code == 0
 
-        loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
-        assert isinstance(loaded, dict)
-        assert loaded["default_agent"] == "codex"
-        assert isinstance(loaded.get("agents"), dict)
-        assert isinstance(loaded["agents"].get("gemini"), dict)
+    project_config = Path(".vibepod/config.yaml")
+    loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    assert loaded["version"] == 1
+    assert isinstance(loaded.get("agents"), dict)
+    assert isinstance(loaded["agents"].get("claude"), dict)
+    assert loaded["agents"]["claude"]["enabled"] is True
+    assert loaded["agents"]["claude"]["env"] == {}
+    assert loaded["agents"]["claude"]["volumes"] == []
+    assert loaded["agents"]["claude"]["init"] == []
+    assert isinstance(loaded["agents"]["claude"]["image"], str)
 
 
-def test_config_init_with_agent_fails_when_agent_already_configured() -> None:
-    with runner.isolated_filesystem():
-        project_config = Path(".vibepod/config.yaml")
-        project_config.parent.mkdir(parents=True, exist_ok=True)
-        project_config.write_text(
-            "version: 1\nagents:\n  claude:\n    enabled: true\n",
-            encoding="utf-8",
-        )
+def test_config_init_with_agent_appends_to_existing_project_config(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    project_config = Path(".vibepod/config.yaml")
+    project_config.parent.mkdir(parents=True, exist_ok=True)
+    project_config.write_text("version: 1\ndefault_agent: codex\n", encoding="utf-8")
 
-        result = runner.invoke(app, ["config", "init", "claude"])
-        assert result.exit_code == 1
-        assert "already contains agent 'claude'" in result.stdout
+    result = runner.invoke(app, ["config", "init", "gemini"])
+    assert result.exit_code == 0
 
-        loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
-        assert isinstance(loaded, dict)
-        assert isinstance(loaded.get("agents"), dict)
-        assert loaded["agents"]["claude"]["enabled"] is True
+    loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    assert loaded["default_agent"] == "codex"
+    assert isinstance(loaded.get("agents"), dict)
+    assert isinstance(loaded["agents"].get("gemini"), dict)
+
+
+def test_config_init_with_agent_fails_when_agent_already_configured(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    project_config = Path(".vibepod/config.yaml")
+    project_config.parent.mkdir(parents=True, exist_ok=True)
+    project_config.write_text(
+        "version: 1\nagents:\n  claude:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["config", "init", "claude"])
+    assert result.exit_code == 1
+    assert "already contains agent 'claude'" in result.stdout
+
+    loaded = yaml.safe_load(project_config.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    assert isinstance(loaded.get("agents"), dict)
+    assert loaded["agents"]["claude"]["enabled"] is True
 
 
 def test_default_config_exposes_agent_init(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -15,6 +15,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
         "VP_IMAGE_AUGGIE",
         "VP_IMAGE_COPILOT",
         "VP_IMAGE_CODEX",
+        "VP_IMAGE_PI",
         "VP_DATASETTE_IMAGE",
         "VP_PROXY_IMAGE",
     ):
@@ -29,5 +30,14 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
     assert images["auggie"] == "vibepod/auggie:latest"
     assert images["copilot"] == "vibepod/copilot:latest"
     assert images["codex"] == "vibepod/codex:latest"
+    assert images["pi"] == "vibepod/pi:latest"
     assert images["datasette"] == "vibepod/datasette:latest"
     assert images["proxy"] == "vibepod/proxy:latest"
+
+
+def test_pi_image_override(monkeypatch) -> None:
+    monkeypatch.setenv("VP_IMAGE_PI", "example/pi:dev")
+
+    images = get_default_images()
+
+    assert images["pi"] == "example/pi:dev"

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -32,6 +32,7 @@ def test_list_json_includes_short_and_full_agent_names(monkeypatch) -> None:
 
     for shortcut, agent in AGENT_SHORTCUTS.items():
         assert by_agent[agent]["short"] == shortcut
+    assert by_agent["pi"]["short"] == "-"
 
 
 def test_list_running_json_preserves_multiple_instances(monkeypatch) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -114,7 +114,7 @@ def test_skills_mounts_for_agent_requires_skill_directories_under_scope_root(
     ]
 
 
-def test_skills_mounts_for_pi_use_shared_agents_path(
+def test_skills_mounts_for_pi_use_agent_dir_skills_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     local_root = tmp_path / "local-skills"
@@ -132,7 +132,7 @@ def test_skills_mounts_for_pi_use_shared_agents_path(
     monkeypatch.setattr(skills_engine, "user_skills_dir", lambda: user_root)
 
     assert run_cmd._skills_mounts_for_agent("pi", tmp_path) == [
-        (str(skill_dir.resolve()), "/config/.agents/skills/example", "ro")
+        (str(skill_dir.resolve()), "/config/.pi/agent/skills/example", "ro")
     ]
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -114,6 +114,28 @@ def test_skills_mounts_for_agent_requires_skill_directories_under_scope_root(
     ]
 
 
+def test_skills_mounts_for_pi_use_shared_agents_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    local_root = tmp_path / "local-skills"
+    user_root = tmp_path / "user-skills"
+    skill_dir = local_root / "installed" / "example"
+    skill_dir.mkdir(parents=True)
+    user_root.mkdir()
+    (local_root / "skills-lock.json").write_text(
+        json.dumps({"skills": {"example": {"path": "installed/example"}}}),
+        encoding="utf-8",
+    )
+    (user_root / "skills-lock.json").write_text(json.dumps({"skills": {}}), encoding="utf-8")
+
+    monkeypatch.setattr(skills_engine, "local_skills_dir", lambda workspace: local_root)
+    monkeypatch.setattr(skills_engine, "user_skills_dir", lambda: user_root)
+
+    assert run_cmd._skills_mounts_for_agent("pi", tmp_path) == [
+        (str(skill_dir.resolve()), "/config/.agents/skills/example", "ro")
+    ]
+
+
 def test_run_agent_supports_duplicate_host_mounts(tmp_path: Path) -> None:
     class _FakeContainers:
         def __init__(self) -> None:


### PR DESCRIPTION
Adds support for the "pi" agent (Earendil) throughout the VibePod codebase, CLI, configuration, and documentation. The changes ensure "pi" is recognized as a first-class agent, can be run with `vp pi`, and is properly handled in agent management, skills mounting, image configuration, and tests. Notably, "pi" does not have a single-letter shortcut due to "p" being assigned to Copilot.

**Agent support and configuration:**
- Added "pi" to the list of supported agents in `src/vibepod/constants.py`, with corresponding image environment variable support and default image logic. [[1]](diffhunk://#diff-cc108532588326dbd91ffbb0582d36d11b0f6d995cf506b66c690cc760e182a2R29) [[2]](diffhunk://#diff-cc108532588326dbd91ffbb0582d36d11b0f6d995cf506b66c690cc760e182a2R55) [[3]](diffhunk://#diff-cc108532588326dbd91ffbb0582d36d11b0f6d995cf506b66c690cc760e182a2R106-R108)
- Implemented the "pi" agent specification in `src/vibepod/core/agents.py`, including its provider, image, command, config directory, and environment variables.
- Updated default and user configuration examples to include "pi" in `docs/configuration.md` and `src/vibepod/core/config.py`. [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R89-R95) [[2]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R148) F3ce1579L91R103)

**CLI and agent invocation:**
- Enabled running the "pi" agent via `vp pi` and clarified in documentation that "pi" does not have a single-letter shortcut. Added CLI tests to verify correct invocation and shortcut handling. [[1]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL43-R44) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR43-R78) [[3]](diffhunk://#diff-f40ea99697a137f87f5a524a5be49b0e057ed7e164e108f43148bc09fc897e3aR35)

**Skills mounting and agent behavior:**
- Ensured "pi" uses the shared `.agents/skills` path for SKILL.md auto-discovery, both in agent logic and documentation. Added tests for correct skills mounting. [[1]](diffhunk://#diff-355148627439c2d94fc0a78e6cdb78e4e590228da98508a642cd06712a3cf0a7R137) [[2]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaL181-R185) [[3]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaL194-R195) [[4]](diffhunk://#diff-24e9fd3e8410789608ff4fea84ccb736745b65b0b02a0cb5316e14a560a28257R117-R138)

**Documentation updates:**
- Updated all relevant documentation files to mention "pi" as a supported agent, including agent tables, image customization, and approval/permission support. [[1]](diffhunk://#diff-769038fe43eef76817f509a7ccfa19477d448ccc86b0264b6ab751b7c232cf80R16) [[2]](diffhunk://#diff-769038fe43eef76817f509a7ccfa19477d448ccc86b0264b6ab751b7c232cf80L76-R77) [[3]](diffhunk://#diff-769038fe43eef76817f509a7ccfa19477d448ccc86b0264b6ab751b7c232cf80R201) [[4]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R25)

**Testing and validation:**
- Added and updated tests to validate "pi" agent specification, image override, shortcut handling, and environment variable support. [[1]](diffhunk://#diff-8d76e49de7c5d0a3300be753b9346e1b6fd535c394b1d9a2c4bd798cfd407193R42-R52) [[2]](diffhunk://#diff-8d76e49de7c5d0a3300be753b9346e1b6fd535c394b1d9a2c4bd798cfd407193L90-R113) [[3]](diffhunk://#diff-8d76e49de7c5d0a3300be753b9346e1b6fd535c394b1d9a2c4bd798cfd407193L128-R141) [[4]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eR18) [[5]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eR33-R43)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Pi agent (Earendil provider). Invoke using `vp pi` shortcut.
  * Introduced `VP_IMAGE_PI` environment variable for custom Pi agent image overrides.

* **Documentation**
  * Updated configuration reference, quickstart guide, and skills documentation to include Pi agent support and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->