### PR TITLE
Adapt docs for 0.17.0, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
 </p>
 
 VibePod is a unified CLI (`vp`) for running AI coding agents in isolated
-Docker containers — no required configuration, no setup. Just
+Docker or Podman containers — no required configuration, no setup. Just
 `vp run <agent>`. Includes built-in local metrics collection, HTTP traffic
 tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 
 ## Features
 
 - ⚡ **Zero config** — no setup required; `vp run <agent>` just works. Optional YAML for custom configuration
-- 🐳 **Isolated agents** — each agent runs in its own Docker container
+- 🐳 **Isolated agents** — each agent runs in its own Docker or Podman container
 - 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy & more
 - 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,6 +1,6 @@
 # Agents
 
-VibePod manages each agent as a Docker container. Credentials and config are persisted to `~/.config/vibepod/agents/<agent>/` on your host and mounted into the container on every run, so you only need to authenticate once.
+VibePod manages each agent as a Docker or Podman container. Credentials and config are persisted to `~/.config/vibepod/agents/<agent>/` on your host and mounted into the container on every run, so you only need to authenticate once.
 
 ## Supported Agents
 
@@ -24,7 +24,7 @@ Start any agent for the first time with `vp run <agent>`. The container will pro
 
 ## Auto-pulling the latest image
 
-VibePod automatically pulls the latest image for an agent before every run. This ensures you always start with the most up-to-date container without manual intervention.
+VibePod automatically pulls the latest image for an agent before every run and shows pull progress while layers download. This ensures you always start with the most up-to-date container without manual intervention.
 
 To disable auto-pull globally:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # VibePod
 
-**One CLI for all AI coding agents — running in Docker containers.**
+**One CLI for all AI coding agents — running in Docker or Podman containers.**
 
-VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker container, pointed at any workspace directory, with a single command. Agent credentials, config, and session logs are persisted across runs without touching your host environment.
+VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker or Podman container, pointed at any workspace directory, with a single command. Agent credentials, config, and session logs are persisted across runs without touching your host environment.
 
 ## Why VibePod?
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -88,7 +88,7 @@ vp run claude
 VibePod will:
 
 1. Pull the agent image if not already present.
-2. Create a dedicated Docker network (`vibepod-network`).
+2. Create a dedicated Docker or Podman network (`vibepod-network`).
 3. Mount your current directory as the workspace inside the container.
 4. Start the agent container and attach your terminal to it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vibepod"
-version = "0.16.0"
+version = "0.17.0"
 description = "One CLI for containerized AI coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/vibepod/__init__.py
+++ b/src/vibepod/__init__.py
@@ -1,3 +1,3 @@
 """VibePod package."""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from platformdirs import user_config_dir
 
 APP_NAME = "vibepod"
-VERSION = "0.16.0"
+VERSION = "0.17.0"
 
 CONFIG_DIR = Path(user_config_dir(APP_NAME))
 GLOBAL_CONFIG_FILE = CONFIG_DIR / "config.yaml"


### PR DESCRIPTION
Updates VibePod to support both Docker and Podman containers throughout the documentation and user-facing descriptions. It also improves the auto-pull experience by displaying pull progress and bumps the version to 0.17.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded container support to include both Docker and Podman for running agents.
  * Improved visibility during image pulls by showing download progress before each run.

* **Documentation**
  * Updated the README and guides to reflect Docker/Podman support and clarify setup steps.
  * Refined quickstart instructions for creating the required network.

* **Chores**
  * Bumped the release version to 0.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->