### PR TITLE
Support Podman keep-id launches

### DIFF
--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -102,6 +102,27 @@ def _normalize_command(value: Any) -> list[str]:
     return [str(value)]
 
 
+def _version_is_podman(version: Any) -> bool:
+    """Return True when Docker-compatible API version metadata belongs to Podman."""
+    if not isinstance(version, dict):
+        return False
+
+    components = version.get("Components", [])
+    if isinstance(components, list):
+        for component in components:
+            if not isinstance(component, dict):
+                continue
+            name = str(component.get("Name", "")).lower()
+            if "podman" in name:
+                return True
+
+    platform = version.get("Platform")
+    if isinstance(platform, dict) and "podman" in str(platform.get("Name", "")).lower():
+        return True
+
+    return "podman" in str(version.get("Name", "")).lower()
+
+
 class DockerManager:
     """Manager for all Docker operations."""
 
@@ -113,6 +134,33 @@ class DockerManager:
             self.client.ping()
         except DockerException as exc:
             raise DockerClientError(f"Docker is not available: {exc}") from exc
+
+        self._rootless_podman: bool | None = None
+
+    def is_rootless_podman(self) -> bool:
+        """Return True for a rootless Podman engine exposed through the Docker API."""
+        cached = getattr(self, "_rootless_podman", None)
+        if isinstance(cached, bool):
+            return cached
+
+        try:
+            info = self.client.info()
+            version = self.client.version()
+        except (APIError, DockerException, AttributeError):
+            self._rootless_podman = False
+            return False
+
+        if not isinstance(info, dict):
+            self._rootless_podman = False
+            return False
+
+        security_options = info.get("SecurityOptions", [])
+        rootless = bool(info.get("Rootless")) or (
+            isinstance(security_options, list)
+            and any(str(option).lower() == "name=rootless" for option in security_options)
+        )
+        self._rootless_podman = rootless and _version_is_podman(version)
+        return self._rootless_podman
 
     def pull_image(self, image: str) -> None:
         try:
@@ -226,6 +274,7 @@ class DockerManager:
         platform: str | None = None,
         user: str | None = None,
         entrypoint: list[str] | None = None,
+        userns_mode: str | None = None,
     ) -> Any:
         container_name = name or f"vibepod-{agent}-{uuid4().hex[:8]}"
 
@@ -246,6 +295,43 @@ class DockerManager:
             volumes.extend(f"{host}:{bind}:{mode}" for host, bind, mode in extra_volumes)
 
         try:
+            if userns_mode is not None:
+                host_config = self.client.api.create_host_config(
+                    binds=volumes,
+                    auto_remove=auto_remove,
+                    network_mode=network,
+                    port_bindings=ports,
+                )
+                # docker-py validates userns_mode against Docker's enum and rejects
+                # Podman's `keep-id`, so set the Docker-compatible HostConfig field
+                # directly for Podman engines.
+                host_config["UsernsMode"] = userns_mode
+
+                create_kwargs: dict[str, Any] = {
+                    "image": image,
+                    "name": container_name,
+                    "command": command,
+                    "tty": True,
+                    "stdin_open": True,
+                    "labels": labels,
+                    "environment": environment,
+                    "working_dir": "/workspace",
+                    "host_config": host_config,
+                }
+                if ports:
+                    create_kwargs["ports"] = list(ports.keys())
+                if platform:
+                    create_kwargs["platform"] = platform
+                if user:
+                    create_kwargs["user"] = user
+                if entrypoint:
+                    create_kwargs["entrypoint"] = entrypoint
+
+                created = self.client.api.create_container(**create_kwargs)
+                container_id = created["Id"]
+                self.client.api.start(container_id)
+                return self.client.containers.get(container_id)
+
             run_kwargs: dict[str, Any] = {
                 "image": image,
                 "name": container_name,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -372,6 +372,167 @@ def test_run_agent_publishes_ports(tmp_path: Path) -> None:
     assert run_kwargs["network"] == "vibepod-network"
 
 
+class _KeepIdApi:
+    def __init__(self) -> None:
+        self.host_config_kwargs: dict | None = None
+        self.host_config: dict | None = None
+        self.create_kwargs: dict | None = None
+        self.started: str | None = None
+
+    def create_host_config(self, **kwargs):
+        self.host_config_kwargs = kwargs
+        self.host_config = {"Binds": kwargs["binds"], "AutoRemove": kwargs["auto_remove"]}
+        return self.host_config
+
+    def create_container(self, **kwargs):
+        self.create_kwargs = kwargs
+        return {"Id": "agent123"}
+
+    def start(self, container_id: str) -> None:
+        self.started = container_id
+
+
+class _KeepIdContainers:
+    def __init__(self) -> None:
+        self.run_called = False
+
+    def run(self, **kwargs):
+        del kwargs
+        self.run_called = True
+        return {"id": "agent"}
+
+    def get(self, container_id: str):
+        return {"id": container_id}
+
+
+class _KeepIdClient:
+    def __init__(self) -> None:
+        self.api = _KeepIdApi()
+        self.containers = _KeepIdContainers()
+
+
+class _EngineClient:
+    def __init__(self, info: dict, version: dict) -> None:
+        self.info_calls = 0
+        self.version_calls = 0
+        self._info = info
+        self._version = version
+
+    def info(self) -> dict:
+        self.info_calls += 1
+        return self._info
+
+    def version(self) -> dict:
+        self.version_calls += 1
+        return self._version
+
+
+def test_run_agent_uses_low_level_api_for_podman_keep_id(tmp_path: Path) -> None:
+    client = _KeepIdClient()
+    manager = object.__new__(DockerManager)
+    manager.client = client  # type: ignore[assignment]
+
+    workspace = tmp_path / "workspace"
+    config_dir = tmp_path / "agents" / "pi"
+    workspace.mkdir(parents=True, exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    container = manager.run_agent(
+        agent="pi",
+        image="vibepod/pi:latest",
+        workspace=workspace,
+        config_dir=config_dir,
+        config_mount_path="/config",
+        env={"USER_UID": "0"},
+        command=["pi"],
+        auto_remove=True,
+        name="vibepod-pi-test",
+        version="0.14.0",
+        network="vibepod-network",
+        ports={"1456/tcp": 1455},
+        extra_volumes=[(str(config_dir / "extra"), "/extra", "ro")],
+        platform="linux/amd64",
+        user="1000:1000",
+        entrypoint=["/entrypoint.sh"],
+        userns_mode="keep-id",
+    )
+
+    assert container == {"id": "agent123"}
+    assert client.containers.run_called is False
+    assert client.api.started == "agent123"
+    assert client.api.host_config_kwargs == {
+        "binds": [
+            f"{workspace}:/workspace:rw",
+            f"{config_dir}:/config:rw",
+            f"{config_dir / 'extra'}:/extra:ro",
+        ],
+        "auto_remove": True,
+        "network_mode": "vibepod-network",
+        "port_bindings": {"1456/tcp": 1455},
+    }
+    assert client.api.host_config is not None
+    assert client.api.host_config["UsernsMode"] == "keep-id"
+    assert client.api.create_kwargs is not None
+    assert client.api.create_kwargs["image"] == "vibepod/pi:latest"
+    assert client.api.create_kwargs["name"] == "vibepod-pi-test"
+    assert client.api.create_kwargs["command"] == ["pi"]
+    assert client.api.create_kwargs["labels"]["vibepod.agent"] == "pi"
+    assert client.api.create_kwargs["environment"] == {"USER_UID": "0"}
+    assert client.api.create_kwargs["working_dir"] == "/workspace"
+    assert client.api.create_kwargs["ports"] == ["1456/tcp"]
+    assert client.api.create_kwargs["platform"] == "linux/amd64"
+    assert client.api.create_kwargs["user"] == "1000:1000"
+    assert client.api.create_kwargs["entrypoint"] == ["/entrypoint.sh"]
+
+
+def test_run_agent_is_rootless_podman_detects_podman_engine() -> None:
+    client = _EngineClient(
+        {"Rootless": True, "SecurityOptions": ["name=rootless"]},
+        {"Components": [{"Name": "Podman Engine", "Version": "5.7.0"}]},
+    )
+    manager = object.__new__(DockerManager)
+    manager.client = client  # type: ignore[assignment]
+
+    assert manager.is_rootless_podman() is True
+    assert manager.is_rootless_podman() is True
+    assert client.info_calls == 1
+    assert client.version_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("info", "version"),
+    [
+        (
+            {"Rootless": True, "SecurityOptions": ["name=rootless"]},
+            {"Components": [{"Name": "Docker Engine"}]},
+        ),
+        (
+            {"Rootless": False, "SecurityOptions": []},
+            {"Components": [{"Name": "Podman Engine"}]},
+        ),
+    ],
+)
+def test_run_agent_is_rootless_podman_requires_rootless_podman_evidence(
+    info: dict, version: dict
+) -> None:
+    client = _EngineClient(info, version)
+    manager = object.__new__(DockerManager)
+    manager.client = client  # type: ignore[assignment]
+
+    assert manager.is_rootless_podman() is False
+
+
+def test_run_agent_is_rootless_podman_treats_sdk_failures_as_false() -> None:
+    class _MissingVersionClient:
+        def info(self) -> dict:
+            return {"Rootless": True, "SecurityOptions": ["name=rootless"]}
+
+    manager = object.__new__(DockerManager)
+    manager.client = _MissingVersionClient()  # type: ignore[assignment]
+
+    assert manager.is_rootless_podman() is False
+
+
 def test_is_codex_oauth_login_detection() -> None:
     assert run_cmd._is_codex_oauth_login("codex", ["login"]) is True
     # device-code and api-key flows don't use the localhost:1455 callback


### PR DESCRIPTION
## Stack

Position: 1/2

Base: `main`

Depends on: none

## Summary

- Detect rootless Podman from Docker-compatible `info()` and `version()` metadata.
- Add opt-in `run_agent(userns_mode=...)` support using Docker SDK low-level create/start APIs.
- Keep the existing `containers.run(...)` path unchanged when `userns_mode` is not provided.

## Why this split exists

- Slice 1 only teaches `DockerManager` the engine/launch primitive.
- Slice 2 can wire `vp run` behavior without mixing command policy into Docker plumbing.

## Review focus

- Docker launches without `userns_mode` still use the high-level SDK path.
- The low-level path preserves binds, ports, env, platform, user, entrypoint, labels, and working dir.
- Podman detection requires both rootless evidence and Podman engine evidence.

## Verification

- [x] `python -m pytest tests/test_run.py -k "run_agent and (podman or userns or ports)"` — pass, 7 passed
- [x] `ruff check src/vibepod/core/docker.py tests/test_run.py` — pass
- [x] `mypy src` — pass

## Complexity impact

`increased-justified`

Reason: adds one opt-in low-level launch path because docker-py rejects Podman `keep-id` through the high-level API; default Docker behavior stays on the existing path.

## Follow-up

- Next PR/MR: wire rootless Podman launch policy through `vp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime detection for Podman and rootless Podman environments.
  * Enabled optional user namespace mode support when launching containers, improving compatibility with Podman-specific modes (e.g., keep-id).

* **Tests**
  * Added mock-based coverage for Podman rootless detection behavior and ensures the correct container launch path is used with custom user namespace modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->