### PR TITLE
Add tau coding agent to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 
 - ⚡ **Zero config** — no setup required; `vp run <agent>` just works. Optional YAML for custom configuration
 - 🐳 **Isolated agents** — each agent runs in its own Docker or Podman container
-- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy & more
+- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau & more
 - 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics
 - ⚖️ **Agent comparison** — benchmark multiple agents against each other in the dashboard
@@ -68,6 +68,7 @@ Use `--ikwid` to append each agent's auto-approval / permission-skip flag when s
 | `agy` | `--dangerously-skip-permissions` |
 | `opencode` | Not supported |
 | `auggie` | Not supported |
+| `tau` | Not supported |
 
 ![VibePod CLI preview](https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/preview.png)
 
@@ -129,6 +130,7 @@ Current defaults:
 - `codex` -> `vibepod/codex:latest`
 - `pi` -> `vibepod/pi:latest`
 - `agy` -> `vibepod/agy:latest`
+- `tau` -> `vibepod/tau:latest`
 - `datasette` -> `vibepod/datasette:latest`
 - `proxy` -> `vibepod/proxy:latest` ([repo](https://github.com/VibePod/vibepod-proxy))
 
@@ -147,6 +149,7 @@ VP_IMAGE_COPILOT=vibepod/copilot:latest vp run copilot
 VP_IMAGE_CODEX=vibepod/codex:latest vp run codex
 VP_IMAGE_PI=vibepod/pi:latest vp run pi
 VP_IMAGE_AGY=vibepod/agy:latest vp run agy
+VP_IMAGE_TAU=vibepod/tau:latest vp run tau
 VP_DATASETTE_IMAGE=vibepod/datasette:latest vp logs start
 VP_SKILLS_ENGINE_IMAGE=vibepod/skills-engine:latest vp skills list
 ```

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -15,6 +15,7 @@ VibePod manages each agent as a Docker or Podman container. Credentials and conf
 | `codex` | OpenAI | `vp x` | `vibepod/codex:latest` |
 | `pi` | Earendil | `vp pi` | `vibepod/pi:latest` |
 | `agy` (Antigravity) | Google | `vp n` | `vibepod/agy:latest` |
+| `tau` | Hugging Face | `vp t` | `vibepod/tau:latest` |
 
 Alias note: `vp run vibe` resolves to `vp run devstral`.
 
@@ -75,7 +76,7 @@ agents:
 
 ## Image customization workflows
 
-VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`). The CLI also supports the alias `vibe`, which resolves to `devstral`. Image customization means changing the image used for one of those IDs.
+VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`, `tau`). The CLI also supports the alias `vibe`, which resolves to `devstral`. Image customization means changing the image used for one of those IDs.
 
 ### 1. Extend an existing image for an agent
 
@@ -201,6 +202,7 @@ Use `--ikwid` to enable each agent's built-in auto-approval / permission-skip mo
 | `agy` | `--dangerously-skip-permissions` |
 | `opencode` | Not supported |
 | `auggie` | Not supported |
+| `tau` | Not supported |
 
 Example:
 
@@ -286,6 +288,7 @@ Task mode applies a finite timeout by default: **2 hours**. Override it per task
 | `claude` | `claude -p "<prompt>"` |
 | `codex` | `codex exec "<prompt>"` |
 | `auggie` | `auggie --print "<prompt>"` |
+| `tau` | `tau -p "<prompt>"` |
 
 Other agents error with a clear message; support can be added by setting `headless_prefix` on their `AgentSpec`.
 
@@ -621,3 +624,71 @@ Use `--ikwid` to append Agy's permission-skip flag:
 ```bash
 vp run agy --ikwid
 ```
+
+### Tau (Hugging Face)
+
+```bash
+vp run tau   # or: vp t
+```
+
+Tau is Hugging Face's minimalist, Pi-inspired terminal coding agent, written in
+Python. It is the first non-Node agent in the VibePod matrix. Credentials and
+configuration are persisted under `~/.config/vibepod/agents/tau/`, mounted at
+`/config` inside the container, where Tau finds them as `~/.tau/`:
+
+| Path in container | Contents |
+|---|---|
+| `/config/.tau/credentials.json` | Provider credentials written by `/login` (mode `0600`) |
+| `/config/.tau/providers.json` | Default provider, per-provider settings, scoped models |
+| `/config/.tau/catalog.toml` | Your own providers and models, overlaid on Tau's built-in catalog |
+| `/config/.tau/sessions/` | Durable JSONL session history (resume and branching) |
+
+**Authentication.** Start Tau and run the `/login` slash command:
+
+```text
+/login              # pick a provider interactively
+/login openai
+/login openai-codex # OpenAI Codex subscription auth
+/model              # choose a model
+```
+
+Tau supports OpenAI, Anthropic, the Codex subscription, OpenRouter, Hugging
+Face, and any custom OpenAI-compatible endpoint. Saved credentials take
+precedence over environment variables and survive container restarts because
+they live in the persisted mount.
+
+API keys can also be injected instead of using `/login`:
+
+```yaml
+agents:
+  tau:
+    env:
+      OPENAI_API_KEY: sk-...
+      HF_TOKEN: hf_...
+```
+
+Or per run: `vp run tau -e OPENAI_API_KEY=sk-...`.
+
+**Custom models.** Drop a `catalog.toml` into
+`~/.config/vibepod/agents/tau/.tau/catalog.toml` on the host to add providers
+and models; it is overlaid on Tau's bundled catalog (scalar fields replace,
+`models` merge with your entries first). Tau deliberately ignores project-level
+`.tau/catalog.toml`, so a repository cannot redirect your model traffic.
+
+**Proxy and TLS.** Tau uses `httpx`, not Node. VibePod's proxy env applies as
+usual: `HTTP_PROXY`/`HTTPS_PROXY` route traffic through `vibepod-proxy`, and
+`SSL_CERT_FILE` points at the mounted mitmproxy CA, which `httpx` honors for its
+verification context. Streaming responses pass through unchanged.
+
+**Non-interactive mode.** Tau's print mode works with both `vp run` and task
+mode:
+
+```bash
+vp run tau -p "explain this repo"
+vp task create tau "Summarize the README"
+```
+
+**Skills.** Tau scans `~/.agents/skills/`, so skills installed via `vp skills`
+are mounted at `/config/.agents/skills/<id>` and picked up automatically.
+
+Tau has no auto-approval flag, so `--ikwid` is not supported for it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,13 @@ agents:
     volumes: []
     init: []
 
+  tau:
+    enabled: true
+    image: vibepod/tau:latest
+    env: {}
+    volumes: []
+    init: []
+
 # Connect agents to a local or remote LLM server (Ollama, vLLM, etc.)
 llm:
   enabled: false
@@ -164,6 +171,7 @@ Each agent image can be overridden individually:
 | `VP_IMAGE_CODEX` | codex |
 | `VP_IMAGE_PI` | pi |
 | `VP_IMAGE_AGY` | agy |
+| `VP_IMAGE_TAU` | tau |
 | `VP_DATASETTE_IMAGE` | datasette (logs UI) |
 | `VP_PROXY_IMAGE` | proxy |
 | `VP_SKILLS_ENGINE_IMAGE` | skills-engine (used by `vp skills`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker 
 | `codex` | OpenAI | `vp x` |
 | `pi` | Earendil | `vp pi` |
 | `agy` (Antigravity) | Google | `vp n` |
+| `tau` | Hugging Face | `vp t` |
 
 ## Next Steps
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -126,8 +126,8 @@ Press **Ctrl+C** to stop the container when you are done.
 ## Shortcuts
 
 You can start agents with the full agent command. Most agents also have a single-letter
-shortcut; Pi uses `vp pi` because `vp p` is assigned to Copilot, and Agy uses
-`vp n`.
+shortcut; Pi uses `vp pi` because `vp p` is assigned to Copilot, Agy uses
+`vp n`, and Tau uses `vp t`.
 
 ```bash
 vp claude   # full name

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -115,6 +115,7 @@ def _agent_skill_paths(agent: str) -> list[str]:
       - pi       reads ~/.pi/agent/skills/          → /config/.pi/agent/skills/
       - opencode reads ~/.agents/skills/ (also ~/.claude/skills/, ~/.config/opencode/skills/)
       - auggie   reads ~/.agents/skills/ (also ~/.augment/skills/, ~/.claude/skills/)
+      - tau      reads ~/.agents/skills/ (also ~/.tau/skills/)
 
     Gemini wraps skills inside an extension manifest and would need a generated
     gemini-extension.json — handled separately when we add that support.
@@ -124,7 +125,7 @@ def _agent_skill_paths(agent: str) -> list[str]:
         return ["/claude/skills"]
     if agent == "pi":
         return ["/config/.pi/agent/skills"]
-    if agent in ("codex", "opencode", "auggie"):
+    if agent in ("codex", "opencode", "auggie", "tau"):
         return ["/config/.agents/skills"]
     return []
 

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -28,6 +28,7 @@ SUPPORTED_AGENTS = (
     "codex",
     "pi",
     "agy",
+    "tau",
 )
 
 AGENT_SHORTCUTS: dict[str, str] = {
@@ -39,6 +40,7 @@ AGENT_SHORTCUTS: dict[str, str] = {
     "p": "copilot",
     "x": "codex",
     "n": "agy",
+    "t": "tau",
 }
 
 AGENT_ALIASES: dict[str, str] = {
@@ -56,6 +58,7 @@ IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (
     "VP_IMAGE_CODEX",
     "VP_IMAGE_PI",
     "VP_IMAGE_AGY",
+    "VP_IMAGE_TAU",
     "VP_DATASETTE_IMAGE",
     "VP_PROXY_IMAGE",
     "VP_SKILLS_ENGINE_IMAGE",
@@ -112,6 +115,10 @@ def get_default_images() -> dict[str, str]:
         "agy": os.environ.get(
             "VP_IMAGE_AGY",
             f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/agy:latest",
+        ),
+        "tau": os.environ.get(
+            "VP_IMAGE_TAU",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/tau:latest",
         ),
         "datasette": os.environ.get(
             "VP_DATASETTE_IMAGE",

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -146,6 +146,19 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         platform="linux/amd64",
         ikwid_args=["--dangerously-skip-permissions"],
     ),
+    "tau": AgentSpec(
+        "tau",
+        "huggingface",
+        DEFAULT_IMAGES["tau"],
+        "tau",
+        ["tau"],
+        "/config",
+        # Tau derives every user-level path from HOME (~/.tau for sessions,
+        # credentials, providers.json and catalog.toml), so the persisted config
+        # mount at /config is all it needs.
+        {"HOME": "/config", "TAU_NO_UPDATE_CHECK": "1"},
+        headless_prefix=["-p"],
+    ),
 }
 
 _SHORTCUT_BY_AGENT = {agent: shortcut for shortcut, agent in AGENT_SHORTCUTS.items()}

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -108,6 +108,14 @@ def _default_config() -> dict[str, Any]:
                 "volumes": [],
                 "init": [],
             },
+            "tau": {
+                "enabled": True,
+                "image": DEFAULT_IMAGES["tau"],
+                "auto_pull": None,
+                "env": {},
+                "volumes": [],
+                "init": [],
+            },
         },
         "logging": {
             "enabled": True,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -63,6 +63,19 @@ def test_agy_spec_matches_container_contract() -> None:
     assert spec.platform == "linux/amd64"
 
 
+def test_tau_spec_matches_container_contract() -> None:
+    spec = get_agent_spec("tau")
+    assert spec.id == "tau"
+    assert spec.provider == "huggingface"
+    assert spec.image == DEFAULT_IMAGES["tau"]
+    assert spec.config_subdir == "tau"
+    assert spec.command == ["tau"]
+    assert spec.config_mount_path == "/config"
+    assert spec.extra_env["HOME"] == "/config"
+    assert spec.extra_env["TAU_NO_UPDATE_CHECK"] == "1"
+    assert spec.headless_prefix == ["-p"]
+
+
 def test_get_agent_spec_unknown() -> None:
     with pytest.raises(ValueError):
         get_agent_spec("unknown")
@@ -116,7 +129,7 @@ def test_gemini_spec_runs_via_node_wrapper() -> None:
 
 
 def test_unsupported_agents_have_no_ikwid_args() -> None:
-    for agent in ("opencode", "auggie"):
+    for agent in ("opencode", "auggie", "tau"):
         spec = get_agent_spec(agent)
         assert spec.ikwid_args is None, f"{agent} should not have ikwid_args"
 
@@ -156,7 +169,7 @@ def test_codex_spec_has_llm_env_map() -> None:
 
 
 def test_agents_without_llm_env_map() -> None:
-    for agent in ("gemini", "opencode", "devstral", "auggie", "copilot", "pi", "agy"):
+    for agent in ("gemini", "opencode", "devstral", "auggie", "copilot", "pi", "agy", "tau"):
         spec = get_agent_spec(agent)
         assert spec.llm_env_map is None, f"{agent} should not have llm_env_map"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,21 @@ def test_pi_alias_runs_agent(monkeypatch) -> None:
     assert called["passthrough"] == []
 
 
+def test_tau_shortcut_runs_tau(monkeypatch) -> None:
+    called: dict[str, object] = {"agent": None, "passthrough": None}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        called["agent"] = agent
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["t"])
+    assert result.exit_code == 0
+    assert called["agent"] == "tau"
+    assert called["passthrough"] == []
+
+
 def test_copilot_shortcut_still_runs_copilot(monkeypatch) -> None:
     called: dict[str, object] = {"agent": None, "passthrough": None}
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -17,6 +17,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
         "VP_IMAGE_CODEX",
         "VP_IMAGE_PI",
         "VP_IMAGE_AGY",
+        "VP_IMAGE_TAU",
         "VP_DATASETTE_IMAGE",
         "VP_PROXY_IMAGE",
     ):
@@ -33,6 +34,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
     assert images["codex"] == "vibepod/codex:latest"
     assert images["pi"] == "vibepod/pi:latest"
     assert images["agy"] == "vibepod/agy:latest"
+    assert images["tau"] == "vibepod/tau:latest"
     assert images["datasette"] == "vibepod/datasette:latest"
     assert images["proxy"] == "vibepod/proxy:latest"
 
@@ -51,3 +53,11 @@ def test_agy_image_override(monkeypatch) -> None:
     images = get_default_images()
 
     assert images["agy"] == "example/agy:dev"
+
+
+def test_tau_image_override(monkeypatch) -> None:
+    monkeypatch.setenv("VP_IMAGE_TAU", "example/tau:dev")
+
+    images = get_default_images()
+
+    assert images["tau"] == "example/tau:dev"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -87,7 +87,7 @@ def test_agent_extra_volumes_for_auggie(tmp_path: Path) -> None:
 def test_agent_extra_volumes_for_other_agents(tmp_path: Path) -> None:
     config_dir = tmp_path / "agents" / "claude"
     # Agents without explicit volume mappings return empty
-    for agent in ("claude", "gemini", "codex", "devstral", "pi", "agy"):
+    for agent in ("claude", "gemini", "codex", "devstral", "pi", "agy", "tau"):
         assert run_cmd._agent_extra_volumes(agent, config_dir) == []
 
 
@@ -195,6 +195,28 @@ def test_skills_mounts_for_pi_use_agent_dir_skills_path(
 
     assert run_cmd._skills_mounts_for_agent("pi", tmp_path) == [
         (str(skill_dir.resolve()), "/config/.pi/agent/skills/example", "ro")
+    ]
+
+
+def test_skills_mounts_for_tau_use_agents_skills_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    local_root = tmp_path / "local-skills"
+    user_root = tmp_path / "user-skills"
+    skill_dir = local_root / "installed" / "example"
+    skill_dir.mkdir(parents=True)
+    user_root.mkdir()
+    (local_root / "skills-lock.json").write_text(
+        json.dumps({"skills": {"example": {"path": "installed/example"}}}),
+        encoding="utf-8",
+    )
+    (user_root / "skills-lock.json").write_text(json.dumps({"skills": {}}), encoding="utf-8")
+
+    monkeypatch.setattr(skills_engine, "local_skills_dir", lambda workspace: local_root)
+    monkeypatch.setattr(skills_engine, "user_skills_dir", lambda: user_root)
+
+    assert run_cmd._skills_mounts_for_agent("tau", tmp_path) == [
+        (str(skill_dir.resolve()), "/config/.agents/skills/example", "ro")
     ]
 
 

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -108,6 +108,7 @@ def test_headless_prefix_set_for_supported_agents() -> None:
     assert AGENT_SPECS["claude"].headless_prefix == ["-p"]
     assert AGENT_SPECS["codex"].headless_prefix == ["exec"]
     assert AGENT_SPECS["auggie"].headless_prefix == ["--print"]
+    assert AGENT_SPECS["tau"].headless_prefix == ["-p"]
 
 
 def test_headless_prefix_none_for_unsupported_agents() -> None:


### PR DESCRIPTION
Adds support for the new [Hugging Face Tau ](https://github.com/huggingface/tau)agent to VibePod, including all core logic, configuration, documentation, and tests. Tau is now a first-class supported agent, with a dedicated Docker image, CLI shortcut, skills mounting, and environment variable overrides. The documentation has been updated throughout to describe Tau's features, configuration, and usage.

**Tau agent integration**

* Added `tau` as a supported agent throughout the codebase, including `AGENT_IDS`, CLI shortcuts (`vp t`), default images, and environment variable overrides. 
* Implemented `AgentSpec` for Tau, configuring its image, command, environment, config mount, and headless (print) mode.
* Updated skills mounting logic so Tau uses the shared `.agents/skills` directory, and added tests for skills mounting. 
* Updated agent extra volumes and config defaults to include Tau, with corresponding tests. 

Implements https://github.com/VibePod/vibepod-cli/issues/106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Hugging Face Tau agent.
  * Added the `vp t` shortcut for launching Tau.
  * Added Tau configuration, image overrides, authentication, provider, model, proxy, and skills guidance.
  * Added headless and non-interactive execution support.
  * Added automatic skills discovery and mounting for Tau.

* **Documentation**
  * Updated supported-agent tables, quickstart guidance, configuration references, and image customization examples.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->