### PR TITLE
Wire rootless Podman keep-id, docs and networking

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,3 +227,10 @@ Or at runtime:
 ```bash
 VP_PROXY_ENABLED=false vp run claude
 ```
+
+!!! note "Podman users"
+    The proxy relies on container-name DNS resolution over the `vibepod-network`
+    network. If you use Podman with the CNI backend, install the `dnsname`
+    plugin (e.g. `podman-plugins` on Fedora, `golang-github-containernetworking-plugin-dnsname`
+    on Debian/Ubuntu) and recreate the network. See [Quickstart — Using Podman](quickstart.md#using-podman-instead-of-docker) for full instructions.
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,7 +3,64 @@
 ## Prerequisites
 
 - Python 3.10+
-- Docker (running)
+- Docker **or** Podman (running)
+
+### Using Podman instead of Docker
+
+VibePod auto-detects rootless Podman and applies the necessary user-namespace
+settings (`keep-id`) so workspace file permissions work correctly.
+
+Point VibePod at the Podman socket by setting `DOCKER_HOST`:
+
+```bash
+export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
+```
+
+!!! warning "Container DNS required"
+    VibePod routes agent traffic through a `vibepod-proxy` container. The agent
+    resolves the proxy by container name over the `vibepod-network` network,
+    which requires **DNS** to be enabled.
+
+    If your Podman installation uses the **CNI** network backend, you must
+    install the `dnsname` plugin — otherwise DNS is disabled and the proxy
+    will be unreachable.
+
+    === "Fedora / RHEL"
+
+        ```bash
+        sudo dnf install podman-plugins
+        ```
+
+    === "Ubuntu / Debian"
+
+        ```bash
+        sudo apt install golang-github-containernetworking-plugin-dnsname
+        ```
+
+    === "Arch"
+
+        ```bash
+        sudo pacman -S podman-dnsname
+        ```
+
+    After installing, recreate the network so DNS takes effect:
+
+    ```bash
+    podman network rm vibepod-network 2>/dev/null
+    podman network create vibepod-network
+    ```
+
+    Verify with:
+
+    ```bash
+    podman network inspect vibepod-network --format '{{.DNSEnabled}}'
+    # Should print: true
+    ```
+
+    **Alternatively**, switch to the [Netavark](https://github.com/containers/netavark)
+    network backend (Podman 4.0+), which includes DNS out of the box. See
+    `podman info --format '{{.Host.NetworkBackend}}'` to check your current
+    backend.
 
 ## Install
 

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -375,6 +375,13 @@ def run(
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
 
+    podman_probe = getattr(manager, "is_rootless_podman", None)
+    rootless_podman = bool(podman_probe()) if callable(podman_probe) else False
+    agent_userns_mode = "keep-id" if rootless_podman else None
+    if rootless_podman:
+        merged_env["USER_UID"] = "0"
+        merged_env["USER_GID"] = "0"
+
     network_name = str(config.get("network", "vibepod-network"))
     manager.ensure_network(network_name)
     extra_network = network or _maybe_select_network(workspace_path, manager, network_name)
@@ -495,7 +502,9 @@ def run(
             extra_volumes.append((str(proxy_ca_dir), "/etc/vibepod-proxy-ca", "ro"))
 
     info(f"Starting {selected_agent} with image {image}")
-    container_user = _host_user() if spec.run_as_host_user else None
+    container_user = None
+    if not rootless_podman and spec.run_as_host_user:
+        container_user = _host_user()
     container = manager.run_agent(
         agent=selected_agent,
         image=image,
@@ -513,6 +522,7 @@ def run(
         platform=spec.platform,
         user=container_user,
         entrypoint=entrypoint,
+        userns_mode=agent_userns_mode,
     )
 
     container.reload()

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -510,6 +510,13 @@ def task_create(
         error(str(exc))
         raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
 
+    podman_probe = getattr(manager, "is_rootless_podman", None)
+    rootless_podman = bool(podman_probe()) if callable(podman_probe) else False
+    agent_userns_mode = "keep-id" if rootless_podman else None
+    if rootless_podman:
+        merged_env["USER_UID"] = "0"
+        merged_env["USER_GID"] = "0"
+
     network_name = str(config.get("network", "vibepod-network"))
     manager.ensure_network(network_name)
 
@@ -605,7 +612,9 @@ def task_create(
         extra_volumes.append((str(actual_ca_dir), "/etc/vibepod-proxy-ca", "ro"))
 
     info(f"Starting task on {selected} with image {image}")
-    container_user = host_user() if spec.run_as_host_user else None
+    container_user = None
+    if not rootless_podman and spec.run_as_host_user:
+        container_user = host_user()
     container = manager.run_agent(
         agent=selected,
         image=image,
@@ -622,6 +631,7 @@ def task_create(
         platform=spec.platform,
         user=container_user,
         entrypoint=entrypoint,
+        userns_mode=agent_userns_mode,
     )
 
     container.reload()

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -511,10 +511,11 @@ class DockerManager:
             "extra_hosts": {"host.docker.internal": "host-gateway"},
         }
 
-        getuid = getattr(os, "getuid", None)
-        getgid = getattr(os, "getgid", None)
-        if callable(getuid) and callable(getgid):
-            run_kwargs["user"] = f"{getuid()}:{getgid()}"
+        if not self.is_rootless_podman():
+            getuid = getattr(os, "getuid", None)
+            getgid = getattr(os, "getgid", None)
+            if callable(getuid) and callable(getgid):
+                run_kwargs["user"] = f"{getuid()}:{getgid()}"
 
         return self.client.containers.run(**run_kwargs)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -867,8 +867,8 @@ def test_run_preserves_host_user_for_non_podman_devstral(
     config["agents"]["devstral"] = {"env": {}, "init": []}
     monkeypatch.setattr(run_cmd, "get_config", lambda: config)
     monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
-    monkeypatch.setattr(run_cmd.os, "getuid", lambda: 1234)
-    monkeypatch.setattr(run_cmd.os, "getgid", lambda: 5678)
+    monkeypatch.setattr(run_cmd.os, "getuid", lambda: 1234, raising=False)
+    monkeypatch.setattr(run_cmd.os, "getgid", lambda: 5678, raising=False)
 
     run_cmd.run(agent="devstral", workspace=tmp_path, detach=True)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -14,7 +14,7 @@ from typer.testing import CliRunner
 
 from vibepod.cli import app
 from vibepod.commands import run as run_cmd
-from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
+from vibepod.constants import EXIT_DOCKER_NOT_RUNNING, SUPPORTED_AGENTS
 from vibepod.core import skills_engine
 from vibepod.core.docker import DockerClientError, DockerManager
 
@@ -781,10 +781,12 @@ def test_resolve_launch_command_requires_non_empty_process() -> None:
 
 
 class _StubDockerManager:
-    """Minimal DockerManager stub that records pull_image calls."""
+    """Minimal DockerManager stub that records pull_image and run_agent calls."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, rootless_podman: bool = False) -> None:
         self.pulled: list[str] = []
+        self.rootless_podman = rootless_podman
+        self.run_kwargs: dict | None = None
         self._container = type(
             "_Container",
             (),
@@ -802,6 +804,9 @@ class _StubDockerManager:
     def ensure_network(self, name: str) -> None:
         pass
 
+    def is_rootless_podman(self) -> bool:
+        return self.rootless_podman
+
     def pull_image(self, image: str) -> None:
         self.pulled.append(image)
 
@@ -809,6 +814,7 @@ class _StubDockerManager:
         pass
 
     def run_agent(self, **kwargs) -> object:  # type: ignore[no-untyped-def]
+        self.run_kwargs = kwargs
         return self._container
 
     def networks_with_running_containers(self) -> list[str]:
@@ -831,6 +837,47 @@ def _make_config(
         "proxy": {"enabled": False},
         "logging": {"enabled": False},
     }
+
+
+@pytest.mark.parametrize("agent", SUPPORTED_AGENTS)
+def test_run_uses_keep_id_for_rootless_podman_agents(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, agent: str
+) -> None:
+    stub = _StubDockerManager(rootless_podman=True)
+    config = _make_config()
+    config["agents"][agent] = {"env": {}, "init": []}
+    monkeypatch.setattr(run_cmd, "get_config", lambda: config)
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    run_cmd.run(agent=agent, workspace=tmp_path, detach=True)
+
+    assert stub.run_kwargs is not None
+    env = stub.run_kwargs["env"]
+    assert stub.run_kwargs["userns_mode"] == "keep-id"
+    assert stub.run_kwargs["user"] is None
+    assert env["USER_UID"] == "0"
+    assert env["USER_GID"] == "0"
+
+
+def test_run_preserves_host_user_for_non_podman_devstral(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    stub = _StubDockerManager(rootless_podman=False)
+    config = _make_config()
+    config["agents"]["devstral"] = {"env": {}, "init": []}
+    monkeypatch.setattr(run_cmd, "get_config", lambda: config)
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(run_cmd.os, "getuid", lambda: 1234)
+    monkeypatch.setattr(run_cmd.os, "getgid", lambda: 5678)
+
+    run_cmd.run(agent="devstral", workspace=tmp_path, detach=True)
+
+    assert stub.run_kwargs is not None
+    env = stub.run_kwargs["env"]
+    assert stub.run_kwargs["userns_mode"] is None
+    assert stub.run_kwargs["user"] == "1234:5678"
+    assert env["USER_UID"] == "1234"
+    assert env["USER_GID"] == "5678"
 
 
 def test_cli_run_forwards_extra_args_to_agent_command(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -987,3 +987,45 @@ def test_task_resolve_unknown_id_errors(monkeypatch, tmp_task_store) -> None:
     with pytest.raises(typer.Exit) as exc:
         task_cmd.task_rm(task_id="deadbeef", force=False)
     assert exc.value.exit_code == 1
+
+
+def test_task_create_uses_keep_id_on_rootless_podman(monkeypatch, tmp_path, tmp_task_store) -> None:
+    class _PodmanDockerManager(_CapturingDockerManager):
+        def is_rootless_podman(self) -> bool:
+            return True
+
+    stub = _PodmanDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
+
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["userns_mode"] == "keep-id"
+    assert stub.run_kwargs["user"] is None
+    assert stub.run_kwargs["env"]["USER_UID"] == "0"
+    assert stub.run_kwargs["env"]["USER_GID"] == "0"
+
+
+def test_task_create_preserves_host_user_for_non_podman(monkeypatch, tmp_path, tmp_task_store) -> None:
+    import os
+    class _DockerDockerManager(_CapturingDockerManager):
+        def is_rootless_podman(self) -> bool:
+            return False
+
+    stub = _DockerDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    spec = task_cmd.get_agent_spec("claude")
+    monkeypatch.setattr(spec, "run_as_host_user", True)
+    monkeypatch.setattr(os, "getuid", lambda: 1234, raising=False)
+    monkeypatch.setattr(os, "getgid", lambda: 5678, raising=False)
+
+    task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
+
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["userns_mode"] is None
+    assert stub.run_kwargs["user"] == "1234:5678"
+    assert stub.run_kwargs["env"]["USER_UID"] == "1234"
+    assert stub.run_kwargs["env"]["USER_GID"] == "5678"

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -1007,7 +1007,9 @@ def test_task_create_uses_keep_id_on_rootless_podman(monkeypatch, tmp_path, tmp_
     assert stub.run_kwargs["env"]["USER_GID"] == "0"
 
 
-def test_task_create_preserves_host_user_for_non_podman(monkeypatch, tmp_path, tmp_task_store) -> None:
+def test_task_create_preserves_host_user_for_non_podman(
+    monkeypatch, tmp_path, tmp_task_store
+) -> None:
     import os
     class _DockerDockerManager(_CapturingDockerManager):
         def is_rootless_podman(self) -> bool:
@@ -1017,8 +1019,17 @@ def test_task_create_preserves_host_user_for_non_podman(monkeypatch, tmp_path, t
     monkeypatch.setattr(task_cmd, "get_config", _make_config)
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
-    spec = task_cmd.get_agent_spec("claude")
-    monkeypatch.setattr(spec, "run_as_host_user", True)
+    import dataclasses
+    original_get_agent_spec = task_cmd.get_agent_spec
+    spec = original_get_agent_spec("claude")
+    modified_spec = dataclasses.replace(spec, run_as_host_user=True)
+    monkeypatch.setattr(
+        task_cmd,
+        "get_agent_spec",
+        lambda agent: (
+            modified_spec if agent == "claude" else original_get_agent_spec(agent)
+        ),
+    )
     monkeypatch.setattr(os, "getuid", lambda: 1234, raising=False)
     monkeypatch.setattr(os, "getgid", lambda: 5678, raising=False)
 


### PR DESCRIPTION
Introduces robust support for running VibePod with Podman, particularly in rootless environments, by auto-detecting Podman engines and adjusting container user and namespace settings for compatibility. It updates the documentation to guide users through Podman setup, ensures correct runtime behavior for agent containers, and adds comprehensive tests for these scenarios.

Example:

```
DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock vp run opencode
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Podman container runtime support with automatic rootless mode detection and user namespace configuration.

* **Documentation**
  * Updated prerequisites to include Podman as a supported container runtime.
  * Added Podman setup guide covering rootless configuration, DNS requirements, and network backend options.
  * Included dnsname plugin installation and Netavark backend setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->