### PR TITLE
Ability to install skills from a local file or directory

### DIFF
--- a/docs/skills/authoring.md
+++ b/docs/skills/authoring.md
@@ -37,11 +37,11 @@ Free-form markdown instructions. Must not be empty.
 ## Authoring loop
 
 ```bash
-mkdir -p ./skills/my-skill
-$EDITOR ./skills/my-skill/SKILL.md
+mkdir -p skills/my-skill
+$EDITOR skills/my-skill/SKILL.md
 
 # install as a symlink so edits show up immediately
-vp skills add ./skills/my-skill --link --scope local
+vp skills add skills/my-skill --link --scope local
 
 # iterate, then validate:
 docker run --rm -v "$PWD/skills/my-skill:/in" \

--- a/docs/skills/locators.md
+++ b/docs/skills/locators.md
@@ -58,15 +58,29 @@ The recommended naming convention for the curated channel is `vibepod-skill-<id>
 <relative-or-absolute-path>
 ```
 
-There is no `file:` scheme — bare paths only. Local locators are distinguished
-from other sources by a leading `.` or `/`.
+There is no `file:` scheme — bare paths only. Any locator that carries no scheme
+is treated as a filesystem path.
 
 Examples:
 
 ```text
+skills/researcher
 ./skills/researcher
+../shared/skills/researcher
 /abs/path/to/skill
+.
+~/skills/researcher
 ```
+
+A leading `~` is expanded on your machine before the engine container starts.
+Locators that look like a scheme but are not supported — `ftp://…`, `mailto:…` —
+are rejected with `Unrecognized locator`. A directory whose first path segment
+contains a colon must therefore be written with a leading `./`.
+
+The one scheme-less exception is an scp-style Git remote — `user@host:path`,
+such as `git@git.example.com:org/repo.git//skills/foo`. That shape needs both
+the `@` and the `:` separator, so a directory named `git@my-skill` is still
+treated as a path.
 
 Use `--link` for symlink installs while authoring a skill:
 

--- a/src/vibepod/core/skills_engine.py
+++ b/src/vibepod/core/skills_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,6 +21,14 @@ from vibepod.core.config import get_config
 from vibepod.core.docker import DockerClientError, DockerManager, NotFound
 
 Scope = Literal["local", "user"]
+
+# Two or more characters before the colon: every locator scheme we support is
+# longer than one character, so a single letter is a Windows drive (``C:\...``).
+_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]+:")
+
+# scp-style git remote: user@host:path. A bare "git@something" with no remote
+# separator is a directory name, not a locator.
+_SCP_RE = re.compile(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:")
 
 _skills_engine_checked = False
 
@@ -82,11 +91,28 @@ def _ensure_dirs(
 
 
 def _is_local_locator(locator: str) -> bool:
-    return locator.startswith("./") or locator.startswith("../") or locator.startswith("/")
+    """Local when the locator carries no scheme.
+
+    Covers ``./skills/foo``, ``../foo``, ``/abs/path``, ``skills/foo``, ``.``,
+    ``..`` and ``~/skills/foo``. Anything scheme-like (``github:``, ``npm:``,
+    ``https://``, ``ftp://``) is left to the engine, which rejects the ones it
+    does not support. scp-style git remotes (``git@host:org/repo.git``) are the
+    one scheme-less exception; a directory named ``git@foo`` stays local.
+    """
+    if _SCP_RE.match(locator):
+        return False
+    return not _SCHEME_RE.match(locator)
 
 
 def _normalize_locator(locator: str) -> str:
-    """Accept common GitHub web URLs by converting them to skill locators."""
+    """Accept common GitHub web URLs by converting them to skill locators.
+
+    Also expands a leading ``~`` on the host: the engine container has a
+    different home directory, so ``~`` cannot survive the boundary.
+    """
+    if locator == "~" or locator.startswith("~/"):
+        return str(Path(locator).expanduser())
+
     parsed = urlparse(locator)
     if parsed.scheme not in {"http", "https"}:
         return locator

--- a/tests/test_skills_engine_driver.py
+++ b/tests/test_skills_engine_driver.py
@@ -166,6 +166,132 @@ def test_add_rejects_missing_local_locator(tmp_path: Path) -> None:
         skills_engine.add("./missing", scope="user", cwd=tmp_path)
 
 
+def test_add_mounts_bare_relative_local_locator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cwd = tmp_path / "project"
+    source = cwd / "skills" / "researcher"
+    source.mkdir(parents=True)
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    skills_engine.add("skills/researcher", scope="user", cwd=cwd)
+
+    cmd = captured["cmd"]
+    mount_args = [arg for i, arg in enumerate(cmd) if cmd[i - 1] == "-v"]
+    assert f"{source.resolve()}:{source.resolve()}:ro" in mount_args
+    assert "-w" in cmd
+    assert str(cwd.resolve()) in cmd
+    # locator string reaches the engine unmodified
+    assert "skills/researcher" in cmd
+
+
+def test_add_mounts_current_directory_locator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    source = tmp_path / "skill"
+    source.mkdir()
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    skills_engine.add(".", scope="user", cwd=source)
+
+    cmd = captured["cmd"]
+    mount_args = [arg for i, arg in enumerate(cmd) if cmd[i - 1] == "-v"]
+    assert f"{source.resolve()}:{source.resolve()}:ro" in mount_args
+    assert "." in cmd
+
+
+def test_add_does_not_mount_remote_locators(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    remotes = (
+        "github:org/repo",
+        "npm:@acme/pkg",
+        "https://git.example.com/x.git",
+        "git@git.example.com:org/repo.git",
+        "ftp://x/y",
+    )
+    for locator in remotes:
+        skills_engine.add(locator, scope="user", cwd=tmp_path)
+        cmd = captured["cmd"]
+        mount_args = [arg for i, arg in enumerate(cmd) if cmd[i - 1] == "-v"]
+        assert not any(m.endswith(":ro") for m in mount_args), locator
+        assert "-w" not in cmd, locator
+
+
+def test_add_expands_tilde_local_locator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    source = home / "skills" / "foo"
+    source.mkdir(parents=True)
+    # POSIX expanduser reads HOME, ntpath.expanduser reads USERPROFILE.
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setattr(skills_engine, "USER_SKILLS_DIR", tmp_path / "user")
+    monkeypatch.setattr(skills_engine, "SKILLS_CACHE_DIR", tmp_path / "cache")
+
+    fake_run, captured = _fake_run_factory(stdout=json.dumps([]))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    skills_engine.add("~/skills/foo", scope="user", cwd=tmp_path)
+
+    cmd = captured["cmd"]
+    mount_args = [arg for i, arg in enumerate(cmd) if cmd[i - 1] == "-v"]
+    assert f"{source.resolve()}:{source.resolve()}:ro" in mount_args
+    # the engine receives the expanded absolute path, never a bare "~"
+    assert str(home / "skills" / "foo") in cmd
+    assert not any(arg.startswith("~") for arg in cmd)
+
+
+def test_is_local_locator_classifies_paths_and_schemes() -> None:
+    """Platform-independent: a Windows drive letter is a path, not a scheme."""
+    for local in (
+        "skills/foo",
+        "./skills/foo",
+        "../shared/skills/foo",
+        "/abs/path",
+        ".",
+        "..",
+        "~/skills/foo",
+        r"C:\dev\skills\foo",
+        "C:/dev/skills/foo",
+        # a directory literally named "git@..." has no scp remote separator
+        "git@local-skill",
+        "./git@local-skill",
+    ):
+        assert skills_engine._is_local_locator(local), local
+
+    for remote in (
+        "github:org/repo",
+        "gitlab:group/repo",
+        "npm:@acme/pkg",
+        "https://git.example.com/x.git",
+        "http://git.example.com/x.git",
+        "ftp://x/y",
+        "git@git.example.com:org/repo.git",
+    ):
+        assert not skills_engine._is_local_locator(remote), remote
+
+
+def test_add_rejects_missing_bare_local_locator(tmp_path: Path) -> None:
+    with pytest.raises(skills_engine.SkillsEngineError, match="Local skill locator not found"):
+        skills_engine.add("skills/missing", scope="user", cwd=tmp_path)
+
+
 def test_run_engine_pulls_image_when_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Refines how local skill locators are detected and handled, making the system more robust and user-friendly. It expands support for various local path formats, ensures tilde (`~`) expansion, and improves documentation. Comprehensive tests are added to cover these scenarios and prevent regressions.

**Local locator detection and normalization improvements:**
* Updated `_is_local_locator` in `skills_engine.py` to treat any locator without a URI scheme as local, including bare paths like `skills/foo`, `.`, `..`, and `~/skills/foo`. Locators with a scheme (e.g., `github:`, `https://`) are not considered local.
* Enhanced `_normalize_locator` to expand a leading `~` to the user's home directory, ensuring compatibility with the engine container.
* Added a regular expression `_SCHEME_RE` to reliably detect URI schemes.

**Documentation updates:**
* Improved documentation in `authoring.md` and `locators.md` to clarify that bare paths (with or without `./`) are local locators, and that a leading `~` is expanded before reaching the engine container.

**Test coverage:**
* Added tests to verify that bare relative paths, the current directory (`.`), and tilde-expanded paths are correctly mounted as local skills, while remote locators are not. Also tests that missing local paths are properly rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified local skill locator syntax and supported path formats.
  * Documented tilde expansion, unsupported schemes, and path validation rules.
  * Updated local setup examples for creating and linking skills.

* **Bug Fixes**
  * Improved handling of relative, absolute, current-directory, home-directory, and parent-relative skill paths.
  * Remote locators are now distinguished from local paths more reliably.
  * Added clearer errors when a referenced local skill directory cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->