### PR TITLE
Extend docs for antigravity cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 
 - ⚡ **Zero config** — no setup required; `vp run <agent>` just works. Optional YAML for custom configuration
 - 🐳 **Isolated agents** — each agent runs in its own Docker container
-- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi & more
+- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy & more
 - 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics
 - ⚖️ **Agent comparison** — benchmark multiple agents against each other in the dashboard
@@ -65,6 +65,7 @@ Use `--ikwid` to append each agent's auto-approval / permission-skip flag when s
 | `copilot` | `--yolo` |
 | `codex` | `--dangerously-bypass-approvals-and-sandbox` |
 | `pi` | `--approve` |
+| `agy` | `--dangerously-skip-permissions` |
 | `opencode` | Not supported |
 | `auggie` | Not supported |
 
@@ -126,6 +127,7 @@ Current defaults:
 - `copilot` -> `vibepod/copilot:latest`
 - `codex` -> `vibepod/codex:latest`
 - `pi` -> `vibepod/pi:latest`
+- `agy` -> `vibepod/agy:latest`
 - `datasette` -> `vibepod/datasette:latest`
 - `proxy` -> `vibepod/proxy:latest` ([repo](https://github.com/VibePod/vibepod-proxy))
 
@@ -143,6 +145,7 @@ VP_IMAGE_AUGGIE=vibepod/auggie:latest vp run auggie
 VP_IMAGE_COPILOT=vibepod/copilot:latest vp run copilot
 VP_IMAGE_CODEX=vibepod/codex:latest vp run codex
 VP_IMAGE_PI=vibepod/pi:latest vp run pi
+VP_IMAGE_AGY=vibepod/agy:latest vp run agy
 VP_DATASETTE_IMAGE=vibepod/datasette:latest vp logs start
 VP_SKILLS_ENGINE_IMAGE=vibepod/skills-engine:latest vp skills list
 ```

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -14,6 +14,7 @@ VibePod manages each agent as a Docker container. Credentials and config are per
 | `copilot` | GitHub | `vp p` | `vibepod/copilot:latest` |
 | `codex` | OpenAI | `vp x` | `vibepod/codex:latest` |
 | `pi` | Earendil | `vp pi` | `vibepod/pi:latest` |
+| `agy` (Antigravity) | Google | `vp n` | `vibepod/agy:latest` |
 
 Alias note: `vp run vibe` resolves to `vp run devstral`.
 
@@ -74,7 +75,7 @@ agents:
 
 ## Image customization workflows
 
-VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`). The CLI also supports the alias `vibe`, which resolves to `devstral`. Image customization means changing the image used for one of those IDs.
+VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`). The CLI also supports the alias `vibe`, which resolves to `devstral`. Image customization means changing the image used for one of those IDs.
 
 ### 1. Extend an existing image for an agent
 
@@ -197,6 +198,7 @@ Use `--ikwid` to enable each agent's built-in auto-approval / permission-skip mo
 | `copilot` | `--yolo` |
 | `codex` | `--dangerously-bypass-approvals-and-sandbox` |
 | `pi` | `--approve` |
+| `agy` | `--dangerously-skip-permissions` |
 | `opencode` | Not supported |
 | `auggie` | Not supported |
 
@@ -595,3 +597,19 @@ Pi has a per-project **trust/approval system**: before loading project-local ext
 - Interactive: run `/trust` to save the decision. It is written to `PI_CODING_AGENT_DIR` (`/config/.pi/agent/trust.json`), which lives inside the persisted config mount, so the trust survives container restarts.
 - `--ikwid`: appends `--approve`, trusting project-local files for that run (see [IKWID mode](#ikwid-mode---ikwid)).
 - Non-interactive modes (`-p`, `--mode json`, `--mode rpc`) show no prompt and fall back to `defaultProjectTrust` in `/config/.pi/agent/settings.json` (`ask` | `always` | `never`). Pre-seed this file if you need unattended runs to trust projects automatically.
+
+### Agy / Antigravity (Google)
+
+```bash
+vp run agy   # or: vp n
+```
+
+Agy runs Google's Antigravity CLI in the same isolated VibePod container
+workflow. Credentials and configuration are persisted under
+`~/.config/vibepod/agents/agy/` and mounted at `/home/agy` inside the container.
+
+Use `--ikwid` to append Agy's permission-skip flag:
+
+```bash
+vp run agy --ikwid
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,13 @@ agents:
     volumes: []
     init: []
 
+  agy:
+    enabled: true
+    image: vibepod/agy:latest
+    env: {}
+    volumes: []
+    init: []
+
 # Connect agents to a local or remote LLM server (Ollama, vLLM, etc.)
 llm:
   enabled: false
@@ -146,6 +153,7 @@ Each agent image can be overridden individually:
 | `VP_IMAGE_COPILOT` | copilot |
 | `VP_IMAGE_CODEX` | codex |
 | `VP_IMAGE_PI` | pi |
+| `VP_IMAGE_AGY` | agy |
 | `VP_DATASETTE_IMAGE` | datasette (logs UI) |
 | `VP_PROXY_IMAGE` | proxy |
 | `VP_SKILLS_ENGINE_IMAGE` | skills-engine (used by `vp skills`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker 
 
 ## Why VibePod?
 
-- **One tool, all agents** — switch between Claude, Gemini, Devstral, Codex, Pi, and more without juggling separate CLIs or global installs.
+- **One tool, all agents** — switch between Claude, Gemini, Devstral, Codex, Pi, Agy, and more without juggling separate CLIs or global installs.
 - **Isolated by default** — each agent runs in its own container. No global npm packages, no credential bleed between sessions.
 - **Workspace-aware** — mount any directory as the workspace at runtime. Works with monorepos, multiple projects, and Docker Compose setups.
 - **Built-in observability** — session logging and an HTTP proxy are included out of the box. Browse all agent traffic in Datasette at `localhost:8001`.
@@ -23,6 +23,7 @@ VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker 
 | `copilot` | GitHub | `vp p` |
 | `codex` | OpenAI | `vp x` |
 | `pi` | Earendil | `vp pi` |
+| `agy` (Antigravity) | Google | `vp n` |
 
 ## Next Steps
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,7 +41,8 @@ Press **Ctrl+C** to stop the container when you are done.
 ## Shortcuts
 
 You can start agents with the full agent command. Most agents also have a single-letter
-shortcut; Pi uses `vp pi` because `vp p` is assigned to Copilot.
+shortcut; Pi uses `vp pi` because `vp p` is assigned to Copilot, and Agy uses
+`vp n`.
 
 ```bash
 vp claude   # full name


### PR DESCRIPTION
Adds support and documentation for the new `agy` (Antigravity) agent, integrating it throughout the VibePod documentation and configuration. The changes ensure that `agy` is treated as a first-class agent alongside existing ones, with clear instructions for usage, configuration, and permission handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Agy (Antigravity) agent from Google, accessible via the `vp n` CLI shortcut

* **Documentation**
  * Updated all reference documentation with Agy agent details: configuration reference, `VP_IMAGE_AGY` environment variable for custom images, credential handling, and permission-skip options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->