### PR TITLE
Add antigravity cli as supported agent

### DIFF
--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -27,6 +27,7 @@ SUPPORTED_AGENTS = (
     "copilot",
     "codex",
     "pi",
+    "agy",
 )
 
 AGENT_SHORTCUTS: dict[str, str] = {
@@ -37,6 +38,7 @@ AGENT_SHORTCUTS: dict[str, str] = {
     "a": "auggie",
     "p": "copilot",
     "x": "codex",
+    "n": "agy",
 }
 
 AGENT_ALIASES: dict[str, str] = {
@@ -53,6 +55,7 @@ IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (
     "VP_IMAGE_COPILOT",
     "VP_IMAGE_CODEX",
     "VP_IMAGE_PI",
+    "VP_IMAGE_AGY",
     "VP_DATASETTE_IMAGE",
     "VP_PROXY_IMAGE",
     "VP_SKILLS_ENGINE_IMAGE",
@@ -105,6 +108,10 @@ def get_default_images() -> dict[str, str]:
         ),
         "pi": os.environ.get(
             "VP_IMAGE_PI", f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/pi:latest"
+        ),
+        "agy": os.environ.get(
+            "VP_IMAGE_AGY",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/agy:latest",
         ),
         "datasette": os.environ.get(
             "VP_DATASETTE_IMAGE",

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -128,6 +128,17 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         {"HOME": "/config", "PI_CODING_AGENT_DIR": "/config/.pi/agent"},
         ikwid_args=["--approve"],
     ),
+    "agy": AgentSpec(
+        "agy",
+        "google",
+        DEFAULT_IMAGES["agy"],
+        "agy",
+        ["agy"],
+        "/home/agy",
+        {"HOME": "/home/agy"},
+        platform="linux/amd64",
+        ikwid_args=["--dangerously-skip-permissions"],
+    ),
 }
 
 _SHORTCUT_BY_AGENT = {agent: shortcut for shortcut, agent in AGENT_SHORTCUTS.items()}

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -99,6 +99,14 @@ def _default_config() -> dict[str, Any]:
                 "volumes": [],
                 "init": [],
             },
+            "agy": {
+                "enabled": True,
+                "image": DEFAULT_IMAGES["agy"],
+                "auto_pull": None,
+                "env": {},
+                "volumes": [],
+                "init": [],
+            },
         },
         "logging": {
             "enabled": True,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from vibepod.constants import AGENT_SHORTCUTS, SUPPORTED_AGENTS
+from vibepod.constants import AGENT_SHORTCUTS, DEFAULT_IMAGES, SUPPORTED_AGENTS
 from vibepod.core.agents import (
     get_agent_shortcut,
     get_agent_spec,
@@ -49,6 +49,18 @@ def test_pi_spec_matches_container_contract() -> None:
     assert spec.config_mount_path == "/config"
     assert spec.extra_env["HOME"] == "/config"
     assert spec.extra_env["PI_CODING_AGENT_DIR"] == "/config/.pi/agent"
+
+
+def test_agy_spec_matches_container_contract() -> None:
+    spec = get_agent_spec("agy")
+    assert spec.id == "agy"
+    assert spec.provider == "google"
+    assert spec.image == DEFAULT_IMAGES["agy"]
+    assert spec.config_subdir == "agy"
+    assert spec.command == ["agy"]
+    assert spec.config_mount_path == "/home/agy"
+    assert spec.extra_env["HOME"] == "/home/agy"
+    assert spec.platform == "linux/amd64"
 
 
 def test_get_agent_spec_unknown() -> None:
@@ -144,6 +156,6 @@ def test_codex_spec_has_llm_env_map() -> None:
 
 
 def test_agents_without_llm_env_map() -> None:
-    for agent in ("gemini", "opencode", "devstral", "auggie", "copilot", "pi"):
+    for agent in ("gemini", "opencode", "devstral", "auggie", "copilot", "pi", "agy"):
         spec = get_agent_spec(agent)
         assert spec.llm_env_map is None, f"{agent} should not have llm_env_map"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -16,6 +16,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
         "VP_IMAGE_COPILOT",
         "VP_IMAGE_CODEX",
         "VP_IMAGE_PI",
+        "VP_IMAGE_AGY",
         "VP_DATASETTE_IMAGE",
         "VP_PROXY_IMAGE",
     ):
@@ -31,6 +32,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
     assert images["copilot"] == "vibepod/copilot:latest"
     assert images["codex"] == "vibepod/codex:latest"
     assert images["pi"] == "vibepod/pi:latest"
+    assert images["agy"] == "vibepod/agy:latest"
     assert images["datasette"] == "vibepod/datasette:latest"
     assert images["proxy"] == "vibepod/proxy:latest"
 
@@ -41,3 +43,11 @@ def test_pi_image_override(monkeypatch) -> None:
     images = get_default_images()
 
     assert images["pi"] == "example/pi:dev"
+
+
+def test_agy_image_override(monkeypatch) -> None:
+    monkeypatch.setenv("VP_IMAGE_AGY", "example/agy:dev")
+
+    images = get_default_images()
+
+    assert images["agy"] == "example/agy:dev"


### PR DESCRIPTION
Adds support for a new agent `antigravity cli` called `agy` to the codebase. The changes include updating the agent configuration, constants, and tests to ensure the new agent is integrated and behaves as expected.

**Agent Integration:**

* Added `agy` to the list of supported agents, agent shortcuts, and environment variable constants in `src/vibepod/constants.py`.
* Updated the `get_default_images` function to include support for the `agy` image, with support for environment variable overrides.

**Agent Specification and Configuration:**

* Defined the `agy` agent in the `AgentSpec` mapping in `src/vibepod/core/agents.py`, specifying its provider, image, command, environment, and platform.
* Updated the default configuration to include the `agy` agent with its image and default settings in `src/vibepod/core/config.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `agy` agent with `"n"` shortcut reference.
  * Configured default container image and runtime environment settings for the `agy` agent.
  * Enabled custom image configuration via environment variable.

* **Tests**
  * Added validation tests for `agy` agent specifications and image configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->