### PR TITLE
Auto-detect Podman socket when DOCKER_HOST unset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
       fail-fast: false
       matrix:
         runtime: [docker, podman]
+    env:
+      VIBEPOD_TEST_RUNTIME: ${{ matrix.runtime }}
 
     steps:
       - name: Check out repository
@@ -101,6 +103,8 @@ jobs:
       fail-fast: false
       matrix:
         runtime: [docker, podman]
+    env:
+      VIBEPOD_TEST_RUNTIME: ${{ matrix.runtime }}
 
     steps:
       - name: Check out repository

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,14 +11,15 @@ VibePod can use Podman's Docker-compatible API socket and applies the
 necessary rootless user-namespace settings (`keep-id`) so workspace file
 permissions work correctly.
 
-Start Podman's Docker-compatible socket and point VibePod at it with
-`DOCKER_HOST`:
+If `DOCKER_HOST` is not set, VibePod asks Podman for its socket location and
+uses it automatically — on macOS this matters because the machine socket path
+changes with `$TMPDIR` at machine-start time. You only need to make sure the
+socket exists:
 
 === "Linux"
 
     ```bash
     systemctl --user enable --now podman.socket
-    export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
     ```
 
 === "macOS"
@@ -26,14 +27,22 @@ Start Podman's Docker-compatible socket and point VibePod at it with
     ```bash
     podman machine init   # first time only
     podman machine start
-    export DOCKER_HOST="unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')"
     ```
 
-    !!! note "The socket path is dynamic"
-        The Podman machine socket lives under `$TMPDIR`, which changes between
-        machine starts — a hardcoded `DOCKER_HOST` will break after a reboot.
-        Always compute it via `podman machine inspect` as above, and add the
-        `export` line to your `~/.zshrc` so every shell picks it up.
+Setting `DOCKER_HOST` explicitly still works and takes precedence:
+
+```bash
+# Linux
+export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
+# macOS
+export DOCKER_HOST=unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
+```
+
+!!! note "The socket path is dynamic on macOS"
+    The Podman machine socket lives under `$TMPDIR`, which changes between
+    machine starts — a hardcoded `DOCKER_HOST` will break after a reboot. If
+    you set it manually, always compute it via `podman machine inspect` as
+    above (e.g. in your `~/.zshrc`).
 
 !!! warning "Container DNS required"
     VibePod routes agent traffic through a `vibepod-proxy` container. The agent

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -6,6 +6,7 @@ import os
 import select
 import shutil
 import signal
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -58,6 +59,76 @@ else:
 
 class DockerClientError(RuntimeError):
     """Raised for Docker availability or lifecycle errors."""
+
+
+_PODMAN_HINT = (
+    "If you use Podman, make sure the machine is running (`podman machine start`) "
+    "or point DOCKER_HOST at the Podman socket."
+)
+
+
+def _run_podman(podman: str, args: list[str]) -> str | None:
+    """Run a Podman subcommand, returning its trimmed stdout on success."""
+    try:
+        result = subprocess.run([podman, *args], capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _podman_machine_sockets(podman: str) -> list[str]:
+    """Socket paths of every configured Podman machine, not just the default one."""
+    listing = _run_podman(podman, ["machine", "list", "--format", "{{.Name}}"])
+    if listing is None:
+        return []
+    # `machine list` suffixes the default machine's name with "*".
+    names = [stripped.rstrip("*") for line in listing.splitlines() if (stripped := line.strip())]
+    if not names:
+        return []
+    inspected = _run_podman(
+        podman,
+        ["machine", "inspect", *names, "--format", "{{.ConnectionInfo.PodmanSocket.Path}}"],
+    )
+    if inspected is None:
+        return []
+    return [stripped for line in inspected.splitlines() if (stripped := line.strip())]
+
+
+def _discover_podman_socket() -> str | None:
+    """Locate a Podman socket to use when the default Docker socket is unavailable.
+
+    Podman machines on macOS expose the Docker-compatible API on a socket whose
+    path depends on $TMPDIR at machine-start time, so it cannot be hardcoded.
+    Ask Podman itself, then fall back to the rootless default on Linux.
+    """
+    if os.environ.get("DOCKER_HOST"):
+        return None
+
+    candidates: list[str] = []
+
+    podman = shutil.which("podman")
+    if podman is not None:
+        machine_sockets = _podman_machine_sockets(podman)
+        candidates.extend(machine_sockets)
+        if not machine_sockets:
+            # With a machine in play `podman info` reports the socket path as seen
+            # from inside the VM, which does not exist on the host — only trust it
+            # for native installs, where no machine is configured.
+            remote_socket = _run_podman(podman, ["info", "--format", "{{.Host.RemoteSocket.Path}}"])
+            if remote_socket is not None:
+                candidates.append(remote_socket)
+
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        candidates.append(os.path.join(runtime_dir, "podman", "podman.sock"))
+
+    for candidate in candidates:
+        path = candidate.removeprefix("unix://")
+        if Path(path).is_socket():
+            return f"unix://{path}"
+    return None
 
 
 def _encode_console_character(ch: str) -> bytes:
@@ -145,7 +216,17 @@ class DockerManager:
             self.client = docker.from_env()
             self.client.ping()
         except DockerException as exc:
-            raise DockerClientError(f"Docker is not available: {exc}") from exc
+            podman_socket = _discover_podman_socket()
+            if podman_socket is None:
+                raise DockerClientError(f"Docker is not available: {exc}. {_PODMAN_HINT}") from exc
+            try:
+                self.client = docker.DockerClient(base_url=podman_socket)
+                self.client.ping()
+            except DockerException as retry_exc:
+                raise DockerClientError(
+                    f"Docker is not available: {exc}. "
+                    f"Found Podman socket {podman_socket} but could not connect: {retry_exc}"
+                ) from retry_exc
 
         self._rootless_podman: bool | None = None
 

--- a/tests/integration/test_runtime_smoke.py
+++ b/tests/integration/test_runtime_smoke.py
@@ -7,6 +7,7 @@ socket works transparently with docker-py.
 
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 import time
@@ -14,10 +15,11 @@ import uuid
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
-from vibepod.core.docker import DockerClientError, DockerManager
+from vibepod.core.docker import DockerClientError, DockerException, DockerManager
 
 pytestmark = pytest.mark.integration
 
@@ -82,6 +84,28 @@ def _wait_for_log(container: Any, needle: bytes, timeout: float = 30.0) -> bytes
             )
         time.sleep(0.5)
     raise AssertionError(f"Timed out waiting for {needle!r} in logs: {logs!r}")
+
+
+def test_docker_manager_discovers_podman_socket(monkeypatch) -> None:
+    """Auto-discovery must find the live Podman socket when DOCKER_HOST is unset.
+
+    CI runners keep a Docker daemon on the default socket, so force
+    ``docker.from_env`` to fail — otherwise the fallback never triggers and
+    this test would silently pass through the Docker daemon instead.
+    """
+    if os.environ.get("VIBEPOD_TEST_RUNTIME") != "podman":
+        pytest.skip("requires a live Podman socket (VIBEPOD_TEST_RUNTIME=podman)")
+
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    with patch(
+        "vibepod.core.docker.docker.from_env",
+        side_effect=DockerException("forced failure to exercise discovery"),
+    ):
+        manager = DockerManager()
+
+    # from_env is patched to fail, so a working client proves the discovered
+    # Podman socket was used.
+    manager.client.ping()
 
 
 def test_pull_run_mount_stop(

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import socket
+import subprocess
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,10 +14,33 @@ import pytest
 from vibepod.core.docker import (
     APIError,
     DockerClientError,
+    DockerException,
     DockerManager,
     NotFound,
+    _discover_podman_socket,
     _parse_image_name,
 )
+
+requires_af_unix = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"), reason="AF_UNIX sockets are not available on this platform"
+)
+
+
+@pytest.fixture()
+def socket_dir() -> Iterator[Path]:
+    """Short-path directory for binding AF_UNIX sockets.
+
+    sun_path is limited to ~104 chars on macOS and pytest's tmp_path on CI
+    runners can exceed it, so keep bound sockets out of tmp_path.
+    """
+    with tempfile.TemporaryDirectory(prefix="vp-sock-") as tmp:
+        yield Path(tmp)
+
+
+def _bind_unix_socket(path: Path) -> socket.socket:
+    sock = socket.socket(socket.AF_UNIX)
+    sock.bind(str(path))
+    return sock
 
 
 def test_parse_image_name() -> None:
@@ -170,3 +197,227 @@ def test_ensure_proxy_pulls_image_when_missing(mock_docker, tmp_path: Path) -> N
         "vibepod/proxy", tag="latest", stream=True, decode=True
     )
     mock_client.containers.run.assert_called_once()
+
+
+def test_discover_podman_socket_skipped_when_docker_host_set(monkeypatch) -> None:
+    monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+    assert _discover_podman_socket() is None
+
+
+@requires_af_unix
+def test_discover_podman_socket_uses_machine_inspect(monkeypatch, socket_dir: Path) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    socket_path = socket_dir / "podman.sock"
+    sock = _bind_unix_socket(socket_path)
+    try:
+        with (
+            patch("vibepod.core.docker.shutil.which", return_value="/usr/bin/podman"),
+            patch("vibepod.core.docker.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"{socket_path}\n")
+            assert _discover_podman_socket() == f"unix://{socket_path}"
+    finally:
+        sock.close()
+
+
+@requires_af_unix
+def test_discover_podman_socket_strips_unix_prefix(monkeypatch, socket_dir: Path) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    socket_path = socket_dir / "podman.sock"
+    sock = _bind_unix_socket(socket_path)
+    try:
+        with (
+            patch("vibepod.core.docker.shutil.which", return_value="/usr/bin/podman"),
+            patch("vibepod.core.docker.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"unix://{socket_path}\n")
+            assert _discover_podman_socket() == f"unix://{socket_path}"
+    finally:
+        sock.close()
+
+
+def test_discover_podman_socket_ignores_stale_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    with (
+        patch("vibepod.core.docker.shutil.which", return_value="/usr/bin/podman"),
+        patch("vibepod.core.docker.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout=f"{tmp_path}/gone.sock\n")
+        assert _discover_podman_socket() is None
+
+
+@requires_af_unix
+def test_discover_podman_socket_xdg_runtime_dir(monkeypatch, socket_dir: Path) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(socket_dir))
+    (socket_dir / "podman").mkdir()
+    socket_path = socket_dir / "podman" / "podman.sock"
+    sock = _bind_unix_socket(socket_path)
+    try:
+        with patch("vibepod.core.docker.shutil.which", return_value=None):
+            assert _discover_podman_socket() == f"unix://{socket_path}"
+    finally:
+        sock.close()
+
+
+def test_discover_podman_socket_none_without_podman(monkeypatch) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    with patch("vibepod.core.docker.shutil.which", return_value=None):
+        assert _discover_podman_socket() is None
+
+
+@requires_af_unix
+def test_discover_podman_socket_falls_back_to_podman_info(monkeypatch, socket_dir: Path) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    socket_path = socket_dir / "podman.sock"
+    sock = _bind_unix_socket(socket_path)
+    try:
+        with (
+            patch("vibepod.core.docker.shutil.which", return_value="/usr/bin/podman"),
+            patch("vibepod.core.docker.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                MagicMock(returncode=125, stdout=""),
+                MagicMock(returncode=0, stdout=f"{socket_path}\n"),
+            ]
+            assert _discover_podman_socket() == f"unix://{socket_path}"
+        assert mock_run.call_count == 2
+    finally:
+        sock.close()
+
+
+@requires_af_unix
+def test_discover_podman_socket_enumerates_non_default_machines(
+    monkeypatch, socket_dir: Path
+) -> None:
+    """A running non-default machine is found even when the default one is dead."""
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    live_path = socket_dir / "dev.sock"
+    sock = _bind_unix_socket(live_path)
+    stale_path = socket_dir / "gone.sock"
+    try:
+        with (
+            patch("vibepod.core.docker.shutil.which", return_value="/usr/bin/podman"),
+            patch("vibepod.core.docker.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                # `machine list` marks the default machine with a trailing "*".
+                MagicMock(returncode=0, stdout="podman-machine-default*\ndev\n"),
+                MagicMock(returncode=0, stdout=f"{stale_path}\n{live_path}\n"),
+            ]
+            assert _discover_podman_socket() == f"unix://{live_path}"
+        listed = mock_run.call_args_list[1].args[0]
+        assert listed[1:4] == ["machine", "inspect", "podman-machine-default"]
+        assert "dev" in listed
+    finally:
+        sock.close()
+
+
+def test_discover_podman_socket_skips_podman_info_when_machines_exist(monkeypatch) -> None:
+    """`podman info` reports the VM-internal path, so never trust it alongside a machine."""
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    with (
+        patch("vibepod.core.docker.shutil.which", return_value="/usr/bin/podman"),
+        patch("vibepod.core.docker.subprocess.run") as mock_run,
+    ):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="podman-machine-default*\n"),
+            MagicMock(returncode=0, stdout="/var/folders/xx/gone/podman.sock\n"),
+        ]
+        assert _discover_podman_socket() is None
+    assert mock_run.call_count == 2
+    assert all("info" not in call.args[0] for call in mock_run.call_args_list)
+
+
+@requires_af_unix
+def test_discover_podman_socket_survives_subprocess_errors(monkeypatch, socket_dir: Path) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(socket_dir))
+    (socket_dir / "podman").mkdir()
+    socket_path = socket_dir / "podman" / "podman.sock"
+    sock = _bind_unix_socket(socket_path)
+    try:
+        with (
+            patch("vibepod.core.docker.shutil.which", return_value="/usr/bin/podman"),
+            patch("vibepod.core.docker.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                subprocess.TimeoutExpired(cmd="podman", timeout=10),
+                OSError("podman exploded"),
+            ]
+            assert _discover_podman_socket() == f"unix://{socket_path}"
+    finally:
+        sock.close()
+
+
+@requires_af_unix
+def test_discover_podman_socket_prefers_podman_over_xdg(monkeypatch, socket_dir: Path) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(socket_dir))
+    (socket_dir / "podman").mkdir()
+    xdg_socket = socket_dir / "podman" / "podman.sock"
+    machine_socket = socket_dir / "machine.sock"
+    sock_machine = _bind_unix_socket(machine_socket)
+    sock_xdg = _bind_unix_socket(xdg_socket)
+    try:
+        with (
+            patch("vibepod.core.docker.shutil.which", return_value="/usr/bin/podman"),
+            patch("vibepod.core.docker.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"{machine_socket}\n")
+            assert _discover_podman_socket() == f"unix://{machine_socket}"
+    finally:
+        sock_machine.close()
+        sock_xdg.close()
+
+
+@patch("vibepod.core.docker.docker")
+def test_init_falls_back_to_podman_socket(mock_docker) -> None:
+    mock_docker.from_env.side_effect = DockerException("no socket")
+    mock_client = MagicMock()
+    mock_docker.DockerClient.return_value = mock_client
+
+    with patch(
+        "vibepod.core.docker._discover_podman_socket",
+        return_value="unix:///tmp/podman.sock",
+    ):
+        manager = DockerManager()
+
+    mock_docker.DockerClient.assert_called_once_with(base_url="unix:///tmp/podman.sock")
+    assert manager.client is mock_client
+    mock_client.ping.assert_called_once()
+
+
+@patch("vibepod.core.docker.docker")
+def test_init_error_includes_podman_hint(mock_docker) -> None:
+    mock_docker.from_env.side_effect = DockerException("no socket")
+
+    with patch("vibepod.core.docker._discover_podman_socket", return_value=None):
+        with pytest.raises(DockerClientError) as exc_info:
+            DockerManager()
+
+    message = str(exc_info.value)
+    assert "podman machine start" in message
+    assert "DOCKER_HOST" in message
+
+
+@patch("vibepod.core.docker.docker")
+def test_init_fallback_failure_raises(mock_docker) -> None:
+    mock_docker.from_env.side_effect = DockerException("no socket")
+    mock_docker.DockerClient.side_effect = DockerException("still broken")
+
+    with patch(
+        "vibepod.core.docker._discover_podman_socket",
+        return_value="unix:///tmp/podman.sock",
+    ):
+        with pytest.raises(DockerClientError) as exc_info:
+            DockerManager()
+
+    assert "Docker is not available" in str(exc_info.value)


### PR DESCRIPTION
Improves VibePod's compatibility with Podman by automatically detecting and using Podman's Docker-compatible API socket when Docker is unavailable. It also adds robust tests for the new discovery logic and updates the documentation to clarify how socket detection works, especially on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VibePod can now automatically discover and connect to Podman’s Docker-compatible socket when Docker is unavailable and `DOCKER_HOST` is not configured.
  * Improved connection errors provide clearer guidance for starting Podman or configuring `DOCKER_HOST`.

* **Documentation**
  * Updated the Podman quickstart with automatic socket discovery details and explicit Linux/macOS configuration steps.

* **Tests**
  * Added integration coverage for Docker-compatible Podman connections, container execution, mounts, and environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->