### PR TITLE
Add task timeout guardrail

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -275,6 +275,8 @@ vp task create claude "Summarize the README"
 
 The command starts a detached container, writes a row to `~/.config/vibepod/tasks.db`, and returns a task id. The container is **not** auto-removed, so you can inspect logs and exit status after it finishes.
 
+Task mode applies a finite timeout by default: **2 hours**. Override it per task with `--timeout 30m`, `--timeout 4h`, or another `s`/`m`/`h` duration. Use `--timeout none` only when you explicitly want an unlimited background task.
+
 ### Supported agents (v1)
 
 | Agent | Invocation inside container |
@@ -310,6 +312,8 @@ Anything after `--` is forwarded to the agent's command after the prompt, matchi
 
 ```bash
 vp task create claude "review staged changes" -- --output-format json
+vp task create --timeout 30m claude "run the fast audit"
+vp task create --timeout none claude "wait for the external job"
 ```
 
 ### Auto-approval for automation
@@ -335,6 +339,7 @@ For compatibility, Codex task mode also maps an explicitly supplied `OPENAI_API_
 
 - **No `--resume` in v1.** Task mode starts a fresh session every time. Use the agent's own resume flag via passthrough (`-- --resume <session_id>` for Claude) if you need continuity.
 - **LLM config model flag is skipped in task mode.** `llm.base_url` / `llm.api_key` / `llm.model` are still injected as env vars, but the `--model`-style CLI flag is not appended — different agents place it differently relative to subcommands. Pass an explicit model via `--`.
+- **Default timeout: 2 hours.** On timeout, VibePod gracefully stops the container and records the task as failed. Pass `--timeout none` to opt out for one task.
 - **Task containers are not auto-removed.** Run `vp task rm <id>` when you're done inspecting one task, or `vp task rm --all -f` to clean up every recorded task and its container.
 
 ## Reattaching a terminal

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json as _json
 import os
+import subprocess
 import sys
 import time
+from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -147,6 +150,114 @@ def _format_task_status(record: TaskRecord) -> str:
 
 
 _TASK_CREATE_CONTEXT = {"allow_extra_args": True, "ignore_unknown_options": True}
+DEFAULT_TASK_TIMEOUT = "2h"
+DEFAULT_TASK_TIMEOUT_SECONDS = 2 * 60 * 60
+_DURATION_UNITS = {"s": 1, "m": 60, "h": 60 * 60}
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_task_timeout(value: str) -> int | None:
+    raw = value.strip().lower()
+    if raw == "none":
+        return None
+    if not raw:
+        raise typer.BadParameter("Timeout must be a duration like 30m or 2h, or 'none'.")
+
+    unit = raw[-1]
+    multiplier = 1
+    number = raw
+    if unit.isalpha():
+        if unit not in _DURATION_UNITS:
+            raise typer.BadParameter("Timeout unit must be one of: s, m, h.")
+        multiplier = _DURATION_UNITS[unit]
+        number = raw[:-1]
+
+    try:
+        amount = int(number)
+    except ValueError as exc:
+        raise typer.BadParameter("Timeout must be a duration like 30m or 2h, or 'none'.") from exc
+    if amount <= 0:
+        raise typer.BadParameter("Timeout must be greater than zero, or 'none'.")
+    return amount * multiplier
+
+
+def _start_timeout_watcher(task_id: str, timeout_seconds: int) -> None:
+    subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "vibepod.cli",
+            "task",
+            "_watch-timeout",
+            task_id,
+            str(timeout_seconds),
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        close_fds=True,
+    )
+
+
+def _enforce_task_timeout(
+    task_id: str,
+    timeout_seconds: int,
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    sleep(timeout_seconds)
+
+    store = _task_store()
+    record = store.get(task_id)
+    if record is None or record.status in TERMINAL_TASK_STATUSES:
+        return
+
+    try:
+        manager = DockerManager()
+        container = manager.get_container(record.container_id)
+        container.reload()
+        state = container.attrs.get("State", {}) or {}
+        if not isinstance(state, dict):
+            state = {}
+        record = _record_with_container_state(store, record, state)
+    except DockerClientError:
+        if record.status not in TERMINAL_TASK_STATUSES:
+            store.update(
+                record.id,
+                status=TASK_STATUS_FAILED,
+                exit_code=record.exit_code,
+                started_at=record.started_at,
+                finished_at=_utcnow(),
+            )
+        return
+
+    if record.status in TERMINAL_TASK_STATUSES:
+        return
+
+    try:
+        container.stop(timeout=10)
+    except Exception as exc:  # docker SDK raises APIError / DockerException
+        warning(f"Failed to stop timed-out task {record.id[:12]}: {exc}")
+    store.update(
+        record.id,
+        status=TASK_STATUS_FAILED,
+        exit_code=record.exit_code,
+        started_at=record.started_at,
+        finished_at=_utcnow(),
+    )
+
+
+@app.command("_watch-timeout", hidden=True)
+def task_watch_timeout(
+    task_id: Annotated[str, typer.Argument(help="Task id to enforce")],
+    timeout_seconds: Annotated[int, typer.Argument(help="Timeout in seconds")],
+) -> None:
+    """Internal helper launched by `vp task create --timeout`."""
+    _enforce_task_timeout(task_id, timeout_seconds)
 
 
 @app.command(
@@ -169,6 +280,16 @@ def task_create_command(
         str | None,
         typer.Option("--network", help="Additional Docker network to connect the container to"),
     ] = None,
+    timeout: Annotated[
+        str,
+        typer.Option(
+            "--timeout",
+            help=(
+                "Maximum task runtime before graceful stop. "
+                "Use s/m/h suffixes, or 'none' to opt out."
+            ),
+        ),
+    ] = DEFAULT_TASK_TIMEOUT,
     pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
     ikwid: Annotated[
         bool,
@@ -186,6 +307,7 @@ def task_create_command(
         env=env,
         name=name,
         network=network,
+        timeout=timeout,
         pull=pull,
         ikwid=ikwid,
         passthrough_args=_context_args(ctx),
@@ -213,6 +335,16 @@ def task_run_command(
         str | None,
         typer.Option("--network", help="Additional Docker network to connect the container to"),
     ] = None,
+    timeout: Annotated[
+        str,
+        typer.Option(
+            "--timeout",
+            help=(
+                "Maximum task runtime before graceful stop. "
+                "Use s/m/h suffixes, or 'none' to opt out."
+            ),
+        ),
+    ] = DEFAULT_TASK_TIMEOUT,
     pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
     ikwid: Annotated[
         bool,
@@ -230,6 +362,7 @@ def task_run_command(
         env=env,
         name=name,
         network=network,
+        timeout=timeout,
         pull=pull,
         ikwid=ikwid,
         passthrough_args=_context_args(ctx),
@@ -252,6 +385,16 @@ def task_create(
         str | None,
         typer.Option("--network", help="Additional Docker network to connect the container to"),
     ] = None,
+    timeout: Annotated[
+        str,
+        typer.Option(
+            "--timeout",
+            help=(
+                "Maximum task runtime before graceful stop. "
+                "Use s/m/h suffixes, or 'none' to opt out."
+            ),
+        ),
+    ] = DEFAULT_TASK_TIMEOUT,
     pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
     ikwid: Annotated[
         bool,
@@ -271,6 +414,7 @@ def task_create(
     passthrough_args = list(passthrough_args or [])
     if deprecated_alias:
         warning("`vp task run` is deprecated; use `vp task create`.")
+    timeout_seconds = _parse_task_timeout(timeout)
 
     config = get_config()
     selected = resolve_agent_name(agent)
@@ -529,6 +673,11 @@ def task_create(
         raise typer.Exit(1) from exc
     success(f"Task started: {record.id}")
     info(f"  container: {container.name}")
+    if timeout_seconds is None:
+        info("  timeout:   none")
+    else:
+        _start_timeout_watcher(record.id, timeout_seconds)
+        info(f"  timeout:   {timeout} ({timeout_seconds}s)")
     info(f"  follow:    vp task logs {record.id[:12]} --follow")
 
 

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -19,6 +19,11 @@ from vibepod.core.tasks import TaskStore
 @pytest.fixture(autouse=True)
 def _allow_all_dirs(monkeypatch):
     monkeypatch.setattr(task_cmd, "is_dir_allowed", lambda p: True)
+    monkeypatch.setattr(
+        task_cmd,
+        "_start_timeout_watcher",
+        lambda task_id, timeout_seconds: None,
+    )
 
 
 @pytest.fixture
@@ -268,6 +273,107 @@ def test_task_create_records_task_in_store(monkeypatch, tmp_path, tmp_task_store
     assert rows[0].prompt == "do a thing"
     assert rows[0].container_id == "cid123456789012"
     assert rows[0].status == "running"
+
+
+def test_task_create_starts_default_timeout_watcher(monkeypatch, tmp_path, tmp_task_store) -> None:
+    stub = _CapturingDockerManager()
+    launched: list[tuple[str, int]] = []
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(
+        task_cmd,
+        "_start_timeout_watcher",
+        lambda task_id, timeout_seconds: launched.append((task_id, timeout_seconds)),
+    )
+
+    task_cmd.task_create(agent="claude", prompt="do a thing", workspace=tmp_path)
+
+    rows = tmp_task_store.list()
+    assert launched == [(rows[0].id, 7200)]
+
+
+def test_task_create_accepts_timeout_override(monkeypatch, tmp_path, tmp_task_store) -> None:
+    stub = _CapturingDockerManager()
+    launched: list[tuple[str, int]] = []
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(
+        task_cmd,
+        "_start_timeout_watcher",
+        lambda task_id, timeout_seconds: launched.append((task_id, timeout_seconds)),
+    )
+
+    task_cmd.task_create(
+        agent="claude",
+        prompt="do a thing",
+        workspace=tmp_path,
+        timeout="30m",
+    )
+
+    rows = tmp_task_store.list()
+    assert launched == [(rows[0].id, 1800)]
+
+
+def test_task_create_timeout_none_disables_watcher(monkeypatch, tmp_path, tmp_task_store) -> None:
+    stub = _CapturingDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(
+        task_cmd,
+        "_start_timeout_watcher",
+        lambda task_id, timeout_seconds: pytest.fail("watcher should not start"),
+    )
+
+    task_cmd.task_create(
+        agent="claude",
+        prompt="do a thing",
+        workspace=tmp_path,
+        timeout="none",
+    )
+
+
+def test_timeout_watcher_stops_running_container_and_marks_failed(
+    monkeypatch, tmp_task_store
+) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="run forever",
+        workspace="/ws",
+        container_id="running",
+        container_name="vibepod-task-running",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+
+    class _RunningContainer:
+        status = "running"
+        attrs = {"State": {"Status": "running"}}
+
+        def __init__(self) -> None:
+            self.stop_timeout: int | None = None
+
+        def reload(self) -> None:
+            pass
+
+        def stop(self, timeout: int = 10) -> None:
+            self.stop_timeout = timeout
+
+    container = _RunningContainer()
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            assert name_or_id == "running"
+            return container
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    task_cmd._enforce_task_timeout(record.id, 30, sleep=lambda seconds: None)
+
+    updated = tmp_task_store.get(record.id)
+    assert container.stop_timeout == 10
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.finished_at is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Introduces a default timeout for tasks created with `vp task create`, improving resource management and preventing runaway background jobs. The timeout is configurable per task, and comprehensive tests are added to ensure correct behavior. Documentation is updated to reflect the new feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks now support configurable timeouts with a 2-hour default; users can customize the duration or disable limits entirely.

* **Documentation**
  * Updated Task mode documentation with timeout behavior details, default values, and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->