### PR TITLE
Handle client close errors on python 3.14

### DIFF
--- a/src/vibepod/cli.py
+++ b/src/vibepod/cli.py
@@ -20,7 +20,10 @@ from vibepod.commands import (
     task,
     update,
 )
+from vibepod.compat import install_python314_http_client_flush_patch
 from vibepod.constants import AGENT_SHORTCUTS, SUPPORTED_AGENTS
+
+install_python314_http_client_flush_patch()
 
 app = typer.Typer(
     name="vp",

--- a/src/vibepod/compat.py
+++ b/src/vibepod/compat.py
@@ -1,0 +1,48 @@
+"""Runtime compatibility shims for supported Python versions."""
+
+from __future__ import annotations
+
+import http.client
+import sys
+
+_HTTP_RESPONSE_FLUSH_PATCH_ATTR = "_vibepod_python314_closed_file_patch"
+_CLOSED_FILE_ERROR = "I/O operation on closed file."
+
+
+def should_ignore_closed_http_response_flush_error(
+    response: object, exc: BaseException
+) -> bool:
+    """Return True for Python 3.14's closed ``HTTPResponse.fp`` flush cleanup error.
+
+    Python 3.14 can surface a ``ValueError`` while finalizing Docker SDK / urllib3
+    HTTP responses if ``HTTPResponse.fp`` is still set but the underlying file is
+    already closed. The command has already completed at that point; suppress only
+    that exact cleanup edge case.
+    """
+    if not isinstance(exc, ValueError) or str(exc) != _CLOSED_FILE_ERROR:
+        return False
+    fp = getattr(response, "fp", None)
+    return bool(getattr(fp, "closed", False))
+
+
+def install_python314_http_client_flush_patch() -> None:
+    """Suppress a Python 3.14 stdlib cleanup edge case seen through Docker SDK."""
+    if sys.version_info < (3, 14):
+        return
+
+    current_flush = http.client.HTTPResponse.flush
+    if bool(getattr(current_flush, _HTTP_RESPONSE_FLUSH_PATCH_ATTR, False)):
+        return
+
+    original_flush = current_flush
+
+    def _flush(self: http.client.HTTPResponse) -> None:
+        try:
+            original_flush(self)
+        except ValueError as exc:
+            if should_ignore_closed_http_response_flush_error(self, exc):
+                return
+            raise
+
+    setattr(_flush, _HTTP_RESPONSE_FLUSH_PATCH_ATTR, True)
+    setattr(http.client.HTTPResponse, "flush", _flush)  # noqa: B010

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
 from typer.testing import CliRunner
 
+from vibepod import compat as compat_module
 from vibepod.cli import app
 from vibepod.commands import run as run_cmd
+from vibepod.compat import (
+    install_python314_http_client_flush_patch,
+    should_ignore_closed_http_response_flush_error,
+)
 
 runner = CliRunner()
 
@@ -20,6 +28,66 @@ def test_version() -> None:
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert "VibePod CLI" in result.stdout
+
+
+def test_python314_http_response_flush_filter_matches_closed_fp_error() -> None:
+    response = SimpleNamespace(fp=SimpleNamespace(closed=True))
+    exc = ValueError("I/O operation on closed file.")
+
+    assert should_ignore_closed_http_response_flush_error(response, exc) is True
+
+
+def test_python314_http_response_flush_filter_does_not_hide_other_errors() -> None:
+    closed_response = SimpleNamespace(fp=SimpleNamespace(closed=True))
+    open_response = SimpleNamespace(fp=SimpleNamespace(closed=False))
+
+    assert (
+        should_ignore_closed_http_response_flush_error(
+            closed_response, ValueError("different error")
+        )
+        is False
+    )
+    assert (
+        should_ignore_closed_http_response_flush_error(
+            open_response, ValueError("I/O operation on closed file.")
+        )
+        is False
+    )
+    assert (
+        should_ignore_closed_http_response_flush_error(
+            closed_response, RuntimeError("I/O operation on closed file.")
+        )
+        is False
+    )
+
+
+def test_python314_http_response_flush_patch_suppresses_closed_fp_error(monkeypatch) -> None:
+    def broken_flush(self) -> None:  # noqa: ANN001
+        raise ValueError("I/O operation on closed file.")
+
+    monkeypatch.setattr(compat_module.sys, "version_info", (3, 14))
+    monkeypatch.setattr(compat_module.http.client.HTTPResponse, "flush", broken_flush)
+
+    install_python314_http_client_flush_patch()
+
+    response = SimpleNamespace(fp=SimpleNamespace(closed=True))
+    compat_module.http.client.HTTPResponse.flush(response)  # type: ignore[arg-type]
+
+
+def test_python314_http_response_flush_patch_reraises_non_matching_value_error(
+    monkeypatch,
+) -> None:
+    def broken_flush(self) -> None:  # noqa: ANN001
+        raise ValueError("I/O operation on closed file.")
+
+    monkeypatch.setattr(compat_module.sys, "version_info", (3, 14))
+    monkeypatch.setattr(compat_module.http.client.HTTPResponse, "flush", broken_flush)
+
+    install_python314_http_client_flush_patch()
+
+    response = SimpleNamespace(fp=SimpleNamespace(closed=False))
+    with pytest.raises(ValueError, match="I/O operation on closed file"):
+        compat_module.http.client.HTTPResponse.flush(response)  # type: ignore[arg-type]
 
 
 def test_full_agent_name_alias_runs_agent(monkeypatch) -> None:


### PR DESCRIPTION
Compatibility patch for Python 3.14 to suppress a specific `ValueError` related to closed HTTP response file pointers, which can occur when using the Docker SDK. The patch is implemented in `vibepod/cli.py` and is thoroughly tested with new unit tests in `tests/test_cli.py`.

Python 3.14 compatibility patch:

* Added `_install_python314_http_client_flush_patch` and `_should_ignore_closed_http_response_flush_error` functions to `vibepod/cli.py` to suppress the "I/O operation on closed file." error raised during HTTP response cleanup in Python 3.14. The patch is applied automatically at module import.
* Imported `http.client` and `sys` in `vibepod/cli.py` to support the new patch logic.
