### PR TITLE
Add ikwid options for pi agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Use `--ikwid` to append each agent's auto-approval / permission-skip flag when s
 | `devstral` (`vibe`) | `--auto-approve` |
 | `copilot` | `--yolo` |
 | `codex` | `--dangerously-bypass-approvals-and-sandbox` |
+| `pi` | `--approve` |
 | `opencode` | Not supported |
 | `auggie` | Not supported |
-| `pi` | Not supported |
 
 ![VibePod CLI preview](https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/preview.png)
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -196,9 +196,9 @@ Use `--ikwid` to enable each agent's built-in auto-approval / permission-skip mo
 | `devstral` | `--auto-approve` |
 | `copilot` | `--yolo` |
 | `codex` | `--dangerously-bypass-approvals-and-sandbox` |
+| `pi` | `--approve` |
 | `opencode` | Not supported |
 | `auggie` | Not supported |
-| `pi` | Not supported |
 
 Example:
 
@@ -514,3 +514,9 @@ vp run pi   # or: vp pi
 ```
 
 Pi runs the Pi coding agent from Earendil in the same isolated VibePod container workflow. Credentials and configuration are persisted under `~/.config/vibepod/agents/pi/`.
+
+Pi has a per-project **trust/approval system**: before loading project-local extensions and settings, it asks you to trust the project once. Inside VibePod:
+
+- Interactive: run `/trust` to save the decision. It is written to `PI_CODING_AGENT_DIR` (`/config/.pi/agent/trust.json`), which lives inside the persisted config mount, so the trust survives container restarts.
+- `--ikwid`: appends `--approve`, trusting project-local files for that run (see [IKWID mode](#ikwid-mode---ikwid)).
+- Non-interactive modes (`-p`, `--mode json`, `--mode rpc`) show no prompt and fall back to `defaultProjectTrust` in `/config/.pi/agent/settings.json` (`ask` | `always` | `never`). Pre-seed this file if you need unattended runs to trust projects automatically.

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -122,6 +122,7 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         ["pi"],
         "/config",
         {"HOME": "/config", "PI_CODING_AGENT_DIR": "/config/.pi/agent"},
+        ikwid_args=["--approve"],
     ),
 }
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -93,13 +93,18 @@ def test_devstral_spec_has_ikwid_args() -> None:
     assert spec.ikwid_args == ["--auto-approve"]
 
 
+def test_pi_spec_has_ikwid_args() -> None:
+    spec = get_agent_spec("pi")
+    assert spec.ikwid_args == ["--approve"]
+
+
 def test_gemini_spec_runs_via_node_wrapper() -> None:
     spec = get_agent_spec("gemini")
     assert spec.command == ["env", "HOME=/config", "node", "/usr/local/bin/gemini"]
 
 
 def test_unsupported_agents_have_no_ikwid_args() -> None:
-    for agent in ("opencode", "auggie", "pi"):
+    for agent in ("opencode", "auggie"):
         spec = get_agent_spec(agent)
         assert spec.ikwid_args is None, f"{agent} should not have ikwid_args"
 


### PR DESCRIPTION
Adds support for the Pi agent's auto-approval (trust) mode by introducing the `--approve` flag, updating both documentation and code to reflect this new capability. It also includes tests to ensure the correct behavior and updates references to the Pi agent's trust system.

**Code changes:**

* Added `ikwid_args=["--approve"]` to the Pi agent's `AgentSpec` in `src/vibepod/core/agents.py`, enabling the flag when running in IKWID mode.

Based on https://github.com/earendil-works/pi/issues/5514 and https://github.com/earendil-works/pi/pull/5549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Pi agent's per-project trust/approval system, including interactive prompts and non-interactive configuration modes with customizable defaults.

* **New Features**
  * Pi agent now includes automatic approval support for IKWID mode operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->