### PR TITLE
Extend test environments for cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,12 @@ jobs:
       - name: Set up Podman machine
         if: matrix.runtime == 'podman'
         run: |
-          brew install podman
+          # No Homebrew bottle for podman on Intel macOS (Tier 3); use official installer.
+          # Pinned: podman 6.x dropped the Intel macOS installer, 5.8 is the last branch shipping it.
+          curl -fsSL -o podman.pkg https://github.com/containers/podman/releases/download/v5.8.5/podman-installer-macos-amd64.pkg
+          sudo installer -pkg podman.pkg -target /
+          echo "/opt/podman/bin" >> "$GITHUB_PATH"
+          export PATH="/opt/podman/bin:$PATH"
           podman machine init --now
           echo "DOCKER_HOST=unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
@@ -49,6 +49,89 @@ jobs:
 
       - name: Run tests
         run: python -m pytest
+
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [docker, podman]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Start Podman API socket
+        if: matrix.runtime == 'podman'
+        run: |
+          systemctl --user enable --now podman.socket
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+
+      - name: Verify daemon responds
+        run: |
+          SOCKET="${DOCKER_HOST:-unix:///var/run/docker.sock}"
+          curl -sf --unix-socket "${SOCKET#unix://}" http://d/_ping
+          echo "daemon OK on ${SOCKET}"
+
+      - name: Run integration tests
+        run: python -m pytest -m integration -v
+
+  integration-macos:
+    runs-on: macos-26-intel
+    timeout-minutes: 45
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [docker, podman]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Set up Docker via Colima
+        if: matrix.runtime == 'docker'
+        run: |
+          brew install colima docker
+          colima start
+          echo "DOCKER_HOST=unix://$HOME/.colima/default/docker.sock" >> "$GITHUB_ENV"
+
+      - name: Set up Podman machine
+        if: matrix.runtime == 'podman'
+        run: |
+          brew install podman
+          podman machine init --now
+          echo "DOCKER_HOST=unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')" >> "$GITHUB_ENV"
+
+      - name: Verify daemon responds
+        run: |
+          SOCKET="${DOCKER_HOST:-unix:///var/run/docker.sock}"
+          curl -sf --unix-socket "${SOCKET#unix://}" http://d/_ping
+          echo "daemon OK on ${SOCKET}"
+
+      - name: Run integration tests
+        run: python -m pytest -m integration -v
 
   lint-typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -91,6 +95,8 @@ jobs:
     runs-on: macos-26-intel
     timeout-minutes: 45
     continue-on-error: true
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -99,6 +105,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ packages = ["src/vibepod"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "integration: requires a real container runtime; run with `pytest -m integration`",
+]
+addopts = "-m 'not integration'"
 
 [tool.ruff]
 line-length = 100

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,19 @@
+"""Everything under tests/integration requires a live container runtime."""
+
+from pathlib import Path
+
+import pytest
+
+_INTEGRATION_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        # This hook receives the whole session's items, not just this
+        # directory's — scope the marker to tests that live under it.
+        if not item.path.is_relative_to(_INTEGRATION_DIR):
+            continue
+        # Check real markers, not item.keywords: keywords include ancestor
+        # node names, and this directory is itself named "integration".
+        if item.get_closest_marker("integration") is None:
+            item.add_marker(pytest.mark.integration)

--- a/tests/integration/test_runtime_smoke.py
+++ b/tests/integration/test_runtime_smoke.py
@@ -1,0 +1,130 @@
+"""Smoke tests against a real container runtime (Docker or Podman).
+
+Deselected by default; run with: pytest -m integration
+The runtime is selected via DOCKER_HOST — Podman's docker-compatible
+socket works transparently with docker-py.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vibepod.core.docker import DockerClientError, DockerManager
+
+pytestmark = pytest.mark.integration
+
+SMOKE_IMAGE = "alpine:3.20"
+SMOKE_AGENT = "integration-smoke"
+
+
+@pytest.fixture()
+def manager() -> DockerManager:
+    try:
+        return DockerManager()
+    except DockerClientError as exc:
+        pytest.fail(f"Container runtime not reachable: {exc}")
+
+
+@pytest.fixture()
+def mountable_tmp_path() -> Iterator[Path]:
+    """Temp dir the runtime can bind-mount.
+
+    On macOS the daemon runs inside a VM (podman machine / colima) that only
+    shares $HOME by default; pytest's tmp_path under /private/var/folders is
+    not visible to it, so anchor temp dirs under $HOME there.
+    """
+    base: Path | None = None
+    if sys.platform == "darwin":
+        base = Path.home() / ".vibepod-integration-tmp"
+        base.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=base) as tmp:
+        yield Path(tmp)
+
+
+@pytest.fixture()
+def cleanup_smoke_containers(manager: DockerManager) -> Iterator[None]:
+    yield
+    for container in manager.list_managed(all_containers=True):
+        if container.labels.get("vibepod.agent") != SMOKE_AGENT:
+            continue
+        try:
+            container.remove(force=True)
+        except Exception:
+            pass
+
+
+def _wait_for_log(container: Any, needle: bytes, timeout: float = 30.0) -> bytes:
+    deadline = time.monotonic() + timeout
+    logs = b""
+    while time.monotonic() < deadline:
+        container.reload()
+        logs = container.logs()
+        if needle in logs:
+            return logs
+        if container.status in ("exited", "dead"):
+            # The container died; grab the final logs before deciding, since
+            # the needle may have been written just before exit.
+            logs = container.logs()
+            if needle in logs:
+                return logs
+            exit_code = container.attrs.get("State", {}).get("ExitCode")
+            raise AssertionError(
+                f"Container {container.status} (exit code {exit_code}) "
+                f"before {needle!r} appeared in logs: {logs!r}"
+            )
+        time.sleep(0.5)
+    raise AssertionError(f"Timed out waiting for {needle!r} in logs: {logs!r}")
+
+
+def test_pull_run_mount_stop(
+    manager: DockerManager,
+    mountable_tmp_path: Path,
+    cleanup_smoke_containers: None,
+) -> None:
+    workspace = mountable_tmp_path / "workspace"
+    config_dir = mountable_tmp_path / "config"
+    workspace.mkdir()
+    config_dir.mkdir()
+    marker = f"vibepod-smoke-{uuid.uuid4().hex}"
+    file_marker = f"file-{marker}"
+    env_marker = f"env-{marker}"
+    (workspace / "hello.txt").write_text(file_marker + "\n")
+
+    manager.pull_image(SMOKE_IMAGE)
+
+    container = manager.run_agent(
+        agent=SMOKE_AGENT,
+        image=SMOKE_IMAGE,
+        workspace=workspace,
+        config_dir=config_dir,
+        config_mount_path="/config",
+        env={"VIBEPOD_SMOKE": env_marker},
+        command=["sh", "-c", 'echo "$VIBEPOD_SMOKE" && cat /workspace/hello.txt && sleep 120'],
+        auto_remove=False,
+        name=f"vibepod-{SMOKE_AGENT}-{uuid.uuid4().hex[:8]}",
+        version="integration-test",
+    )
+
+    # Env injection: the echoed env value must land in the logs.
+    logs = _wait_for_log(container, env_marker.encode())
+    assert env_marker.encode() in logs
+    # Workspace bind-mount: the file content is distinct from the env value.
+    logs = _wait_for_log(container, file_marker.encode())
+    assert file_marker.encode() in logs
+
+    managed_ids = {c.id for c in manager.list_managed()}
+    assert container.id in managed_ids
+
+    stopped = manager.stop_agent(SMOKE_AGENT, force=True)
+    assert stopped >= 1
+
+    container.reload()
+    assert container.status != "running"


### PR DESCRIPTION
Introduces integration test support for real container runtimes (Docker and Podman) and enhances the CI workflow to run these tests across all major operating systems. It also marks integration tests so they are only run explicitly, and adds robust smoke tests to verify container orchestration. The most important changes are:

**CI Workflow Enhancements:**
* Added `macos-latest` to the matrix for the main test job to ensure coverage on macOS.
* Introduced new `integration` and `integration-macos` jobs in `.github/workflows/ci.yml` to run integration tests against both Docker and Podman on Ubuntu and macOS, including setup steps for each runtime.

**Test Marking and Configuration:**
* Updated `pyproject.toml` to define an `integration` marker for tests that require a real container runtime, and changed the default pytest options to skip integration tests unless explicitly selected.
* Added `tests/integration/conftest.py` to automatically mark all tests under `tests/integration` with the `integration` marker, ensuring correct test selection.

**Integration Smoke Tests:**
* Added `tests/integration/test_runtime_smoke.py`, which provides comprehensive smoke tests for container runtime interactions, including image pulling, environment variable injection, workspace mounting, and container lifecycle management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration smoke tests covering Docker- and Podman-compatible runtimes.
  * Verified image pulling, container startup, environment variables, mounted files, logging, tracking, and shutdown.
  * Integration tests are skipped by default and can be run explicitly when a container runtime is available.

* **Chores**
  * Expanded continuous integration coverage to Linux and macOS environments using Docker and Podman.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->