### PR TITLE
Add task lifecycle persistence

### DIFF
--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 import typer
 from rich.prompt import Confirm
@@ -35,7 +35,15 @@ from vibepod.core.launch import (
     terminal_env_defaults,
     update_container_mapping,
 )
-from vibepod.core.tasks import TaskRecord, TaskStore
+from vibepod.core.tasks import (
+    TASK_STATUS_COMPLETED,
+    TASK_STATUS_FAILED,
+    TASK_STATUS_RUNNING,
+    TASK_STATUS_STARTING,
+    TERMINAL_TASK_STATUSES,
+    TaskRecord,
+    TaskStore,
+)
 from vibepod.utils.console import console, error, info, success, warning
 
 app = typer.Typer(
@@ -43,6 +51,7 @@ app = typer.Typer(
     help="Run agents headlessly as background tasks",
     no_args_is_help=True,
 )
+_NO_CONTEXT = cast(typer.Context, None)
 
 
 def _task_store() -> TaskStore:
@@ -64,6 +73,78 @@ def _resolve_task(store: TaskStore, id_or_prefix: str) -> TaskRecord:
         error(f"Ambiguous task id '{id_or_prefix}' (matches: {joined}). Use a longer prefix.")
         raise typer.Exit(1)
     return matches[0]
+
+
+def _context_args(ctx: typer.Context | None) -> list[str]:
+    return list(ctx.args) if ctx is not None and ctx.args else []
+
+
+def _state_timestamp(state: dict[str, Any], key: str) -> str | None:
+    value = state.get(key)
+    if value is None:
+        return None
+    timestamp = str(value)
+    if not timestamp or timestamp.startswith("0001-01-01"):
+        return None
+    return timestamp
+
+
+def _task_state_from_docker(
+    state: dict[str, Any],
+) -> tuple[str, int | None, str | None, str | None]:
+    docker_status = str(state.get("Status") or "")
+    exit_code = state.get("ExitCode")
+    normalized_exit_code = exit_code if isinstance(exit_code, int) else None
+    started_at = _state_timestamp(state, "StartedAt")
+    finished_at = _state_timestamp(state, "FinishedAt")
+
+    if docker_status == "exited":
+        status = TASK_STATUS_COMPLETED if normalized_exit_code == 0 else TASK_STATUS_FAILED
+    elif docker_status in {"dead", "removing"}:
+        status = TASK_STATUS_FAILED
+    elif docker_status == "created":
+        status = TASK_STATUS_STARTING
+    elif docker_status:
+        status = TASK_STATUS_RUNNING
+    else:
+        status = TASK_STATUS_RUNNING
+
+    if status not in TERMINAL_TASK_STATUSES:
+        normalized_exit_code = None
+        finished_at = None
+
+    return status, normalized_exit_code, started_at, finished_at
+
+
+def _record_with_container_state(
+    store: TaskStore,
+    record: TaskRecord,
+    state: dict[str, Any],
+) -> TaskRecord:
+    status, exit_code, started_at, finished_at = _task_state_from_docker(state)
+    if (
+        record.status == status
+        and record.exit_code == exit_code
+        and record.started_at == started_at
+        and record.finished_at == finished_at
+    ):
+        return record
+    return (
+        store.update(
+            record.id,
+            status=status,
+            exit_code=exit_code,
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+        or record
+    )
+
+
+def _format_task_status(record: TaskRecord) -> str:
+    if record.status in TERMINAL_TASK_STATUSES and record.exit_code is not None:
+        return f"{record.status} ({record.exit_code})"
+    return record.status
 
 
 def task_run(
@@ -135,11 +216,7 @@ def task_run(
         **parse_env_pairs(env or []),
     }
 
-    if (
-        selected == "codex"
-        and "CODEX_API_KEY" not in merged_env
-        and "OPENAI_API_KEY" in merged_env
-    ):
+    if selected == "codex" and "CODEX_API_KEY" not in merged_env and "OPENAI_API_KEY" in merged_env:
         merged_env["CODEX_API_KEY"] = merged_env["OPENAI_API_KEY"]
 
     if (
@@ -313,6 +390,11 @@ def task_run(
                 mapping_path, container_ip, container.id, container.name, selected
             )
 
+    state = container.attrs.get("State", {}) or {}
+    if not isinstance(state, dict):
+        state = {}
+    initial_status = TASK_STATUS_RUNNING if container.status == "running" else TASK_STATUS_STARTING
+
     store = _task_store()
     try:
         record = store.create(
@@ -323,6 +405,8 @@ def task_run(
             container_name=container.name,
             image=image,
             vibepod_version=__version__,
+            status=initial_status,
+            started_at=_state_timestamp(state, "StartedAt"),
         )
     except Exception as exc:
         error(f"Failed to persist task record: {exc}. Stopping container {container.name}.")
@@ -380,7 +464,7 @@ def _task_run_cmd(
         network=network,
         pull=pull,
         ikwid=ikwid,
-        passthrough_args=list(ctx.args) if ctx.args else [],
+        passthrough_args=_context_args(ctx),
     )
 
 
@@ -388,9 +472,7 @@ def _task_run_cmd(
 def task_list(
     agent: Annotated[str | None, typer.Option("--agent", help="Filter by agent name")] = None,
     as_json: Annotated[bool, typer.Option("--json", help="Output JSON")] = False,
-    limit: Annotated[
-        int | None, typer.Option("--limit", help="Max rows to show")
-    ] = 20,
+    limit: Annotated[int | None, typer.Option("--limit", help="Max rows to show")] = 20,
 ) -> None:
     """List recent tasks with container status."""
     filter_agent: str | None = None
@@ -402,10 +484,6 @@ def task_list(
     store = _task_store()
     tasks = store.list(agent=filter_agent, limit=limit)
 
-    if as_json:
-        print(_json.dumps([t.as_dict() for t in tasks], indent=2))
-        return
-
     if not tasks:
         console.print("No tasks recorded.")
         return
@@ -415,6 +493,34 @@ def task_list(
     except DockerClientError:
         manager = None
 
+    rows: list[tuple[TaskRecord, str]] = []
+    for task in tasks:
+        record = task
+        display_status = _format_task_status(record)
+        if manager is not None:
+            try:
+                container = manager.get_container(record.container_id)
+                container.reload()
+                state = container.attrs.get("State", {}) or {}
+                if not isinstance(state, dict):
+                    state = {}
+                record = _record_with_container_state(store, record, state)
+                display_status = _format_task_status(record)
+            except DockerClientError:
+                if record.status not in TERMINAL_TASK_STATUSES:
+                    display_status = "removed"
+        rows.append((record, display_status))
+    if as_json:
+        payloads = []
+        for record, display_status in rows:
+            payload = record.as_dict()
+            if display_status == "removed":
+                payload["status"] = "removed"
+                payload["exit_code"] = None
+            payloads.append(payload)
+        print(_json.dumps(payloads, indent=2))
+        return
+
     table = Table(title="Tasks", title_justify="left")
     table.add_column("ID", style="cyan")
     table.add_column("AGENT", style="magenta")
@@ -422,20 +528,7 @@ def task_list(
     table.add_column("CREATED")
     table.add_column("PROMPT")
 
-    for task in tasks:
-        status = "?"
-        if manager is not None:
-            try:
-                container = manager.get_container(task.container_id)
-                container.reload()
-                state = container.attrs.get("State", {}) or {}
-                status = state.get("Status", "?")
-                if status == "exited":
-                    code = state.get("ExitCode")
-                    if code is not None:
-                        status = f"exited ({code})"
-            except DockerClientError:
-                status = "removed"
+    for task, status in rows:
         first_line = next((ln for ln in task.prompt.splitlines() if ln.strip()), "")
         prompt_preview = first_line.strip()
         if len(prompt_preview) > 60:
@@ -502,18 +595,20 @@ def task_status(
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
 
-    payload: dict[str, Any] = record.as_dict()
+    payload: dict[str, Any]
     try:
         container = manager.get_container(record.container_id)
         container.reload()
         state = container.attrs.get("State", {}) or {}
-        payload["status"] = state.get("Status")
-        payload["exit_code"] = state.get("ExitCode")
-        payload["started_at"] = state.get("StartedAt")
-        payload["finished_at"] = state.get("FinishedAt")
+        if not isinstance(state, dict):
+            state = {}
+        record = _record_with_container_state(store, record, state)
+        payload = record.as_dict()
     except DockerClientError:
-        payload["status"] = "removed"
-        payload["exit_code"] = None
+        payload = record.as_dict()
+        if record.status not in TERMINAL_TASK_STATUSES:
+            payload["status"] = "removed"
+            payload["exit_code"] = None
 
     if as_json:
         print(_json.dumps(payload, indent=2))

--- a/src/vibepod/core/tasks.py
+++ b/src/vibepod/core/tasks.py
@@ -6,8 +6,18 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 from uuid import uuid4
+
+TASK_STATUS_QUEUED: Final = "queued"
+TASK_STATUS_STARTING: Final = "starting"
+TASK_STATUS_RUNNING: Final = "running"
+TASK_STATUS_COMPLETED: Final = "completed"
+TASK_STATUS_FAILED: Final = "failed"
+TASK_STATUS_CANCELLED: Final = "cancelled"
+TERMINAL_TASK_STATUSES: Final = frozenset(
+    {TASK_STATUS_COMPLETED, TASK_STATUS_FAILED, TASK_STATUS_CANCELLED}
+)
 
 _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS tasks (
@@ -19,12 +29,29 @@ CREATE TABLE IF NOT EXISTS tasks (
     container_name   TEXT NOT NULL,
     image            TEXT NOT NULL,
     vibepod_version  TEXT NOT NULL,
-    created_at       TEXT NOT NULL
+    created_at       TEXT NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'running',
+    exit_code        INTEGER,
+    started_at       TEXT,
+    finished_at      TEXT,
+    updated_at       TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_agent ON tasks(agent);
 CREATE INDEX IF NOT EXISTS idx_tasks_created_at ON tasks(created_at);
 """
+
+_MIGRATION_COLUMNS: Final[dict[str, str]] = {
+    "status": "TEXT NOT NULL DEFAULT 'running'",
+    "exit_code": "INTEGER",
+    "started_at": "TEXT",
+    "finished_at": "TEXT",
+    "updated_at": "TEXT",
+}
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 @dataclass(frozen=True)
@@ -38,6 +65,11 @@ class TaskRecord:
     image: str
     vibepod_version: str
     created_at: str
+    status: str
+    exit_code: int | None
+    started_at: str | None
+    finished_at: str | None
+    updated_at: str
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> TaskRecord:
@@ -51,6 +83,11 @@ class TaskRecord:
             image=row["image"],
             vibepod_version=row["vibepod_version"],
             created_at=row["created_at"],
+            status=row["status"],
+            exit_code=row["exit_code"],
+            started_at=row["started_at"],
+            finished_at=row["finished_at"],
+            updated_at=row["updated_at"],
         )
 
     def as_dict(self) -> dict[str, Any]:
@@ -64,6 +101,11 @@ class TaskRecord:
             "image": self.image,
             "vibepod_version": self.vibepod_version,
             "created_at": self.created_at,
+            "status": self.status,
+            "exit_code": self.exit_code,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "updated_at": self.updated_at,
         }
 
 
@@ -79,7 +121,21 @@ class TaskStore:
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.executescript(_SCHEMA)
+        self._migrate_schema(conn)
         return conn
+
+    def _migrate_schema(self, conn: sqlite3.Connection) -> None:
+        existing = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+        migrated = False
+        for column, definition in _MIGRATION_COLUMNS.items():
+            if column not in existing:
+                conn.execute(f"ALTER TABLE tasks ADD COLUMN {column} {definition}")
+                migrated = True
+        if migrated:
+            conn.execute(
+                "UPDATE tasks SET updated_at = created_at "
+                "WHERE updated_at IS NULL OR updated_at = ''"
+            )
 
     def create(
         self,
@@ -91,15 +147,18 @@ class TaskStore:
         container_name: str,
         image: str,
         vibepod_version: str,
+        status: str = TASK_STATUS_RUNNING,
+        started_at: str | None = None,
     ) -> TaskRecord:
         task_id = uuid4().hex
-        created_at = datetime.now(timezone.utc).isoformat()
+        created_at = _utcnow()
         with self._connect() as conn:
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, agent, prompt, workspace, container_id, container_name, "
-                "image, vibepod_version, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "image, vibepod_version, created_at, status, exit_code, started_at, "
+                "finished_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     task_id,
                     agent,
@@ -109,6 +168,11 @@ class TaskStore:
                     container_name,
                     image,
                     vibepod_version,
+                    created_at,
+                    status,
+                    None,
+                    started_at,
+                    None,
                     created_at,
                 ),
             )
@@ -122,13 +186,16 @@ class TaskStore:
             image=image,
             vibepod_version=vibepod_version,
             created_at=created_at,
+            status=status,
+            exit_code=None,
+            started_at=started_at,
+            finished_at=None,
+            updated_at=created_at,
         )
 
     def get(self, task_id: str) -> TaskRecord | None:
         with self._connect() as conn:
-            row = conn.execute(
-                "SELECT * FROM tasks WHERE id = ?", (task_id,)
-            ).fetchone()
+            row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
         return TaskRecord.from_row(row) if row else None
 
     def find_by_prefix(self, prefix: str) -> list[TaskRecord]:
@@ -155,6 +222,26 @@ class TaskStore:
         with self._connect() as conn:
             rows = conn.execute(query, params).fetchall()
         return [TaskRecord.from_row(row) for row in rows]
+
+    def update(
+        self,
+        task_id: str,
+        *,
+        status: str,
+        exit_code: int | None = None,
+        started_at: str | None = None,
+        finished_at: str | None = None,
+    ) -> TaskRecord | None:
+        updated_at = _utcnow()
+        with self._connect() as conn:
+            cur = conn.execute(
+                "UPDATE tasks SET status = ?, exit_code = ?, started_at = ?, "
+                "finished_at = ?, updated_at = ? WHERE id = ?",
+                (status, exit_code, started_at, finished_at, updated_at, task_id),
+            )
+        if cur.rowcount == 0:
+            return None
+        return self.get(task_id)
 
     def delete(self, task_id: str) -> bool:
         with self._connect() as conn:

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -33,6 +33,7 @@ def tmp_task_store(tmp_path, monkeypatch):
 def fake_ctx():
     """Minimal ctx stand-in for direct task_run() calls (no passthrough args)."""
     import types
+
     return types.SimpleNamespace(args=[])
 
 
@@ -162,9 +163,7 @@ def test_task_run_codex_uses_exec_subcommand(monkeypatch, tmp_path, tmp_task_sto
     assert stub.run_kwargs["command"] == ["codex", "exec", "refactor auth"]
 
 
-def test_task_run_codex_aliases_openai_api_key(
-    monkeypatch, tmp_path, tmp_task_store
-) -> None:
+def test_task_run_codex_aliases_openai_api_key(monkeypatch, tmp_path, tmp_task_store) -> None:
     stub = _CapturingDockerManager()
     cfg = _make_config()
     cfg["agents"]["codex"] = {
@@ -198,9 +197,7 @@ def test_task_run_ikwid_appends_ikwid_args_before_headless_prefix(
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
-    task_cmd.task_run(
-        agent="claude", prompt="do it", workspace=tmp_path, ikwid=True
-    )
+    task_cmd.task_run(agent="claude", prompt="do it", workspace=tmp_path, ikwid=True)
 
     assert stub.run_kwargs["command"] == [
         "claude",
@@ -254,6 +251,7 @@ def test_task_run_records_task_in_store(monkeypatch, tmp_path, tmp_task_store) -
     assert rows[0].agent == "claude"
     assert rows[0].prompt == "do a thing"
     assert rows[0].container_id == "cid123456789012"
+    assert rows[0].status == "running"
 
 
 # ---------------------------------------------------------------------------
@@ -271,7 +269,7 @@ def test_task_list_shows_recorded_tasks(monkeypatch, tmp_task_store) -> None:
         image="vibepod/claude:latest",
         vibepod_version="0.11.0",
     )
-    # Make DockerManager unavailable so list falls back to "?" status (no network calls).
+    # Make DockerManager unavailable so list uses persisted task state (no network calls).
     from vibepod.core.docker import DockerClientError
 
     class _Unavailable:
@@ -284,6 +282,143 @@ def test_task_list_shows_recorded_tasks(monkeypatch, tmp_task_store) -> None:
     assert result.exit_code == 0, result.output
     assert '"agent": "claude"' in result.output
     assert '"prompt": "do a"' in result.output
+
+
+def test_task_status_persists_terminal_container_state(monkeypatch, tmp_task_store) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="done",
+        workspace="/ws",
+        container_id="exited",
+        container_name="vibepod-task-exited",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+
+    class _ExitedContainer:
+        attrs = {
+            "State": {
+                "Status": "exited",
+                "ExitCode": 0,
+                "StartedAt": "2026-06-11T14:00:00Z",
+                "FinishedAt": "2026-06-11T14:05:00Z",
+            }
+        }
+
+        def reload(self) -> None:
+            pass
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            assert name_or_id == "exited"
+            return _ExitedContainer()
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    result = CliRunner().invoke(app, ["task", "status", record.id, "--json"])
+
+    assert result.exit_code == 0, result.output
+    updated = tmp_task_store.get(record.id)
+    assert updated is not None
+    assert updated.status == "completed"
+    assert updated.exit_code == 0
+    assert updated.started_at == "2026-06-11T14:00:00Z"
+    assert updated.finished_at == "2026-06-11T14:05:00Z"
+    assert '"status": "completed"' in result.output
+
+
+def test_task_status_uses_persisted_terminal_state_when_container_removed(
+    monkeypatch, tmp_task_store
+) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="done",
+        workspace="/ws",
+        container_id="gone",
+        container_name="vibepod-task-gone",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+    tmp_task_store.update(
+        record.id,
+        status="failed",
+        exit_code=2,
+        started_at="2026-06-11T14:00:00Z",
+        finished_at="2026-06-11T14:05:00Z",
+    )
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            from vibepod.core.docker import DockerClientError
+
+            raise DockerClientError("gone")
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    result = CliRunner().invoke(app, ["task", "status", record.id[:12], "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"status": "failed"' in result.output
+    assert '"exit_code": 2' in result.output
+
+
+def test_task_list_persists_terminal_container_state(monkeypatch, tmp_task_store) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="done",
+        workspace="/ws",
+        container_id="exited",
+        container_name="vibepod-task-exited",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+
+    class _ExitedContainer:
+        attrs = {"State": {"Status": "exited", "ExitCode": 1}}
+
+        def reload(self) -> None:
+            pass
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            assert name_or_id == "exited"
+            return _ExitedContainer()
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    result = CliRunner().invoke(app, ["task", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    updated = tmp_task_store.get(record.id)
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.exit_code == 1
+    assert '"status": "failed"' in result.output
+
+
+def test_task_list_uses_removed_status_when_container_removed(monkeypatch, tmp_task_store) -> None:
+    tmp_task_store.create(
+        agent="claude",
+        prompt="removed task",
+        workspace="/ws",
+        container_id="gone",
+        container_name="vibepod-task-gone",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            from vibepod.core.docker import DockerClientError
+
+            raise DockerClientError("gone")
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    result = CliRunner().invoke(app, ["task", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"status": "removed"' in result.output
 
 
 def test_task_rm_deletes_store_row_when_container_gone(monkeypatch, tmp_task_store) -> None:
@@ -310,9 +445,7 @@ def test_task_rm_deletes_store_row_when_container_gone(monkeypatch, tmp_task_sto
     assert tmp_task_store.get(record.id) is None
 
 
-def test_task_rm_refuses_running_container_without_force(
-    monkeypatch, tmp_task_store
-) -> None:
+def test_task_rm_refuses_running_container_without_force(monkeypatch, tmp_task_store) -> None:
     record = tmp_task_store.create(
         agent="claude",
         prompt="still going",
@@ -355,9 +488,7 @@ def test_task_rm_all_rejects_task_id(tmp_task_store) -> None:
         task_cmd.task_rm(task_id="abc123", all_tasks=True, force=False)
 
 
-def test_task_rm_all_refuses_running_containers_without_force(
-    monkeypatch, tmp_task_store
-) -> None:
+def test_task_rm_all_refuses_running_containers_without_force(monkeypatch, tmp_task_store) -> None:
     running = tmp_task_store.create(
         agent="claude",
         prompt="still going",
@@ -409,9 +540,7 @@ def test_task_rm_all_refuses_running_containers_without_force(
     assert not containers["stopped"].removed
 
 
-def test_task_rm_all_force_removes_all_records_and_containers(
-    monkeypatch, tmp_task_store
-) -> None:
+def test_task_rm_all_force_removes_all_records_and_containers(monkeypatch, tmp_task_store) -> None:
     running = tmp_task_store.create(
         agent="claude",
         prompt="still going",

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 from vibepod.core.tasks import TaskStore
@@ -32,10 +33,88 @@ def test_create_returns_record_and_persists_row(tmp_path: Path) -> None:
     assert len(record.id) == 32  # uuid4 hex
     assert record.agent == "claude"
     assert record.prompt == "do the thing"
+    assert record.status == "running"
+    assert record.exit_code is None
+    assert record.started_at is None
+    assert record.finished_at is None
+    assert record.updated_at == record.created_at
 
     retrieved = store.get(record.id)
     assert retrieved is not None
     assert retrieved.as_dict() == record.as_dict()
+
+
+def test_update_transitions_lifecycle_state(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    record = store.create(**_new_kwargs())
+
+    updated = store.update(
+        record.id,
+        status="completed",
+        exit_code=0,
+        started_at="2026-06-11T14:00:00Z",
+        finished_at="2026-06-11T14:05:00Z",
+    )
+
+    assert updated is not None
+    assert updated.status == "completed"
+    assert updated.exit_code == 0
+    assert updated.started_at == "2026-06-11T14:00:00Z"
+    assert updated.finished_at == "2026-06-11T14:05:00Z"
+    assert updated.updated_at >= updated.created_at
+    assert store.get(record.id) == updated
+
+
+def test_update_missing_task_returns_none(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+
+    assert store.update("missing", status="failed", exit_code=1) is None
+
+
+def test_existing_database_is_migrated_with_lifecycle_columns(tmp_path: Path) -> None:
+    db_path = tmp_path / "tasks.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE tasks ("
+        "id TEXT PRIMARY KEY, "
+        "agent TEXT NOT NULL, "
+        "prompt TEXT NOT NULL, "
+        "workspace TEXT NOT NULL, "
+        "container_id TEXT NOT NULL, "
+        "container_name TEXT NOT NULL, "
+        "image TEXT NOT NULL, "
+        "vibepod_version TEXT NOT NULL, "
+        "created_at TEXT NOT NULL"
+        ")"
+    )
+    conn.execute(
+        "INSERT INTO tasks "
+        "(id, agent, prompt, workspace, container_id, container_name, image, "
+        "vibepod_version, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "abc123",
+            "claude",
+            "legacy task",
+            "/tmp/ws",
+            "legacy-container",
+            "vibepod-task-legacy",
+            "vibepod/claude:latest",
+            "0.11.0",
+            "2026-06-11T14:00:00+00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    record = TaskStore(db_path).get("abc123")
+
+    assert record is not None
+    assert record.status == "running"
+    assert record.exit_code is None
+    assert record.started_at is None
+    assert record.finished_at is None
+    assert record.updated_at == "2026-06-11T14:00:00+00:00"
 
 
 def test_get_missing_returns_none(tmp_path: Path) -> None:


### PR DESCRIPTION
Implements persistent tracking and synchronization of task/container state in the task management system. It introduces new fields for task status, exit code, and timestamps, synchronizes these with Docker container state, and ensures that terminal (completed/failed/cancelled) states are retained even after containers are removed. The changes also include schema migrations, improved CLI output, and comprehensive tests for these scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks now persist richer lifecycle details (status, exit code, start/finish/updated timestamps), including automatic schema migration for existing records.

* **Bug Fixes**
  * Live task status/exit code refresh now reflects current container state when available.
  * If a container is later missing, previously persisted terminal results are preserved (and non-terminal tasks are marked as removed).

* **Tests**
  * Added/updated CLI and SQLite migration tests to verify lifecycle persistence, terminal-state handling, and updated timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->