### PR TITLE
Add task cancel command

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -300,6 +300,7 @@ vp task logs <id>                # dump captured stdout/stderr
 vp task logs <id> --follow       # stream
 
 vp task status <id>              # state, exit code, timestamps
+vp task cancel <id>              # gracefully stop a running task, keeping logs
 vp task rm <id>                  # remove task + its (stopped) container
 vp task rm <id> -f               # kill running container before removing
 vp task rm --all                 # remove all stopped/finished tasks

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -39,6 +39,7 @@ from vibepod.core.launch import (
     update_container_mapping,
 )
 from vibepod.core.tasks import (
+    TASK_STATUS_CANCELLED,
     TASK_STATUS_COMPLETED,
     TASK_STATUS_FAILED,
     TASK_STATUS_RUNNING,
@@ -123,6 +124,8 @@ def _record_with_container_state(
     record: TaskRecord,
     state: dict[str, Any],
 ) -> TaskRecord:
+    if record.status == TASK_STATUS_CANCELLED:
+        return record
     status, exit_code, started_at, finished_at = _task_state_from_docker(state)
     if (
         record.status == status
@@ -710,7 +713,7 @@ def task_list(
     for task in tasks:
         record = task
         display_status = _format_task_status(record)
-        if manager is not None:
+        if manager is not None and record.status != TASK_STATUS_CANCELLED:
             try:
                 container = manager.get_container(record.container_id)
                 container.reload()
@@ -809,19 +812,22 @@ def task_status(
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
 
     payload: dict[str, Any]
-    try:
-        container = manager.get_container(record.container_id)
-        container.reload()
-        state = container.attrs.get("State", {}) or {}
-        if not isinstance(state, dict):
-            state = {}
-        record = _record_with_container_state(store, record, state)
+    if record.status == TASK_STATUS_CANCELLED:
         payload = record.as_dict()
-    except DockerClientError:
-        payload = record.as_dict()
-        if record.status not in TERMINAL_TASK_STATUSES:
-            payload["status"] = "removed"
-            payload["exit_code"] = None
+    else:
+        try:
+            container = manager.get_container(record.container_id)
+            container.reload()
+            state = container.attrs.get("State", {}) or {}
+            if not isinstance(state, dict):
+                state = {}
+            record = _record_with_container_state(store, record, state)
+            payload = record.as_dict()
+        except DockerClientError:
+            payload = record.as_dict()
+            if record.status not in TERMINAL_TASK_STATUSES:
+                payload["status"] = "removed"
+                payload["exit_code"] = None
 
     if as_json:
         print(_json.dumps(payload, indent=2))
@@ -835,6 +841,90 @@ def task_status(
     if payload.get("exit_code") is not None:
         info(f"Exit code:  {payload['exit_code']}")
     info(f"Created:    {record.created_at}")
+
+
+@app.command("cancel")
+def task_cancel(
+    task_id: Annotated[str, typer.Argument(help="Task id (full or prefix)")],
+) -> None:
+    """Gracefully stop a running task while keeping its record and logs."""
+    store = _task_store()
+    record = _resolve_task(store, task_id)
+
+    if record.status in TERMINAL_TASK_STATUSES:
+        info(f"Task {record.id[:12]} already finished with status: {record.status}")
+        return
+
+    try:
+        manager = DockerManager()
+    except DockerClientError as exc:
+        error(str(exc))
+        raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
+
+    try:
+        container = manager.get_container(record.container_id)
+        container.reload()
+        state = container.attrs.get("State", {}) or {}
+        if not isinstance(state, dict):
+            state = {}
+        record = _record_with_container_state(store, record, state)
+    except DockerClientError:
+        store.update(
+            record.id,
+            status=TASK_STATUS_FAILED,
+            exit_code=record.exit_code,
+            started_at=record.started_at,
+            finished_at=_utcnow(),
+        )
+        error(
+            f"Container for this task is gone. "
+            f"Use `vp task rm {record.id[:12]}` to remove the stale registry entry."
+        )
+        raise typer.Exit(0) from None
+
+    if record.status in TERMINAL_TASK_STATUSES:
+        info(f"Task {record.id[:12]} already finished with status: {record.status}")
+        return
+
+    if getattr(container, "status", "") in {"running", "restarting", "paused"}:
+        try:
+            container.stop(timeout=10)
+        except Exception as exc:  # docker SDK raises APIError / DockerException
+            try:
+                container.reload()
+                status = getattr(container, "status", "")
+            except Exception:
+                status = ""
+            if status in {"exited", "dead"}:
+                state = container.attrs.get("State", {}) or {}
+                if not isinstance(state, dict):
+                    state = {}
+                record = _record_with_container_state(store, record, state)
+            else:
+                error(f"Failed to cancel task {record.id[:12]}: {exc}")
+                raise typer.Exit(1) from exc
+    elif getattr(container, "status", "") == "created":
+        try:
+            container.remove(force=True)
+        except Exception as exc:
+            error(f"Failed to remove created task container {record.id[:12]}: {exc}")
+            raise typer.Exit(1) from exc
+
+    updated: TaskRecord | None
+    if record.status in TERMINAL_TASK_STATUSES:
+        updated = record
+    else:
+        updated = store.update(
+            record.id,
+            status=TASK_STATUS_CANCELLED,
+            exit_code=record.exit_code,
+            started_at=record.started_at,
+            finished_at=_utcnow(),
+        )
+    if updated is None:
+        error(f"Task {record.id[:12]} disappeared before it could be cancelled.")
+        raise typer.Exit(1)
+    success(f"Cancelled task {updated.id[:12]}")
 
 
 @app.command("rm")

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -543,7 +543,239 @@ def test_task_list_uses_removed_status_when_container_removed(monkeypatch, tmp_t
     assert '"status": "removed"' in result.output
 
 
+def test_task_cancel_stops_running_container_and_keeps_record(monkeypatch, tmp_task_store) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="stop me",
+        workspace="/ws",
+        container_id="running",
+        container_name="vibepod-task-running",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+
+    class _RunningContainer:
+        status = "running"
+        attrs = {"State": {"Status": "running"}}
+
+        def __init__(self) -> None:
+            self.stop_timeout: int | None = None
+            self.remove_called = False
+
+        def reload(self) -> None:
+            pass
+
+        def stop(self, timeout: int = 10) -> None:
+            self.stop_timeout = timeout
+
+        def remove(self, force: bool = False) -> None:  # pragma: no cover
+            self.remove_called = True
+
+    container = _RunningContainer()
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            assert name_or_id == "running"
+            return container
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    task_cmd.task_cancel(task_id=record.id[:12])
+
+    updated = tmp_task_store.get(record.id)
+    assert container.stop_timeout == 10
+    assert container.remove_called is False
+    assert updated is not None
+    assert updated.status == "cancelled"
+    assert updated.finished_at is not None
+
+
+def test_task_cancel_noops_for_already_finished_task(monkeypatch, tmp_task_store) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="done",
+        workspace="/ws",
+        container_id="done",
+        container_name="vibepod-task-done",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+    tmp_task_store.update(
+        record.id,
+        status="completed",
+        exit_code=0,
+        started_at="2026-06-11T14:00:00Z",
+        finished_at="2026-06-11T14:05:00Z",
+    )
+
+    class _Manager:
+        def get_container(self, name_or_id: str):  # pragma: no cover
+            raise AssertionError("finished tasks should not query Docker")
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    task_cmd.task_cancel(task_id=record.id[:12])
+
+    updated = tmp_task_store.get(record.id)
+    assert updated is not None
+    assert updated.status == "completed"
+    assert updated.exit_code == 0
+
+
+def test_task_list_and_status_preserve_cancelled_status(monkeypatch, tmp_task_store) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="cancelled task",
+        workspace="/ws",
+        container_id="cancelled-ctr",
+        container_name="vibepod-task-cancelled",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+    tmp_task_store.update(
+        record.id,
+        status="cancelled",
+        exit_code=None,
+        started_at="2026-06-11T14:00:00Z",
+        finished_at="2026-06-11T14:05:00Z",
+    )
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            raise AssertionError("cancelled tasks should not query Docker")
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    # 1. Test task list
+    result_list = CliRunner().invoke(app, ["task", "list", "--json"])
+    assert result_list.exit_code == 0, result_list.output
+    assert '"status": "cancelled"' in result_list.output
+
+    # 2. Test task status
+    result_status = CliRunner().invoke(app, ["task", "status", record.id[:12], "--json"])
+    assert result_status.exit_code == 0, result_status.output
+    assert '"status": "cancelled"' in result_status.output
+
+
+def test_task_cancel_handles_created_container_by_removing_it(monkeypatch, tmp_task_store) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="stuck created",
+        workspace="/ws",
+        container_id="created-ctr",
+        container_name="vibepod-task-created",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+
+    class _CreatedContainer:
+        status = "created"
+        attrs = {"State": {"Status": "created"}}
+
+        def __init__(self) -> None:
+            self.remove_called = False
+
+        def reload(self) -> None:
+            pass
+
+        def stop(self, timeout: int = 10) -> None:
+            raise AssertionError("should not stop a created container")
+
+        def remove(self, force: bool = False) -> None:
+            self.remove_called = True
+
+    container = _CreatedContainer()
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            assert name_or_id == "created-ctr"
+            return container
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    task_cmd.task_cancel(task_id=record.id[:12])
+
+    updated = tmp_task_store.get(record.id)
+    assert container.remove_called is True
+    assert updated is not None
+    assert updated.status == "cancelled"
+
+
+def test_task_cancel_handles_missing_container_gracefully(monkeypatch, tmp_task_store) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="missing container",
+        workspace="/ws",
+        container_id="missing-ctr",
+        container_name="vibepod-task-missing",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            from vibepod.core.docker import DockerClientError
+
+            raise DockerClientError("Container not found")
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    with pytest.raises(typer.Exit) as exc_info:
+        task_cmd.task_cancel(task_id=record.id[:12])
+
+    assert exc_info.value.exit_code == 0
+    updated = tmp_task_store.get(record.id)
+    assert updated is not None
+    assert updated.status == "failed"
+
+
+def test_task_cancel_ignores_stop_exception_if_container_reaches_terminal_state(
+    monkeypatch, tmp_task_store
+) -> None:
+    record = tmp_task_store.create(
+        agent="claude",
+        prompt="race condition",
+        workspace="/ws",
+        container_id="race-ctr",
+        container_name="vibepod-task-race",
+        image="vibepod/claude:latest",
+        vibepod_version="0.11.0",
+    )
+
+    class _RaceContainer:
+        status = "running"
+        attrs = {"State": {"Status": "running"}}
+
+        def __init__(self) -> None:
+            self.stop_called = False
+
+        def reload(self) -> None:
+            if self.stop_called:
+                self.status = "exited"
+                self.attrs = {"State": {"Status": "exited", "ExitCode": 1}}
+
+        def stop(self, timeout: int = 10) -> None:
+            self.stop_called = True
+            raise RuntimeError("Container is not running")
+
+    container = _RaceContainer()
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            assert name_or_id == "race-ctr"
+            return container
+
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: _Manager())
+
+    task_cmd.task_cancel(task_id=record.id[:12])
+
+    updated = tmp_task_store.get(record.id)
+    assert updated is not None
+    assert updated.status == "failed"
+
+
 def test_task_rm_deletes_store_row_when_container_gone(monkeypatch, tmp_task_store) -> None:
+
     record = tmp_task_store.create(
         agent="claude",
         prompt="gone",


### PR DESCRIPTION
Adds a new `cancel` command to the task management CLI, allowing users to gracefully stop running tasks while preserving their logs and records. It also includes tests to ensure correct behavior and updates the documentation to reflect the new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `vp task cancel <id>` to gracefully stop headless background tasks, refresh their state, and mark them as cancelled while retaining captured logs.
* **Bug Fixes**
  * `task list` and `task status` now avoid unnecessary container re-synchronization for tasks already marked as cancelled.
* **Documentation**
  * Updated Agents “Managing tasks” documentation to include the new `vp task cancel` command.
* **Tests**
  * Expanded unit tests for running, created, completed (Docker-free no-op), missing-container, and stop-race behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->