### PR TITLE
Add new login command for codex to use port forward

### DIFF
--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -68,6 +68,33 @@ def _write_claude_stored_token(config_dir: Path, token: str) -> Path:
     return path
 
 
+# Codex's OAuth login server is hard-bound to 127.0.0.1:1455 (it can't be told
+# to bind elsewhere), and the browser callback goes to http://localhost:1455.
+# Docker publishes ports to the container's bridge interface, not its loopback,
+# so the codex image runs a socat forwarder on CODEX_OAUTH_FORWARD_PORT that
+# bridges bridge-interface -> 127.0.0.1:1455. We publish that forwarder port to
+# the host as CODEX_OAUTH_CALLBACK_PORT so the host browser reaches Codex.
+CODEX_OAUTH_CALLBACK_PORT = 1455
+CODEX_OAUTH_FORWARD_PORT = 1456
+
+
+def _is_codex_oauth_login(agent: str, passthrough_args: list[str]) -> bool:
+    """True when this is a `codex login` OAuth flow needing the localhost callback.
+
+    The device-code and API-key flows don't use the callback, so they skip the
+    port publishing and forwarder.
+    """
+    if agent != "codex" or "login" not in passthrough_args:
+        return False
+
+    non_oauth_flags = ("--device-auth", "--with-api-key")
+    return not any(
+        arg == flag or arg.startswith(f"{flag}=")
+        for arg in passthrough_args
+        for flag in non_oauth_flags
+    )
+
+
 def _parse_env_pairs(values: list[str]) -> dict[str, str]:
     parsed: dict[str, str] = {}
     for entry in values:
@@ -431,6 +458,7 @@ def run(
 
     agent_cfg = config.get("agents", {}).get(selected_agent, {})
     spec = get_agent_spec(selected_agent)
+    codex_oauth_login = _is_codex_oauth_login(selected_agent, passthrough_args)
     init_commands = _agent_init_commands(selected_agent, agent_cfg)
     merged_env = {
         "USER_UID": str(os.getuid()),
@@ -440,6 +468,17 @@ def run(
         **{str(k): str(v) for k, v in agent_cfg.get("env", {}).items()},
         **_parse_env_pairs(env or []),
     }
+    agent_ports: dict[str, Any] | None = None
+    if codex_oauth_login:
+        # Tell the codex image to start the loopback forwarder, and publish it to
+        # the host on the port Codex's redirect URI expects.
+        merged_env["VIBEPOD_OAUTH_FORWARD_PORT"] = str(CODEX_OAUTH_FORWARD_PORT)
+        agent_ports = {f"{CODEX_OAUTH_FORWARD_PORT}/tcp": CODEX_OAUTH_CALLBACK_PORT}
+        info(
+            "codex login: publishing the OAuth callback on "
+            f"http://localhost:{CODEX_OAUTH_CALLBACK_PORT}/auth/callback "
+            "(open the URL Codex prints in your host browser)"
+        )
 
     if (
         selected_agent == "claude"
@@ -611,6 +650,7 @@ def run(
         name=name,
         version=__version__,
         network=network_name,
+        ports=agent_ports,
         extra_volumes=extra_volumes,
         platform=spec.platform,
         user=container_user,

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -177,6 +177,7 @@ class DockerManager:
         name: str | None,
         version: str,
         network: str | None = None,
+        ports: dict[str, Any] | None = None,
         extra_volumes: list[tuple[str, str, str]] | None = None,
         platform: str | None = None,
         user: str | None = None,
@@ -215,6 +216,10 @@ class DockerManager:
                 "working_dir": "/workspace",
                 "network": network,
             }
+            if ports:
+                # Maps "<container_port>/tcp" -> host_port. Used to publish the
+                # Codex OAuth callback forwarder during `codex login`.
+                run_kwargs["ports"] = ports
             if platform:
                 run_kwargs["platform"] = platform
             if user:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -269,6 +269,61 @@ def test_run_agent_forwards_entrypoint(tmp_path: Path) -> None:
     assert run_kwargs["entrypoint"] == ["/bin/sh", "-lc", 'echo "init"; exec "$@"', "--"]
 
 
+def test_run_agent_publishes_ports(tmp_path: Path) -> None:
+    class _FakeContainers:
+        def __init__(self) -> None:
+            self.run_kwargs: dict | None = None
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+            return {"id": "agent"}
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.containers = _FakeContainers()
+
+    manager = object.__new__(DockerManager)
+    manager.client = _FakeClient()  # type: ignore[assignment]
+
+    workspace = tmp_path / "workspace"
+    config_dir = tmp_path / "agents" / "codex"
+    workspace.mkdir(parents=True, exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    manager.run_agent(
+        agent="codex",
+        image="vibepod/codex:latest",
+        workspace=workspace,
+        config_dir=config_dir,
+        config_mount_path="/config",
+        env={},
+        command=["codex", "login"],
+        auto_remove=True,
+        name=None,
+        version="0.2.1",
+        network="vibepod-network",
+        ports={"1456/tcp": 1455},
+    )
+
+    run_kwargs = manager.client.containers.run_kwargs  # type: ignore[union-attr]
+    assert run_kwargs is not None
+    # published callback forwarder, still on the user-defined network
+    assert run_kwargs["ports"] == {"1456/tcp": 1455}
+    assert run_kwargs["network"] == "vibepod-network"
+
+
+def test_is_codex_oauth_login_detection() -> None:
+    assert run_cmd._is_codex_oauth_login("codex", ["login"]) is True
+    # device-code and api-key flows don't use the localhost:1455 callback
+    assert run_cmd._is_codex_oauth_login("codex", ["login", "--device-auth"]) is False
+    assert run_cmd._is_codex_oauth_login("codex", ["login", "--device-auth=true"]) is False
+    assert run_cmd._is_codex_oauth_login("codex", ["login", "--with-api-key"]) is False
+    assert run_cmd._is_codex_oauth_login("codex", ["login", "--with-api-key=secret"]) is False
+    # non-login codex invocations and other agents stay on the normal path
+    assert run_cmd._is_codex_oauth_login("codex", []) is False
+    assert run_cmd._is_codex_oauth_login("claude", ["login"]) is False
+
+
 def test_x11_volumes_and_env_returns_socket_and_display() -> None:
     volumes, env = run_cmd._x11_volumes_and_env(":0")
     assert ("/tmp/.X11-unix", "/tmp/.X11-unix", "rw") in volumes


### PR DESCRIPTION
Adds support for publishing the Codex OAuth callback port during the `codex login` OAuth flow, ensuring the browser callback works correctly when running Codex in Docker. It introduces detection logic to determine when the OAuth flow is needed, configures container port publishing, and adds tests for the new behavior.

**Codex OAuth callback support:**

* Added constants `CODEX_OAUTH_CALLBACK_PORT` and `CODEX_OAUTH_FORWARD_PORT` to define the callback and forwarder ports for Codex OAuth login.
* Implemented `_is_codex_oauth_login` to detect when the `codex login` OAuth flow requires port publishing.
* Modified `run` in `run.py` to set environment variables and publish the correct ports when the OAuth flow is detected. [[1]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaR455) [[2]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaR465-R475) [[3]](diffhunk://#diff-849d49b086c3d77e2f47c2cd039e4ce598d9017e816d2b9da5526882c7dc30aaR647)
* Updated `run_agent` in `docker.py` to accept and handle a `ports` argument, mapping container ports to host ports for the callback forwarder. [[1]](diffhunk://#diff-261077742cc6453cbf6e8cfcde31fa96d63c26f5e30af5569232276b3b0b99acR180) [[2]](diffhunk://#diff-261077742cc6453cbf6e8cfcde31fa96d63c26f5e30af5569232276b3b0b99acR219-R222)

**Testing:**

* Added tests to verify that `run_agent` publishes ports correctly and that `_is_codex_oauth_login` accurately detects when the OAuth flow is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Codex OAuth localhost callback authentication flow.
  * Implemented automatic port forwarding configuration for OAuth login callbacks.
  * Enhanced compatibility with multiple authentication methods including OAuth, device-auth, and API-key flows.

* **Tests**
  * Added unit tests to verify port forwarding and authentication flow detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->