### PR TITLE
Fix --paste-images: mount X11 auth cookie

### DIFF
--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -47,6 +47,9 @@ from vibepod.core.launch import (
     parse_env_pairs as _parse_env_pairs,
 )
 from vibepod.core.launch import (
+    prepare_x11_auth as _prepare_x11_auth,
+)
+from vibepod.core.launch import (
     read_claude_stored_token as _read_claude_stored_token,
 )
 from vibepod.core.launch import (
@@ -455,7 +458,13 @@ def run(
         if not display:
             warning("--paste-images requires DISPLAY to be set; skipping X11 forwarding")
         else:
-            x11_vols, x11_env = _x11_volumes_and_env(display)
+            x11_auth = _prepare_x11_auth(display, config_dir)
+            if x11_auth is None:
+                warning(
+                    "Could not prepare an X11 auth cookie (is `xauth` installed?); "
+                    "clipboard access may be rejected by the X server"
+                )
+            x11_vols, x11_env = _x11_volumes_and_env(display, x11_auth)
             extra_volumes.extend(x11_vols)
             merged_env.update(x11_env)
 

--- a/src/vibepod/core/launch.py
+++ b/src/vibepod/core/launch.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -128,10 +130,63 @@ def agent_extra_volumes(agent: str, config_dir: Path) -> list[tuple[str, str, st
     return []
 
 
-def x11_volumes_and_env(display: str) -> tuple[list[tuple[str, str, str]], dict[str, str]]:
+X11_CONTAINER_XAUTH_PATH = "/tmp/.vibepod-xauth"
+
+
+def prepare_x11_auth(display: str, config_dir: Path) -> Path | None:
+    """Write an Xauthority file whose cookies work from inside the container.
+
+    Host cookies are keyed to the host's hostname (FamilyLocal); the container
+    has a different hostname, so the X server rejects its connections with
+    "Authorization required, but no authorization protocol specified".
+    Rewriting the address family to FamilyWild (0xffff) makes the cookie match
+    regardless of hostname.
+    """
+    xauth = shutil.which("xauth")
+    if xauth is None:
+        return None
+    try:
+        nlist = subprocess.run(
+            [xauth, "nlist", display],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    entries = [line for line in nlist.stdout.splitlines() if line.strip()]
+    if nlist.returncode != 0 or not entries:
+        return None
+
+    wild = "".join(f"ffff{line[4:]}\n" for line in entries)
+    auth_file = config_dir / "Xauthority"
+    try:
+        fd = os.open(auth_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        os.close(fd)
+        os.chmod(auth_file, 0o600)
+        merge = subprocess.run(
+            [xauth, "-f", str(auth_file), "nmerge", "-"],
+            input=wild,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if merge.returncode != 0:
+        return None
+    return auth_file
+
+
+def x11_volumes_and_env(
+    display: str, xauth_file: Path | None = None
+) -> tuple[list[tuple[str, str, str]], dict[str, str]]:
     """Return X11 socket volumes and DISPLAY env for paste-image support."""
     volumes: list[tuple[str, str, str]] = [("/tmp/.X11-unix", "/tmp/.X11-unix", "rw")]
     env: dict[str, str] = {"DISPLAY": display}
+    if xauth_file is not None:
+        volumes.append((str(xauth_file), X11_CONTAINER_XAUTH_PATH, "ro"))
+        env["XAUTHORITY"] = X11_CONTAINER_XAUTH_PATH
     return volumes, env
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 import importlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -590,7 +591,8 @@ def test_prepare_x11_auth_writes_wildcard_cookie(monkeypatch, tmp_path: Path) ->
     assert merged["file"] == str(result)
     assert merged["input"].startswith("ffff ")
     assert merged["input"].strip().endswith("deadbeefdeadbeef")
-    assert (result.stat().st_mode & 0o777) == 0o600
+    if os.name != "nt":  # POSIX file modes are not meaningful on Windows
+        assert (result.stat().st_mode & 0o777) == 0o600
 
 
 def test_prepare_x11_auth_returns_none_without_xauth_binary(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 import importlib
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -15,7 +16,7 @@ from typer.testing import CliRunner
 from vibepod.cli import app
 from vibepod.commands import run as run_cmd
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING, SUPPORTED_AGENTS
-from vibepod.core import skills_engine
+from vibepod.core import launch, skills_engine
 from vibepod.core.docker import DockerClientError, DockerManager
 
 # ---------------------------------------------------------------------------
@@ -551,6 +552,64 @@ def test_x11_volumes_and_env_returns_socket_and_display() -> None:
     assert env == {"DISPLAY": ":0"}
 
 
+def test_x11_volumes_and_env_mounts_xauth_file(tmp_path: Path) -> None:
+    """When an auth file is prepared, it is mounted read-only and XAUTHORITY is set."""
+    auth_file = tmp_path / "Xauthority"
+    auth_file.write_bytes(b"cookie")
+
+    volumes, env = run_cmd._x11_volumes_and_env(":0", auth_file)
+
+    assert (str(auth_file), launch.X11_CONTAINER_XAUTH_PATH, "ro") in volumes
+    assert env["XAUTHORITY"] == launch.X11_CONTAINER_XAUTH_PATH
+    assert env["DISPLAY"] == ":0"
+
+
+def test_prepare_x11_auth_writes_wildcard_cookie(monkeypatch, tmp_path: Path) -> None:
+    """Host cookies are rewritten to FamilyWild (ffff) so they match any hostname."""
+    nlist_line = (
+        "0100 0004 6d79686f7374 0001 30 0012 "
+        "4d49542d4d414749432d434f4f4b49452d31 0010 deadbeefdeadbeef"
+    )
+    merged: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        if "nlist" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=nlist_line + "\n", stderr="")
+        if "nmerge" in cmd:
+            merged["input"] = kwargs.get("input")
+            merged["file"] = cmd[cmd.index("-f") + 1]
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(launch.shutil, "which", lambda name: "/usr/bin/xauth")
+    monkeypatch.setattr(launch.subprocess, "run", fake_run)
+
+    result = launch.prepare_x11_auth(":0", tmp_path)
+
+    assert result == tmp_path / "Xauthority"
+    assert merged["file"] == str(result)
+    assert merged["input"].startswith("ffff ")
+    assert merged["input"].strip().endswith("deadbeefdeadbeef")
+    assert (result.stat().st_mode & 0o777) == 0o600
+
+
+def test_prepare_x11_auth_returns_none_without_xauth_binary(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(launch.shutil, "which", lambda name: None)
+    assert launch.prepare_x11_auth(":0", tmp_path) is None
+
+
+def test_prepare_x11_auth_returns_none_on_empty_cookie_list(monkeypatch, tmp_path: Path) -> None:
+    """No cookies for the display (e.g. xhost-only setups) → no auth file."""
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(launch.shutil, "which", lambda name: "/usr/bin/xauth")
+    monkeypatch.setattr(launch.subprocess, "run", fake_run)
+
+    assert launch.prepare_x11_auth(":0", tmp_path) is None
+
+
 def test_x11_volumes_and_env_preserves_display_value() -> None:
     volumes, env = run_cmd._x11_volumes_and_env(":1")
     assert env["DISPLAY"] == ":1"
@@ -599,6 +658,56 @@ def test_paste_images_flag_adds_x11_volumes_and_env(monkeypatch, tmp_path: Path)
     assert ("/tmp/.X11-unix", "/tmp/.X11-unix", "rw") in captured.get(
         "extra_volumes", []
     ), f"X11 socket not found in extra_volumes: {captured.get('extra_volumes')}"
+
+
+def test_paste_images_flag_mounts_xauth_cookie(monkeypatch, tmp_path: Path) -> None:
+    """--paste-images prepares an auth cookie and passes XAUTHORITY to the container."""
+    captured: dict = {}
+
+    class _CapturingDockerManager:
+        def ensure_network(self, name: str) -> None:
+            pass
+
+        def networks_with_running_containers(self) -> list[str]:
+            return []
+
+        def pull_image(self, image: str) -> None:
+            pass
+
+        def ensure_proxy(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+        def run_agent(self, **kwargs) -> object:  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+            container = type(
+                "_Container",
+                (),
+                {
+                    "name": "vibepod-claude-test",
+                    "id": "abc123",
+                    "status": "running",
+                    "attrs": {"NetworkSettings": {"Networks": {}}},
+                    "reload": lambda self: None,
+                    "labels": {},
+                    "logs": lambda self, **kw: b"",
+                },
+            )()
+            return container
+
+    auth_file = tmp_path / "Xauthority"
+    auth_file.write_bytes(b"cookie")
+
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
+    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+    monkeypatch.setattr(run_cmd, "_prepare_x11_auth", lambda display, config_dir: auth_file)
+
+    run_cmd.run(agent="claude", workspace=tmp_path, detach=True, paste_images=True)
+
+    assert (str(auth_file), launch.X11_CONTAINER_XAUTH_PATH, "ro") in captured.get(
+        "extra_volumes", []
+    ), f"Xauthority mount not found in extra_volumes: {captured.get('extra_volumes')}"
+    assert captured.get("env", {}).get("XAUTHORITY") == launch.X11_CONTAINER_XAUTH_PATH
 
 
 def test_paste_images_flag_warns_when_display_not_set(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Improves X11 authentication support for containerized runs, particularly for the `--paste-images` feature, by ensuring that X11 authorization cookies are correctly prepared and mounted inside the container. It introduces a new function to generate a wildcard Xauthority file, updates the container environment and volumes accordingly, and adds comprehensive tests to verify the new behavior.

**X11 Authentication Improvements:**

* Added the `prepare_x11_auth` function in `vibepod/core/launch.py` to generate an Xauthority file with wildcard (FamilyWild) cookies, ensuring X11 authentication works inside containers regardless of hostname.
* Updated the `x11_volumes_and_env` function to accept an optional Xauthority file and mount it read-only in the container, setting the `XAUTHORITY` environment variable if present.
* Modified the `run` command in `vibepod/commands/run.py` to use the new Xauthority preparation logic and warn the user if the `xauth` binary is missing.