### PR TITLE
Add macOS Podman machine setup

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,12 +11,29 @@ VibePod can use Podman's Docker-compatible API socket and applies the
 necessary rootless user-namespace settings (`keep-id`) so workspace file
 permissions work correctly.
 
-Start Podman's user socket and point VibePod at it with `DOCKER_HOST`:
+Start Podman's Docker-compatible socket and point VibePod at it with
+`DOCKER_HOST`:
 
-```bash
-systemctl --user enable --now podman.socket
-export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
-```
+=== "Linux"
+
+    ```bash
+    systemctl --user enable --now podman.socket
+    export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
+    ```
+
+=== "macOS"
+
+    ```bash
+    podman machine init   # first time only
+    podman machine start
+    export DOCKER_HOST="unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')"
+    ```
+
+    !!! note "The socket path is dynamic"
+        The Podman machine socket lives under `$TMPDIR`, which changes between
+        machine starts — a hardcoded `DOCKER_HOST` will break after a reboot.
+        Always compute it via `podman machine inspect` as above, and add the
+        `export` line to your `~/.zshrc` so every shell picks it up.
 
 !!! warning "Container DNS required"
     VibePod routes agent traffic through a `vibepod-proxy` container. The agent


### PR DESCRIPTION
Updates the `docs/quickstart.md` guide to clarify how to configure VibePod to use Podman's Docker-compatible API socket on both Linux and macOS. The instructions now provide OS-specific setup steps and highlight important details about the dynamic socket path on macOS.

**Documentation improvements for Podman socket setup:**

* Added separate sections for Linux and macOS, each with tailored instructions for starting Podman's socket and setting the `DOCKER_HOST` environment variable (`docs/quickstart.md`).
* Included a note explaining that the Podman machine socket path is dynamic on macOS, advising users to always compute it and update their shell configuration accordingly (`docs/quickstart.md`).

Ref https://github.com/VibePod/vibepod-cli/issues/102