### PR TITLE
Remove dangling vibepod images after pulling new ones

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,15 @@ default_agent: claude
 # Can be overridden per agent with agents.<agent>.auto_pull
 auto_pull: true
 
+# Remove untagged vibepod images after a pull (default: true)
+# When a pull retags `latest`, the previous image stays behind untagged
+# (`vibepod/claude   <none>`) and such images accumulate over time. With
+# auto_clean every pull sweeps the whole `vibepod/` namespace, so leftovers
+# from earlier pulls are cleared too. Tagged images, images of other
+# namespaces, and images still used by a container are never removed — an
+# image held by a container is picked up by a later sweep instead.
+auto_clean: true
+
 # Remove the container automatically when it stops (default: true)
 auto_remove: true
 
@@ -129,6 +138,7 @@ These variables override the corresponding config keys without editing any file:
 |---|---|---|
 | `VP_DEFAULT_AGENT` | `default_agent` | `VP_DEFAULT_AGENT=vibe` |
 | `VP_AUTO_PULL` | `auto_pull` | `VP_AUTO_PULL=true` |
+| `VP_AUTO_CLEAN` | `auto_clean` | `VP_AUTO_CLEAN=false` |
 | `VP_LOG_LEVEL` | `log_level` | `VP_LOG_LEVEL=debug` |
 | `VP_NO_COLOR` | `no_color` | `VP_NO_COLOR=true` |
 | `VP_DATASETTE_PORT` | `logging.ui_port` | `VP_DATASETTE_PORT=9001` |

--- a/src/vibepod/commands/logs.py
+++ b/src/vibepod/commands/logs.py
@@ -63,12 +63,15 @@ def logs_start(
 
     if _is_latest_tag(datasette_image):
         info("Checking for datasette image updates…")
-        updated = manager.pull_if_newer(datasette_image)
-        if updated:
+        if manager.pull_if_newer(datasette_image):
             info("New image available — restarting datasette")
             existing = manager.find_datasette()
             if existing:
                 existing.remove(force=True)
+        if bool(config.get("auto_clean", True)):
+            # Swept here, not during the pull: only after the old container is
+            # gone can Docker drop the image it was holding.
+            manager.clean_untagged_images()
 
     info(f"Starting Datasette on http://localhost:{datasette_port}")
     manager.ensure_datasette(

--- a/src/vibepod/commands/proxy.py
+++ b/src/vibepod/commands/proxy.py
@@ -42,9 +42,16 @@ def proxy_start() -> None:
 
     manager.ensure_network(network_name)
 
+    auto_clean = bool(config.get("auto_clean", True))
+    updated = False
     if _is_latest_tag(proxy_image):
         info("Checking for proxy image updates…")
-        manager.pull_if_newer(proxy_image)
+        updated = manager.pull_if_newer(proxy_image)
+        if updated:
+            info("New image available — restarting proxy")
+            existing = manager.find_proxy()
+            if existing:
+                existing.remove(force=True)
 
     info("Starting proxy")
     manager.ensure_proxy(
@@ -53,6 +60,10 @@ def proxy_start() -> None:
         ca_dir=ca_dir,
         network=network_name,
     )
+    if auto_clean:
+        # Swept last: the replaced image is only removable once the proxy
+        # container that held it has been recreated on the new one.
+        manager.clean_untagged_images()
     success("Proxy is running")
 
 

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -396,7 +396,7 @@ def run(
     should_pull = pull or (auto_pull_enabled and _is_latest_tag(image))
     if should_pull:
         info(f"Pulling image: {image}")
-        manager.pull_image(image)
+        manager.pull_image(image, auto_clean=bool(config.get("auto_clean", True)))
 
     command = spec.command
     entrypoint: list[str] | None = None
@@ -477,7 +477,7 @@ def run(
         )
 
         if _is_latest_tag(proxy_image):
-            manager.pull_if_newer(proxy_image)
+            manager.pull_if_newer(proxy_image, auto_clean=bool(config.get("auto_clean", True)))
 
         manager.ensure_proxy(
             image=proxy_image,

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -527,7 +527,7 @@ def task_create(
     should_pull = pull or (auto_pull_enabled and _is_latest_tag(image))
     if should_pull:
         info(f"Pulling image: {image}")
-        manager.pull_image(image)
+        manager.pull_image(image, auto_clean=bool(config.get("auto_clean", True)))
 
     base_command = spec.command
     entrypoint: list[str] | None = None
@@ -582,7 +582,7 @@ def task_create(
         )
 
         if _is_latest_tag(proxy_image):
-            manager.pull_if_newer(proxy_image)
+            manager.pull_if_newer(proxy_image, auto_clean=bool(config.get("auto_clean", True)))
 
         actual_ca_dir = proxy_ca_dir or proxy_db_path.parent / "mitmproxy"
         manager.ensure_proxy(

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -30,6 +30,7 @@ def _default_config() -> dict[str, Any]:
         "version": 1,
         "default_agent": "claude",
         "auto_pull": True,
+        "auto_clean": True,
         "auto_remove": True,
         "network": "vibepod-network",
         "log_level": "info",
@@ -164,6 +165,7 @@ def _apply_env(config: dict[str, Any]) -> dict[str, Any]:
     mappings: dict[str, tuple[str, Any]] = {
         "VP_DEFAULT_AGENT": ("default_agent", str),
         "VP_AUTO_PULL": ("auto_pull", lambda x: x.lower() == "true"),
+        "VP_AUTO_CLEAN": ("auto_clean", lambda x: x.lower() == "true"),
         "VP_LOG_LEVEL": ("log_level", str),
         "VP_NO_COLOR": ("no_color", lambda x: x.lower() == "true"),
         "VP_DATASETTE_PORT": ("logging.ui_port", int),

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -66,6 +66,9 @@ _PODMAN_HINT = (
     "or point DOCKER_HOST at the Podman socket."
 )
 
+#: Image namespace owned by vibepod; the only one auto_clean ever sweeps.
+IMAGE_NAMESPACE = "vibepod"
+
 
 def _run_podman(podman: str, args: list[str]) -> str | None:
     """Run a Podman subcommand, returning its trimmed stdout on success."""
@@ -192,6 +195,24 @@ def _version_is_podman(version: Any) -> bool:
         return True
 
     return "podman" in str(version.get("Name", "")).lower()
+
+
+def _reference_namespace(reference: str) -> str | None:
+    """Return the namespace of an image *reference*, ignoring registry and digest.
+
+    ``vibepod/claude@sha256:…`` and ``ghcr.io/vibepod/claude@sha256:…`` both
+    yield ``vibepod``. A bare ``python@sha256:…`` has no namespace, and neither
+    has a deeper path such as ``ghcr.io/acme/vibepod/tool`` — that repository
+    belongs to ``acme``, not to us.
+    """
+    repository = reference.split("@", 1)[0]
+    parts = repository.split("/")
+    if len(parts) > 2 and ("." in parts[0] or ":" in parts[0] or parts[0] == "localhost"):
+        # Drop the registry host; what remains must be exactly <namespace>/<image>.
+        parts = parts[1:]
+    if len(parts) != 2:
+        return None
+    return parts[0]
 
 
 def _parse_image_name(image: str) -> tuple[str, str | None]:
@@ -341,33 +362,75 @@ class DockerManager:
                 raise DockerClientError(f"Failed to pull image {image}: {exc}") from exc
             raise DockerClientError(f"Failed to pull image {image}: {exc}") from exc
 
-    def pull_image(self, image: str) -> None:
+    def pull_image(self, image: str, auto_clean: bool = False) -> None:
         self._pull_image_with_progress(image)
+        if auto_clean:
+            self.clean_untagged_images()
 
-    def pull_if_newer(self, image: str) -> bool:
+    def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
         """Pull *image* and return True if the local image was updated.
 
         Returns False when the image is already up to date, when the pull
         fails (e.g. no network / private registry), or when the image only
         exists locally and cannot be found on a registry.
+
+        With *auto_clean*, untagged images left behind by this and earlier
+        pulls are swept afterwards (see :meth:`clean_untagged_images`).
         """
         try:
-            old_id: str | None
-            try:
-                old_id = self.client.images.get(image).id
-            except NotFound:
-                old_id = None
-
+            old_id = self.image_id(image)
             self.pull_image(image)
-
-            try:
-                new_id = self.client.images.get(image).id
-            except NotFound:
+            new_id = self.image_id(image)
+            if new_id is None:
                 return False
 
+            if auto_clean:
+                self.clean_untagged_images()
             return bool(old_id != new_id)
         except (APIError, DockerClientError):
             return False
+
+    def image_id(self, image: str) -> str | None:
+        """Return the local id of *image*, or None when it cannot be determined."""
+        try:
+            return str(self.client.images.get(image).id)
+        except DockerException:
+            # Covers NotFound and any transient daemon error: callers treat a
+            # missing id as "no confirmed image", never as a failure to report.
+            return None
+
+    def clean_untagged_images(self, namespace: str = IMAGE_NAMESPACE) -> int:
+        """Remove untagged *namespace* images and return how many were removed.
+
+        A pull that moves the ``latest`` tag leaves the previous image behind
+        with no tag but with its repository digest intact, so it still shows up
+        as ``vibepod/claude <none>``. Sweeping the whole namespace — rather
+        than only the image just replaced — also clears leftovers from earlier
+        pulls whose removal failed because a container still held them.
+
+        Images that are still tagged, that belong to another namespace, or that
+        cannot be attributed to one are never touched. Docker refuses to remove
+        images used by a container (running or stopped); those stay and are
+        retried by the next sweep.
+        """
+        try:
+            images = self.client.images.list()
+        except DockerException:
+            return 0
+
+        removed = 0
+        for image in images:
+            if image.tags:
+                continue
+            digests = image.attrs.get("RepoDigests") or []
+            if not any(_reference_namespace(str(digest)) == namespace for digest in digests):
+                continue
+            try:
+                self.client.images.remove(str(image.id))
+            except DockerException:
+                continue
+            removed += 1
+        return removed
 
     def ensure_network(self, name: str) -> None:
         try:

--- a/src/vibepod/core/skills_engine.py
+++ b/src/vibepod/core/skills_engine.py
@@ -138,12 +138,18 @@ def run_engine(
             )
 
             if not image_exists:
-                manager.pull_image(SKILLS_ENGINE_IMAGE)
+                manager.pull_image(
+                    SKILLS_ENGINE_IMAGE,
+                    auto_clean=bool(config.get("auto_clean", True)),
+                )
             elif auto_pull_enabled and is_latest:
                 try:
                     from vibepod.utils.console import info
                     info("Checking for skills-engine image updates…")
-                    manager.pull_if_newer(SKILLS_ENGINE_IMAGE)
+                    manager.pull_if_newer(
+                        SKILLS_ENGINE_IMAGE,
+                        auto_clean=bool(config.get("auto_clean", True)),
+                    )
                 except Exception:
                     pass
             _skills_engine_checked = True

--- a/tests/integration/test_runtime_smoke.py
+++ b/tests/integration/test_runtime_smoke.py
@@ -19,12 +19,13 @@ from unittest.mock import patch
 
 import pytest
 
-from vibepod.core.docker import DockerClientError, DockerException, DockerManager
+from vibepod.core.docker import DockerClientError, DockerException, DockerManager, NotFound
 
 pytestmark = pytest.mark.integration
 
 SMOKE_IMAGE = "alpine:3.20"
 SMOKE_AGENT = "integration-smoke"
+_CLEANUP_ATTEMPTS = 3
 
 
 @pytest.fixture()
@@ -54,13 +55,32 @@ def mountable_tmp_path() -> Iterator[Path]:
 @pytest.fixture()
 def cleanup_smoke_containers(manager: DockerManager) -> Iterator[None]:
     yield
+    failures: list[str] = []
     for container in manager.list_managed(all_containers=True):
         if container.labels.get("vibepod.agent") != SMOKE_AGENT:
             continue
-        try:
-            container.remove(force=True)
-        except Exception:
-            pass
+        last_error: Exception | None = None
+        for attempt in range(1, _CLEANUP_ATTEMPTS + 1):
+            try:
+                container.remove(force=True)
+                last_error = None
+                break
+            except NotFound:
+                last_error = None
+                break
+            except DockerException as exc:
+                # A removal can lose a race with the runtime's own reaper; log
+                # every attempt so a persistent failure is diagnosable.
+                last_error = exc
+                print(
+                    f"cleanup: removing {container.name} failed "
+                    f"(attempt {attempt}/{_CLEANUP_ATTEMPTS}): {exc}"
+                )
+                time.sleep(0.5)
+        if last_error is not None:
+            failures.append(f"{container.name}: {last_error}")
+    if failures:
+        pytest.fail("Smoke containers could not be removed: " + "; ".join(failures))
 
 
 def _wait_for_log(container: Any, needle: bytes, timeout: float = 30.0) -> bytes:

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -116,6 +116,174 @@ def test_pull_image_chunk_error(mock_docker) -> None:
     assert "Registry returned 404" in str(exc_info.value)
 
 
+def _fake_image(image_id: str, tags: list[str], digests: list[str]):
+    """Build a stand-in for a docker-py Image with the attributes the sweep reads."""
+    image = MagicMock()
+    image.id = image_id
+    image.tags = tags
+    image.attrs = {"RepoDigests": digests}
+    return image
+
+
+@patch("vibepod.core.docker.docker")
+def test_clean_untagged_images_removes_untagged_namespace_images(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.images.list.return_value = [
+        _fake_image("sha256:current", ["vibepod/claude:latest"], ["vibepod/claude@sha256:aaa"]),
+        _fake_image("sha256:old", [], ["vibepod/claude@sha256:bbb"]),
+        _fake_image("sha256:older", [], ["vibepod/codex@sha256:ccc"]),
+    ]
+
+    manager = DockerManager()
+    removed = manager.clean_untagged_images()
+
+    assert removed == 2
+    assert [call.args[0] for call in mock_client.images.remove.call_args_list] == [
+        "sha256:old",
+        "sha256:older",
+    ]
+
+
+@patch("vibepod.core.docker.docker")
+def test_clean_untagged_images_keeps_foreign_and_unattributable_images(mock_docker) -> None:
+    """Only images provably in the namespace are touched; anonymous layers stay."""
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.images.list.return_value = [
+        _fake_image("sha256:other", [], ["python@sha256:aaa"]),
+        _fake_image("sha256:anonymous", [], []),
+        _fake_image("sha256:library", [], ["docker.io/library/python@sha256:bbb"]),
+    ]
+
+    manager = DockerManager()
+    removed = manager.clean_untagged_images()
+
+    assert removed == 0
+    mock_client.images.remove.assert_not_called()
+
+
+@patch("vibepod.core.docker.docker")
+def test_clean_untagged_images_matches_registry_qualified_references(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.images.list.return_value = [
+        _fake_image("sha256:old", [], ["ghcr.io/vibepod/claude@sha256:aaa"]),
+    ]
+
+    manager = DockerManager()
+
+    assert manager.clean_untagged_images() == 1
+    mock_client.images.remove.assert_called_once_with("sha256:old")
+
+
+@patch("vibepod.core.docker.docker")
+def test_clean_untagged_images_keeps_foreign_nested_references(mock_docker) -> None:
+    """A third-party repository that merely contains a `vibepod` path segment is not ours."""
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.images.list.return_value = [
+        _fake_image("sha256:foreign", [], ["ghcr.io/acme/vibepod/tool@sha256:aaa"]),
+    ]
+
+    manager = DockerManager()
+
+    assert manager.clean_untagged_images() == 0
+    mock_client.images.remove.assert_not_called()
+
+
+@patch("vibepod.core.docker.docker")
+def test_clean_untagged_images_skips_images_still_in_use(mock_docker) -> None:
+    """A container holding one image must not stop the rest of the sweep."""
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.images.list.return_value = [
+        _fake_image("sha256:in-use", [], ["vibepod/claude@sha256:aaa"]),
+        _fake_image("sha256:free", [], ["vibepod/claude@sha256:bbb"]),
+    ]
+    mock_client.images.remove.side_effect = [
+        APIError("conflict: image is being used by stopped container"),
+        None,
+    ]
+
+    manager = DockerManager()
+    removed = manager.clean_untagged_images()
+
+    assert removed == 1
+    assert [call.args[0] for call in mock_client.images.remove.call_args_list] == [
+        "sha256:in-use",
+        "sha256:free",
+    ]
+
+
+@patch("vibepod.core.docker.docker")
+def test_clean_untagged_images_survives_list_failure(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.images.list.side_effect = DockerException("connection refused")
+
+    manager = DockerManager()
+
+    assert manager.clean_untagged_images() == 0
+
+
+@patch("vibepod.core.docker.docker")
+def test_pull_image_cleans_untagged_images(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.api.pull.return_value = [{"status": "Downloaded newer image"}]
+    mock_client.images.list.return_value = [
+        _fake_image("sha256:old", [], ["vibepod/claude@sha256:aaa"]),
+    ]
+
+    manager = DockerManager()
+    manager.pull_image("vibepod/claude:latest", auto_clean=True)
+
+    mock_client.images.remove.assert_called_once_with("sha256:old")
+
+
+@patch("vibepod.core.docker.docker")
+def test_pull_image_keeps_untagged_images_by_default(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.api.pull.return_value = [{"status": "Downloaded newer image"}]
+
+    manager = DockerManager()
+    manager.pull_image("vibepod/claude:latest")
+
+    mock_client.images.list.assert_not_called()
+    mock_client.images.remove.assert_not_called()
+
+
+@patch("vibepod.core.docker.docker")
+def test_pull_if_newer_cleans_untagged_images_even_when_up_to_date(mock_docker) -> None:
+    """The sweep also clears leftovers from earlier pulls whose removal failed."""
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_image = MagicMock()
+    mock_image.id = "sha256:same"
+    mock_client.images.get.side_effect = [mock_image, mock_image]
+    mock_client.api.pull.return_value = [{"status": "Image is up to date"}]
+    mock_client.images.list.return_value = [
+        _fake_image("sha256:leftover", [], ["vibepod/claude@sha256:aaa"]),
+    ]
+
+    manager = DockerManager()
+    updated = manager.pull_if_newer("vibepod/claude:latest", auto_clean=True)
+
+    assert updated is False
+    mock_client.images.remove.assert_called_once_with("sha256:leftover")
+
+
 @patch("vibepod.core.docker.docker")
 def test_pull_if_newer(mock_docker) -> None:
     mock_client = MagicMock()
@@ -149,6 +317,40 @@ def test_pull_if_newer(mock_docker) -> None:
     mock_client.api.pull.side_effect = APIError("Failed")
     updated = manager.pull_if_newer("vibepod/datasette:latest")
     assert updated is False
+
+
+@patch("vibepod.core.docker.docker")
+def test_pull_if_newer_keeps_untagged_images_by_default(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_image_old = MagicMock()
+    mock_image_old.id = "sha256:old"
+    mock_image_new = MagicMock()
+    mock_image_new.id = "sha256:new"
+
+    mock_client.images.get.side_effect = [mock_image_old, mock_image_new]
+    mock_client.api.pull.return_value = [{"status": "Downloaded newer image"}]
+
+    manager = DockerManager()
+    updated = manager.pull_if_newer("vibepod/claude:latest")
+
+    assert updated is True
+    mock_client.images.list.assert_not_called()
+    mock_client.images.remove.assert_not_called()
+
+
+@patch("vibepod.core.docker.docker")
+def test_image_id_returns_none_on_daemon_error(mock_docker) -> None:
+    """A daemon hiccup while reading an image id is reported as 'no image'."""
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    mock_client.images.get.side_effect = APIError("daemon hiccup")
+
+    manager = DockerManager()
+
+    assert manager.image_id("vibepod/claude:latest") is None
 
 
 @patch("vibepod.core.docker.docker")

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,85 @@
+"""Logs command tests."""
+
+from __future__ import annotations
+
+from vibepod.commands import logs as logs_cmd
+
+
+class _FakeContainer:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def remove(self, force: bool = False) -> None:
+        self._events.append("container.remove")
+
+
+class _FakeManager:
+    def __init__(self, events: list[str], updated: bool = True) -> None:
+        self._events = events
+        self._updated = updated
+        self._container = _FakeContainer(events)
+        self._image_ids = iter(["old-id", "new-id"])
+
+    def image_id(self, image: str) -> str | None:
+        return next(self._image_ids)
+
+    def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
+        self._events.append(f"pull_if_newer(auto_clean={auto_clean})")
+        return self._updated
+
+    def find_datasette(self):
+        return self._container
+
+    def clean_untagged_images(self) -> int:
+        self._events.append("clean_untagged_images")
+        return 0
+
+    def ensure_datasette(self, **kwargs) -> None:
+        self._events.append("ensure_datasette")
+
+
+def _patch_common(monkeypatch, events: list[str], config: dict, updated: bool = True) -> None:
+    monkeypatch.setattr(logs_cmd, "DockerManager", lambda: _FakeManager(events, updated))
+    monkeypatch.setattr(logs_cmd, "get_config", lambda: config)
+    monkeypatch.setattr(logs_cmd, "_wait_for_datasette", lambda port: True)
+
+
+def test_logs_start_cleans_images_after_container(monkeypatch) -> None:
+    events: list[str] = []
+    _patch_common(monkeypatch, events, {"auto_clean": True})
+
+    logs_cmd.logs_start(port=None, no_open=True)
+
+    assert events == [
+        "pull_if_newer(auto_clean=False)",
+        "container.remove",
+        "clean_untagged_images",
+        "ensure_datasette",
+    ]
+
+
+def test_logs_start_skips_image_cleanup_without_auto_clean(monkeypatch) -> None:
+    events: list[str] = []
+    _patch_common(monkeypatch, events, {"auto_clean": False})
+
+    logs_cmd.logs_start(port=None, no_open=True)
+
+    assert events == [
+        "pull_if_newer(auto_clean=False)",
+        "container.remove",
+        "ensure_datasette",
+    ]
+
+
+def test_logs_start_cleans_leftovers_without_update(monkeypatch) -> None:
+    """Leftovers from an earlier failed removal are swept even when nothing changed."""
+    events: list[str] = []
+    _patch_common(monkeypatch, events, {"auto_clean": True}, updated=False)
+
+    logs_cmd.logs_start(port=None, no_open=True)
+
+    assert events == [
+        "pull_if_newer(auto_clean=False)",
+        "clean_untagged_images",
+        "ensure_datasette",
+    ]

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -1,0 +1,87 @@
+"""Proxy command tests."""
+
+from __future__ import annotations
+
+from vibepod.commands import proxy as proxy_cmd
+
+
+class _FakeContainer:
+    def __init__(self, events: list[str], status: str = "running") -> None:
+        self._events = events
+        self.status = status
+
+    def remove(self, force: bool = False) -> None:
+        self._events.append("container.remove")
+
+
+class _FakeManager:
+    def __init__(self, events: list[str], updated: bool = True) -> None:
+        self._events = events
+        self._updated = updated
+        self._container: _FakeContainer | None = _FakeContainer(events)
+
+    def ensure_network(self, name: str) -> None:
+        self._events.append("ensure_network")
+
+    def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
+        self._events.append(f"pull_if_newer(auto_clean={auto_clean})")
+        return self._updated
+
+    def find_proxy(self):
+        return self._container
+
+    def clean_untagged_images(self) -> int:
+        self._events.append("clean_untagged_images")
+        return 0
+
+    def ensure_proxy(self, **kwargs) -> None:
+        self._events.append("ensure_proxy")
+
+
+def _patch_common(monkeypatch, events: list[str], config: dict, updated: bool = True) -> None:
+    monkeypatch.setattr(proxy_cmd, "DockerManager", lambda: _FakeManager(events, updated))
+    monkeypatch.setattr(proxy_cmd, "get_config", lambda: config)
+
+
+def test_proxy_start_recreates_container_before_cleanup(monkeypatch) -> None:
+    """The running proxy holds the replaced image, so it must go before the sweep."""
+    events: list[str] = []
+    _patch_common(monkeypatch, events, {"auto_clean": True})
+
+    proxy_cmd.proxy_start()
+
+    assert events == [
+        "ensure_network",
+        "pull_if_newer(auto_clean=False)",
+        "container.remove",
+        "ensure_proxy",
+        "clean_untagged_images",
+    ]
+
+
+def test_proxy_start_keeps_container_without_update(monkeypatch) -> None:
+    events: list[str] = []
+    _patch_common(monkeypatch, events, {"auto_clean": True}, updated=False)
+
+    proxy_cmd.proxy_start()
+
+    assert events == [
+        "ensure_network",
+        "pull_if_newer(auto_clean=False)",
+        "ensure_proxy",
+        "clean_untagged_images",
+    ]
+
+
+def test_proxy_start_skips_cleanup_without_auto_clean(monkeypatch) -> None:
+    events: list[str] = []
+    _patch_common(monkeypatch, events, {"auto_clean": False})
+
+    proxy_cmd.proxy_start()
+
+    assert events == [
+        "ensure_network",
+        "pull_if_newer(auto_clean=False)",
+        "container.remove",
+        "ensure_proxy",
+    ]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -628,7 +628,7 @@ def test_paste_images_flag_adds_x11_volumes_and_env(monkeypatch, tmp_path: Path)
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -723,7 +723,7 @@ def test_paste_images_flag_warns_when_display_not_set(monkeypatch, tmp_path: Pat
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -767,7 +767,7 @@ def test_paste_images_false_does_not_add_x11(monkeypatch, tmp_path: Path) -> Non
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -918,7 +918,7 @@ class _StubDockerManager:
     def is_rootless_podman(self) -> bool:
         return self.rootless_podman
 
-    def pull_image(self, image: str) -> None:
+    def pull_image(self, image: str, auto_clean: bool = False) -> None:
         self.pulled.append(image)
 
     def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1002,7 +1002,7 @@ def test_cli_run_forwards_extra_args_to_agent_command(monkeypatch, tmp_path: Pat
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1134,7 +1134,7 @@ def test_ikwid_appends_args_for_claude(monkeypatch, tmp_path: Path) -> None:
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1176,7 +1176,7 @@ def test_ikwid_appends_args_for_codex(monkeypatch, tmp_path: Path) -> None:
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1220,7 +1220,7 @@ def test_ikwid_appends_args_for_gemini(monkeypatch, tmp_path: Path) -> None:
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1270,7 +1270,7 @@ def test_ikwid_appends_args_for_copilot(monkeypatch, tmp_path: Path) -> None:
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1314,7 +1314,7 @@ def test_ikwid_appends_args_for_devstral(monkeypatch, tmp_path: Path) -> None:
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1363,7 +1363,7 @@ def test_ikwid_ignored_for_unsupported_agent(monkeypatch, tmp_path: Path) -> Non
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1408,7 +1408,7 @@ def test_ikwid_false_does_not_modify_command(monkeypatch, tmp_path: Path) -> Non
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1450,7 +1450,7 @@ def test_llm_enabled_injects_openai_env_vars(monkeypatch, tmp_path: Path) -> Non
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1507,7 +1507,7 @@ def test_llm_enabled_injects_openai_env_vars_for_codex(monkeypatch, tmp_path: Pa
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1560,7 +1560,7 @@ def test_llm_disabled_does_not_inject_env_vars(monkeypatch, tmp_path: Path) -> N
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1616,7 +1616,7 @@ def test_llm_skipped_for_agent_without_mapping(monkeypatch, tmp_path: Path) -> N
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1668,7 +1668,7 @@ def test_llm_empty_model_not_injected(monkeypatch, tmp_path: Path) -> None:
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1722,7 +1722,7 @@ def test_llm_per_agent_env_overrides_llm(monkeypatch, tmp_path: Path) -> None:
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1790,7 +1790,7 @@ def test_run_forwards_host_terminal_env(monkeypatch, tmp_path: Path) -> None:
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1841,7 +1841,7 @@ def test_run_sets_default_term_when_host_term_missing(monkeypatch, tmp_path: Pat
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -1895,7 +1895,7 @@ def _make_capturing_docker_manager():
         def networks_with_running_containers(self) -> list[str]:
             return []
 
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
 
         def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_skills_engine_driver.py
+++ b/tests/test_skills_engine_driver.py
@@ -19,9 +19,9 @@ def mock_docker_manager(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeDockerManager:
         def __init__(self) -> None:
             self.client = MagicMock()
-        def pull_image(self, image: str) -> None:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
-        def pull_if_newer(self, image: str) -> bool:
+        def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
             return False
 
     monkeypatch.setattr(skills_engine, "DockerManager", FakeDockerManager)
@@ -182,9 +182,9 @@ def test_run_engine_pulls_image_when_missing(
         def __init__(self) -> None:
             self.client = MagicMock()
             self.client.images.get.side_effect = NotFound("not found")
-        def pull_image(self, image: str) -> None:
-            pulled_images.append(image)
-        def pull_if_newer(self, image: str) -> bool:
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
+            pulled_images.append((image, auto_clean))
+        def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
             checked_images.append(image)
             return False
 
@@ -196,7 +196,7 @@ def test_run_engine_pulls_image_when_missing(
 
     skills_engine.list_skills()
 
-    assert skills_engine.SKILLS_ENGINE_IMAGE in pulled_images
+    assert (skills_engine.SKILLS_ENGINE_IMAGE, True) in pulled_images
     assert not checked_images
 
 
@@ -215,15 +215,17 @@ def test_run_engine_checks_updates_when_latest(
         def __init__(self) -> None:
             self.client = MagicMock()
             self.client.images.get.return_value = MagicMock()
-        def pull_image(self, image: str) -> None:
-            pulled_images.append(image)
-        def pull_if_newer(self, image: str) -> bool:
-            checked_images.append(image)
+        def pull_image(self, image: str, auto_clean: bool = False) -> None:
+            pulled_images.append((image, auto_clean))
+        def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
+            checked_images.append((image, auto_clean))
             return False
 
     monkeypatch.setattr(skills_engine, "DockerManager", FakeDockerManager)
     monkeypatch.setattr(skills_engine, "_skills_engine_checked", False)
-    monkeypatch.setattr(skills_engine, "get_config", lambda: {"auto_pull": True})
+    monkeypatch.setattr(
+        skills_engine, "get_config", lambda: {"auto_pull": True, "auto_clean": True}
+    )
 
     fake_run, _ = _fake_run_factory(stdout=json.dumps([]))
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -231,4 +233,4 @@ def test_run_engine_checks_updates_when_latest(
     skills_engine.list_skills()
 
     assert not pulled_images
-    assert "vibepod/skills-engine:latest" in checked_images
+    assert ("vibepod/skills-engine:latest", True) in checked_images

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -71,7 +71,7 @@ class _CapturingDockerManager:
     def networks_with_running_containers(self) -> list[str]:
         return []
 
-    def pull_image(self, image: str) -> None:
+    def pull_image(self, image: str, auto_clean: bool = False) -> None:
         pass
 
     def ensure_proxy(self, **kwargs) -> None:


### PR DESCRIPTION
Introduces a new `auto_clean` feature to automatically remove untagged vibepod images after a pull, and integrates it across the CLI, configuration, and documentation. It also adds support for configuring this behavior via environment variables and updates the default configuration accordingly. Additionally, several internal refactorings and helpers are added to support namespace-based image cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of untagged, unused images after image pulls and updates.
  * Cleanup is enabled by default and can be controlled with the `VP_AUTO_CLEAN` environment variable.
  * Updated image-refresh workflows to safely replace containers when newer images are detected.

* **Bug Fixes**
  * Prevented dangling image leftovers from accumulating while preserving images still in use or tagged elsewhere.

* **Documentation**
  * Documented the new cleanup setting and environment-variable override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->