### PR TITLE
Adapt docs for 0.18.0, bump version

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -210,6 +210,32 @@ Example:
 vp run codex --ikwid
 ```
 
+## Pasting images (`--paste-images`)
+
+Agents that accept pasted screenshots need access to your clipboard, which lives
+on the host X server. Use `--paste-images` to forward it:
+
+```bash
+vp run claude --paste-images
+```
+
+VibePod mounts the X11 socket (`/tmp/.X11-unix`), passes your `DISPLAY`, and
+prepares an X authority cookie for the container. Host cookies are bound to the
+host's hostname, which the container does not share, so VibePod rewrites the
+cookie to the wildcard address family and mounts it read-only at
+`/tmp/.vibepod-xauth`. Without that rewrite the X server answers with
+"Authorization required, but no authorization protocol specified".
+
+Requirements and caveats:
+
+- `DISPLAY` must be set; otherwise VibePod warns and starts without forwarding.
+- The `xauth` binary must be available on the host, otherwise the cookie cannot
+  be prepared and clipboard access may be rejected.
+- X11 only (including XWayland). There is no Wayland-native or macOS clipboard
+  forwarding.
+- Forwarding the X socket lets the container talk to your X server; only use it
+  with agents you trust.
+
 ## Detached mode
 
 Use `-d` / `--detach` to start an agent container in the background without attaching your terminal. The agent process starts immediately inside the container — `-d` only controls whether VibePod attaches your terminal to it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vibepod"
-version = "0.17.0"
+version = "0.18.0"
 description = "One CLI for containerized AI coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/vibepod/__init__.py
+++ b/src/vibepod/__init__.py
@@ -1,3 +1,3 @@
 """VibePod package."""
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from platformdirs import user_config_dir
 
 APP_NAME = "vibepod"
-VERSION = "0.17.0"
+VERSION = "0.18.0"
 
 CONFIG_DIR = Path(user_config_dir(APP_NAME))
 GLOBAL_CONFIG_FILE = CONFIG_DIR / "config.yaml"


### PR DESCRIPTION
Updates the VibePod project to version 0.18.0 and adds documentation for the new `--paste-images` feature, which enables clipboard (image) forwarding for agents that support pasted screenshots. The most important changes are:

Documentation updates:

* Added a new section to `docs/agents/index.md` describing the `--paste-images` option, including usage instructions, requirements, caveats, and security considerations for clipboard forwarding via X11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for forwarding host clipboard images into agent containers with `--paste-images`.
  * Documented supported environments, setup requirements, warnings, and security considerations.

* **Release**
  * Updated the application version to 0.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->