### PR TITLE
Rename task run to task create

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -267,7 +267,7 @@ The argument is resolved as an agent name/shortcut first; anything else is looke
 Run an agent non-interactively as a background task. Claude calls this "headless mode"; codex and auggie expose equivalent flags. VibePod wraps them in a uniform `vp task` command.
 
 ```bash
-vp task run claude "Summarize the README"
+vp task create claude "Summarize the README"
 # ✓ Task started: 9f1e8a20b4c14e2f89d7f6a1c3e42b99
 #   container: vibepod-claude-abcdef12
 #   follow:    vp task logs 9f1e8a20b4c1 --follow
@@ -309,7 +309,7 @@ Task ids can be abbreviated to any unique prefix (e.g., the first 12 chars shown
 Anything after `--` is forwarded to the agent's command after the prompt, matching the CLI's documented form (`claude -p "..." --allowedTools ...`):
 
 ```bash
-vp task run claude "review staged changes" -- --output-format json
+vp task create claude "review staged changes" -- --output-format json
 ```
 
 ### Auto-approval for automation
@@ -317,7 +317,7 @@ vp task run claude "review staged changes" -- --output-format json
 Headless tasks typically need to run without permission prompts. Pass `--ikwid` to apply the agent's documented auto-approve flag (e.g., `--dangerously-skip-permissions` for Claude):
 
 ```bash
-vp task run claude "fix the failing test in auth.py" --ikwid
+vp task create claude "fix the failing test in auth.py" --ikwid
 ```
 
 ### Codex task authentication
@@ -325,7 +325,7 @@ vp task run claude "fix the failing test in auth.py" --ikwid
 `codex exec` reuses saved Codex login state from the mounted config directory when available. For automation and smoke tests, pass `CODEX_API_KEY` explicitly:
 
 ```bash
-vp task run -e CODEX_API_KEY="$OPENAI_API_KEY" --ikwid codex \
+vp task create -e CODEX_API_KEY="$OPENAI_API_KEY" --ikwid codex \
   "Print exactly TASK_OK_CODEX and exit."
 ```
 

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -1,4 +1,4 @@
-"""Task command implementation — run agents headlessly in the background."""
+"""Task command implementation — create headless background agent tasks."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Annotated, Any, cast
+from typing import Annotated, Any
 
 import typer
 from rich.prompt import Confirm
@@ -48,10 +48,9 @@ from vibepod.utils.console import console, error, info, success, warning
 
 app = typer.Typer(
     name="task",
-    help="Run agents headlessly as background tasks",
+    help="Create and manage headless background agent tasks",
     no_args_is_help=True,
 )
-_NO_CONTEXT = cast(typer.Context, None)
 
 
 def _task_store() -> TaskStore:
@@ -147,19 +146,131 @@ def _format_task_status(record: TaskRecord) -> str:
     return record.status
 
 
-def task_run(
-    agent: str,
-    prompt: str,
-    workspace: Path = Path("."),
-    env: list[str] | None = None,
-    name: str | None = None,
-    network: str | None = None,
-    pull: bool = False,
-    ikwid: bool = False,
-    passthrough_args: list[str] | None = None,
+_TASK_CREATE_CONTEXT = {"allow_extra_args": True, "ignore_unknown_options": True}
+
+
+@app.command(
+    "create",
+    context_settings=_TASK_CREATE_CONTEXT,
+)
+def task_create_command(
+    ctx: typer.Context,
+    agent: Annotated[str, typer.Argument(help="Agent to run headlessly")],
+    prompt: Annotated[str, typer.Argument(help="Prompt to send to the agent")],
+    workspace: Annotated[
+        Path, typer.Option("-w", "--workspace", help="Workspace directory")
+    ] = Path("."),
+    env: Annotated[
+        list[str] | None,
+        typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
+    ] = None,
+    name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
+    network: Annotated[
+        str | None,
+        typer.Option("--network", help="Additional Docker network to connect the container to"),
+    ] = None,
+    pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    ikwid: Annotated[
+        bool,
+        typer.Option(
+            "--ikwid",
+            help="I Know What I'm Doing: enable auto-approval flags for supported agents",
+        ),
+    ] = False,
 ) -> None:
     """Start an agent task in the background and print its id."""
-    passthrough_args = list(passthrough_args) if passthrough_args else []
+    task_create(
+        agent=agent,
+        prompt=prompt,
+        workspace=workspace,
+        env=env,
+        name=name,
+        network=network,
+        pull=pull,
+        ikwid=ikwid,
+        passthrough_args=_context_args(ctx),
+    )
+
+
+@app.command(
+    "run",
+    context_settings=_TASK_CREATE_CONTEXT,
+    hidden=True,
+)
+def task_run_command(
+    ctx: typer.Context,
+    agent: Annotated[str, typer.Argument(help="Agent to run headlessly")],
+    prompt: Annotated[str, typer.Argument(help="Prompt to send to the agent")],
+    workspace: Annotated[
+        Path, typer.Option("-w", "--workspace", help="Workspace directory")
+    ] = Path("."),
+    env: Annotated[
+        list[str] | None,
+        typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
+    ] = None,
+    name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
+    network: Annotated[
+        str | None,
+        typer.Option("--network", help="Additional Docker network to connect the container to"),
+    ] = None,
+    pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    ikwid: Annotated[
+        bool,
+        typer.Option(
+            "--ikwid",
+            help="I Know What I'm Doing: enable auto-approval flags for supported agents",
+        ),
+    ] = False,
+) -> None:
+    """Deprecated alias for `task create`."""
+    task_create(
+        agent=agent,
+        prompt=prompt,
+        workspace=workspace,
+        env=env,
+        name=name,
+        network=network,
+        pull=pull,
+        ikwid=ikwid,
+        passthrough_args=_context_args(ctx),
+        deprecated_alias=True,
+    )
+
+
+def task_create(
+    agent: Annotated[str, typer.Argument(help="Agent to run headlessly")],
+    prompt: Annotated[str, typer.Argument(help="Prompt to send to the agent")],
+    workspace: Annotated[
+        Path, typer.Option("-w", "--workspace", help="Workspace directory")
+    ] = Path("."),
+    env: Annotated[
+        list[str] | None,
+        typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
+    ] = None,
+    name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
+    network: Annotated[
+        str | None,
+        typer.Option("--network", help="Additional Docker network to connect the container to"),
+    ] = None,
+    pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    ikwid: Annotated[
+        bool,
+        typer.Option(
+            "--ikwid",
+            help="I Know What I'm Doing: enable auto-approval flags for supported agents",
+        ),
+    ] = False,
+    passthrough_args: list[str] | None = None,
+    deprecated_alias: bool = False,
+) -> None:
+    """Start an agent task in the background and print its id.
+
+    Extra arguments after `--` are forwarded to the agent's command, after the
+    prompt (matches the documented invocation for `claude -p`, `codex exec`, etc).
+    """
+    passthrough_args = list(passthrough_args or [])
+    if deprecated_alias:
+        warning("`vp task run` is deprecated; use `vp task create`.")
 
     config = get_config()
     selected = resolve_agent_name(agent)
@@ -419,53 +530,6 @@ def task_run(
     success(f"Task started: {record.id}")
     info(f"  container: {container.name}")
     info(f"  follow:    vp task logs {record.id[:12]} --follow")
-
-
-@app.command(
-    "run",
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
-)
-def _task_run_cmd(
-    ctx: typer.Context,
-    agent: Annotated[str, typer.Argument(help="Agent to run headlessly")],
-    prompt: Annotated[str, typer.Argument(help="Prompt to send to the agent")],
-    workspace: Annotated[
-        Path, typer.Option("-w", "--workspace", help="Workspace directory")
-    ] = Path("."),
-    env: Annotated[
-        list[str] | None,
-        typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
-    ] = None,
-    name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
-    network: Annotated[
-        str | None,
-        typer.Option("--network", help="Additional Docker network to connect the container to"),
-    ] = None,
-    pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
-    ikwid: Annotated[
-        bool,
-        typer.Option(
-            "--ikwid",
-            help="I Know What I'm Doing: enable auto-approval flags for supported agents",
-        ),
-    ] = False,
-) -> None:
-    """Start an agent task in the background and print its id.
-
-    Extra arguments after `--` are forwarded to the agent's command, after the
-    prompt (matches the documented invocation for `claude -p`, `codex exec`, etc).
-    """
-    task_run(
-        agent=agent,
-        prompt=prompt,
-        workspace=workspace,
-        env=env,
-        name=name,
-        network=network,
-        pull=pull,
-        ikwid=ikwid,
-        passthrough_args=_context_args(ctx),
-    )
 
 
 @app.command("list")

--- a/src/vibepod/core/launch.py
+++ b/src/vibepod/core/launch.py
@@ -1,4 +1,4 @@
-"""Helpers shared by `vp run` and `vp task run` for launching agent containers."""
+"""Helpers shared by `vp run` and `vp task create` for launching agent containers."""
 
 from __future__ import annotations
 

--- a/src/vibepod/core/tasks.py
+++ b/src/vibepod/core/tasks.py
@@ -110,7 +110,7 @@ class TaskRecord:
 
 
 class TaskStore:
-    """Registry of agent tasks. One row per `vp task run` invocation."""
+    """Registry of agent tasks. One row per `vp task create` invocation."""
 
     def __init__(self, db_path: str | Path) -> None:
         self._db_path = Path(db_path)

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -113,39 +113,39 @@ def test_headless_prefix_none_for_unsupported_agents() -> None:
 
 
 # ---------------------------------------------------------------------------
-# task run — agent validation
+# task create — agent validation
 # ---------------------------------------------------------------------------
 
 
-def test_task_run_rejects_unknown_agent(monkeypatch, tmp_path, tmp_task_store) -> None:
+def test_task_create_rejects_unknown_agent(monkeypatch, tmp_path, tmp_task_store) -> None:
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
 
     with pytest.raises(typer.Exit) as exc:
-        task_cmd.task_run(agent="nosuchthing", prompt="hi", workspace=tmp_path)
+        task_cmd.task_create(agent="nosuchthing", prompt="hi", workspace=tmp_path)
     assert exc.value.exit_code == 1
 
 
-def test_task_run_rejects_agent_without_headless_prefix(
+def test_task_create_rejects_agent_without_headless_prefix(
     monkeypatch, tmp_path, tmp_task_store
 ) -> None:
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
 
     with pytest.raises(typer.Exit) as exc:
-        task_cmd.task_run(agent="gemini", prompt="hi", workspace=tmp_path)
+        task_cmd.task_create(agent="gemini", prompt="hi", workspace=tmp_path)
     assert exc.value.exit_code == 1
 
 
 # ---------------------------------------------------------------------------
-# task run — happy path, command shape
+# task create — happy path, command shape
 # ---------------------------------------------------------------------------
 
 
-def test_task_run_claude_builds_headless_command(monkeypatch, tmp_path, tmp_task_store) -> None:
+def test_task_create_claude_builds_headless_command(monkeypatch, tmp_path, tmp_task_store) -> None:
     stub = _CapturingDockerManager()
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
-    task_cmd.task_run(agent="claude", prompt="do the thing", workspace=tmp_path)
+    task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
 
     assert stub.run_kwargs is not None
     assert stub.run_kwargs["command"] == ["claude", "-p", "do the thing"]
@@ -153,17 +153,17 @@ def test_task_run_claude_builds_headless_command(monkeypatch, tmp_path, tmp_task
     assert stub.run_kwargs["agent"] == "claude"
 
 
-def test_task_run_codex_uses_exec_subcommand(monkeypatch, tmp_path, tmp_task_store) -> None:
+def test_task_create_codex_uses_exec_subcommand(monkeypatch, tmp_path, tmp_task_store) -> None:
     stub = _CapturingDockerManager()
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
-    task_cmd.task_run(agent="codex", prompt="refactor auth", workspace=tmp_path)
+    task_cmd.task_create(agent="codex", prompt="refactor auth", workspace=tmp_path)
 
     assert stub.run_kwargs["command"] == ["codex", "exec", "refactor auth"]
 
 
-def test_task_run_codex_aliases_openai_api_key(monkeypatch, tmp_path, tmp_task_store) -> None:
+def test_task_create_codex_aliases_openai_api_key(monkeypatch, tmp_path, tmp_task_store) -> None:
     stub = _CapturingDockerManager()
     cfg = _make_config()
     cfg["agents"]["codex"] = {
@@ -173,31 +173,31 @@ def test_task_run_codex_aliases_openai_api_key(monkeypatch, tmp_path, tmp_task_s
     monkeypatch.setattr(task_cmd, "get_config", lambda: cfg)
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
-    task_cmd.task_run(agent="codex", prompt="say ok", workspace=tmp_path)
+    task_cmd.task_create(agent="codex", prompt="say ok", workspace=tmp_path)
 
     env = stub.run_kwargs["env"]
     assert env["OPENAI_API_KEY"] == "sk-test-key"
     assert env["CODEX_API_KEY"] == "sk-test-key"
 
 
-def test_task_run_auggie_uses_print_flag(monkeypatch, tmp_path, tmp_task_store) -> None:
+def test_task_create_auggie_uses_print_flag(monkeypatch, tmp_path, tmp_task_store) -> None:
     stub = _CapturingDockerManager()
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
-    task_cmd.task_run(agent="auggie", prompt="run tests", workspace=tmp_path)
+    task_cmd.task_create(agent="auggie", prompt="run tests", workspace=tmp_path)
 
     assert stub.run_kwargs["command"] == ["auggie", "--print", "run tests"]
 
 
-def test_task_run_ikwid_appends_ikwid_args_before_headless_prefix(
+def test_task_create_ikwid_appends_ikwid_args_before_headless_prefix(
     monkeypatch, tmp_path, tmp_task_store
 ) -> None:
     stub = _CapturingDockerManager()
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
-    task_cmd.task_run(agent="claude", prompt="do it", workspace=tmp_path, ikwid=True)
+    task_cmd.task_create(agent="claude", prompt="do it", workspace=tmp_path, ikwid=True)
 
     assert stub.run_kwargs["command"] == [
         "claude",
@@ -207,7 +207,7 @@ def test_task_run_ikwid_appends_ikwid_args_before_headless_prefix(
     ]
 
 
-def test_task_run_passthrough_args_appended_after_prompt(
+def test_task_create_passthrough_args_appended_after_prompt(
     monkeypatch, tmp_path, tmp_task_store
 ) -> None:
     """Extra args after `--` are appended to the agent's command after the prompt."""
@@ -219,7 +219,7 @@ def test_task_run_passthrough_args_appended_after_prompt(
         app,
         [
             "task",
-            "run",
+            "create",
             "-w",
             str(tmp_path),
             "claude",
@@ -239,12 +239,28 @@ def test_task_run_passthrough_args_appended_after_prompt(
     ]
 
 
-def test_task_run_records_task_in_store(monkeypatch, tmp_path, tmp_task_store) -> None:
+def test_task_run_alias_still_starts_task(monkeypatch, tmp_path, tmp_task_store) -> None:
     stub = _CapturingDockerManager()
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
-    task_cmd.task_run(agent="claude", prompt="do a thing", workspace=tmp_path)
+    result = CliRunner().invoke(
+        app,
+        ["task", "run", "-w", str(tmp_path), "claude", "summarize"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.output
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["command"] == ["claude", "-p", "summarize"]
+
+
+def test_task_create_records_task_in_store(monkeypatch, tmp_path, tmp_task_store) -> None:
+    stub = _CapturingDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    task_cmd.task_create(agent="claude", prompt="do a thing", workspace=tmp_path)
 
     rows = tmp_task_store.list()
     assert len(rows) == 1

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -61,7 +61,7 @@ def test_update_transitions_lifecycle_state(tmp_path: Path) -> None:
     assert updated.exit_code == 0
     assert updated.started_at == "2026-06-11T14:00:00Z"
     assert updated.finished_at == "2026-06-11T14:05:00Z"
-    assert updated.updated_at >= updated.created_at
+    assert updated.updated_at > record.updated_at
     assert store.get(record.id) == updated
 
 


### PR DESCRIPTION
Updates the headless agent task functionality to deprecate the old `vp task run` command in favor of the new `vp task create` command, ensuring consistency across the codebase, documentation, and tests. The changes introduce `create` as the primary subcommand for launching background agent tasks, while keeping `run` as a hidden alias that warns users of its deprecation. All related documentation, code comments, and tests have been updated to reflect this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `vp task create` as the primary way to start headless background agent tasks.
  * Kept `vp task run` as a hidden/deprecated alias that still starts tasks but shows a deprecation notice.
  * Improved CLI argument passthrough so extra options after `--` are forwarded as expected.
* **Documentation**
  * Updated task-mode examples and authentication examples to use `vp task create`.
* **Tests**
  * Updated and expanded CLI and task-store tests to cover the new command flow and stricter timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->