### PR TITLE
Project based image overlays, auto-built Dockerfile fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 - 🐳 **Isolated agents** — each agent runs in its own Docker or Podman container
 - 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau & more
 - 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
+- 🧱 **Project overlays** — commit a `FROM`-less Dockerfile fragment in `.vibepod/overlay/` and VibePod auto-builds a cached, content-addressed image layer on top of the agent's base image ([docs](https://vibepod.dev/docs/overlays/))
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics
 - ⚖️ **Agent comparison** — benchmark multiple agents against each other in the dashboard
 - 🔒 **Privacy-first** — all metrics collected and stored locally, never sent to the cloud

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,7 @@ agents:
     env: {}       # Extra environment variables passed to the container
     volumes: []   # Reserved for future use
     init: []      # Optional shell commands run before agent startup
+    overlay: true # Set false to ignore the project's .vibepod/overlay/ (see Project overlays)
 
   gemini:
     enabled: true

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -3,7 +3,7 @@
 A project can extend the agent image it runs in — extra apt packages, language
 toolchains, CLIs — by committing a `FROM`-less Dockerfile fragment:
 
-```
+```text
 .vibepod/overlay/
 ├── Dockerfile          # shared: applies to every agent in this project
 └── claude/

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -31,6 +31,9 @@ RUN pip install -r /tmp/requirements.txt
 ```
 
 Because the directory is committable, the whole team shares the environment.
+Symlinks anywhere in the overlay directory — including a symlinked
+`Dockerfile` — are ignored: their targets may not exist on a teammate's
+machine or may point outside the committed project.
 
 ## Compared to `init` and custom images
 
@@ -45,7 +48,8 @@ Because the directory is committable, the whole team shares the environment.
 ## Controls
 
 - `vp run <agent> --no-overlay` — skip the overlay for one run
-- `vp run <agent> --rebuild-overlay` — force a rebuild
+- `vp run <agent> --rebuild-overlay` — force a rebuild, bypassing docker's
+  layer cache so every instruction re-runs
 - `agents.<agent>.overlay: false` in `.vibepod/config.yaml` or the global
   config — disable overlays for that agent
 

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -1,0 +1,53 @@
+# Project overlays
+
+A project can extend the agent image it runs in — extra apt packages, language
+toolchains, CLIs — by committing a `FROM`-less Dockerfile fragment:
+
+```
+.vibepod/overlay/
+├── Dockerfile          # shared: applies to every agent in this project
+└── claude/
+    └── Dockerfile      # per-agent: wins over the shared one for claude
+```
+
+On `vp run` (and `vp task create`), VibePod appends the fragment to the agent's
+base image and builds a workspace-local image tagged
+`vibepod/overlay-<agent>:<hash>`. The hash covers the base image, the fragment,
+and every file in the overlay directory, so:
+
+- unchanged overlays never rebuild — the cached image is reused instantly
+- switching branches with different overlays just switches images
+- pulling a newer base image rebuilds the overlay on top of it
+
+The overlay directory is the docker build context, so the fragment can `COPY`
+files committed next to it:
+
+```dockerfile
+# .vibepod/overlay/Dockerfile — no FROM line
+RUN apt-get update && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+```
+
+Because the directory is committable, the whole team shares the environment.
+
+## Compared to `init` and custom images
+
+- `agents.<agent>.init` re-runs shell commands on **every** start — good for
+  tiny setup, slow for package installs.
+- A custom image (`agents.<agent>.image`, see
+  [Customizing agent images](agents/index.md#overriding-the-image)) is fully
+  manual: write a complete Dockerfile, build, tag, configure.
+- An overlay sits in between: persistent like a custom image, zero-ceremony
+  like `init`.
+
+## Controls
+
+- `vp run <agent> --no-overlay` — skip the overlay for one run
+- `vp run <agent> --rebuild-overlay` — force a rebuild
+- `agents.<agent>.overlay: false` in `.vibepod/config.yaml` or the global
+  config — disable overlays for that agent
+
+Superseded overlay images for the same project and agent are removed
+automatically after each successful build.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Overview: skills/index.md
     - Locator format: skills/locators.md
     - Authoring: skills/authoring.md
+  - Project overlays: overlays.md
   - Configuration: configuration.md
   - LLM Integration: llm.md
   - CLI Reference: cli-reference.md

--- a/src/vibepod/cli.py
+++ b/src/vibepod/cli.py
@@ -44,6 +44,13 @@ def run_command(
         Path, typer.Option("-w", "--workspace", help="Workspace directory")
     ] = Path("."),
     pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    no_overlay: Annotated[
+        bool, typer.Option("--no-overlay", help="Skip the project overlay image")
+    ] = False,
+    rebuild_overlay: Annotated[
+        bool,
+        typer.Option("--rebuild-overlay", help="Force rebuilding the project overlay image"),
+    ] = False,
     detach: Annotated[
         bool, typer.Option("-d", "--detach", help="Run container in background")
     ] = False,
@@ -76,6 +83,8 @@ def run_command(
         agent=agent,
         workspace=workspace,
         pull=pull,
+        no_overlay=no_overlay,
+        rebuild_overlay=rebuild_overlay,
         detach=detach,
         env=env,
         name=name,
@@ -109,8 +118,13 @@ def _register_run_alias(command_name: str, agent_name: str) -> None:
         workspace: Annotated[
             Path, typer.Option("-w", "--workspace", help="Workspace directory")
         ] = Path("."),
-        pull: Annotated[
-            bool, typer.Option("--pull", help="Pull latest image before run")
+        pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+        no_overlay: Annotated[
+            bool, typer.Option("--no-overlay", help="Skip the project overlay image")
+        ] = False,
+        rebuild_overlay: Annotated[
+            bool,
+            typer.Option("--rebuild-overlay", help="Force rebuilding the project overlay image"),
         ] = False,
         detach: Annotated[
             bool, typer.Option("-d", "--detach", help="Run container in background")
@@ -119,9 +133,7 @@ def _register_run_alias(command_name: str, agent_name: str) -> None:
             list[str] | None,
             typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
         ] = None,
-        name: Annotated[
-            str | None, typer.Option("--name", help="Custom container name")
-        ] = None,
+        name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
         network: Annotated[
             str | None,
             typer.Option(
@@ -148,6 +160,8 @@ def _register_run_alias(command_name: str, agent_name: str) -> None:
             agent=agent_name,
             workspace=workspace,
             pull=pull,
+            no_overlay=no_overlay,
+            rebuild_overlay=rebuild_overlay,
             detach=detach,
             env=env,
             name=name,

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -32,6 +32,9 @@ from vibepod.core.launch import (
     agent_init_commands as _agent_init_commands,
 )
 from vibepod.core.launch import (
+    apply_overlay_if_enabled,
+)
+from vibepod.core.launch import (
     get_container_ip as _get_container_ip,
 )
 from vibepod.core.launch import (
@@ -241,6 +244,13 @@ def run(
         Path, typer.Option("-w", "--workspace", help="Workspace directory")
     ] = Path("."),
     pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    no_overlay: Annotated[
+        bool, typer.Option("--no-overlay", help="Skip the project overlay image")
+    ] = False,
+    rebuild_overlay: Annotated[
+        bool,
+        typer.Option("--rebuild-overlay", help="Force rebuilding the project overlay image"),
+    ] = False,
     detach: Annotated[
         bool, typer.Option("-d", "--detach", help="Run container in background")
     ] = False,
@@ -398,6 +408,16 @@ def run(
     if should_pull:
         info(f"Pulling image: {image}")
         manager.pull_image(image, auto_clean=bool(config.get("auto_clean", True)))
+
+    image = apply_overlay_if_enabled(
+        manager=manager,
+        workspace_path=workspace_path,
+        agent=selected_agent,
+        image=image,
+        agent_cfg=agent_cfg,
+        no_overlay=no_overlay,
+        rebuild_overlay=rebuild_overlay,
+    )
 
     command = spec.command
     entrypoint: list[str] | None = None

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -29,6 +29,7 @@ from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag
 from vibepod.core.launch import (
     agent_extra_volumes,
     agent_init_commands,
+    apply_overlay_if_enabled,
     get_container_ip,
     host_identity_env,
     host_user,
@@ -294,6 +295,13 @@ def task_create_command(
         ),
     ] = DEFAULT_TASK_TIMEOUT,
     pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    no_overlay: Annotated[
+        bool, typer.Option("--no-overlay", help="Skip the project overlay image")
+    ] = False,
+    rebuild_overlay: Annotated[
+        bool,
+        typer.Option("--rebuild-overlay", help="Force rebuilding the project overlay image"),
+    ] = False,
     ikwid: Annotated[
         bool,
         typer.Option(
@@ -312,6 +320,8 @@ def task_create_command(
         network=network,
         timeout=timeout,
         pull=pull,
+        no_overlay=no_overlay,
+        rebuild_overlay=rebuild_overlay,
         ikwid=ikwid,
         passthrough_args=_context_args(ctx),
     )
@@ -349,6 +359,13 @@ def task_run_command(
         ),
     ] = DEFAULT_TASK_TIMEOUT,
     pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    no_overlay: Annotated[
+        bool, typer.Option("--no-overlay", help="Skip the project overlay image")
+    ] = False,
+    rebuild_overlay: Annotated[
+        bool,
+        typer.Option("--rebuild-overlay", help="Force rebuilding the project overlay image"),
+    ] = False,
     ikwid: Annotated[
         bool,
         typer.Option(
@@ -367,6 +384,8 @@ def task_run_command(
         network=network,
         timeout=timeout,
         pull=pull,
+        no_overlay=no_overlay,
+        rebuild_overlay=rebuild_overlay,
         ikwid=ikwid,
         passthrough_args=_context_args(ctx),
         deprecated_alias=True,
@@ -399,6 +418,13 @@ def task_create(
         ),
     ] = DEFAULT_TASK_TIMEOUT,
     pull: Annotated[bool, typer.Option("--pull", help="Pull latest image before run")] = False,
+    no_overlay: Annotated[
+        bool, typer.Option("--no-overlay", help="Skip the project overlay image")
+    ] = False,
+    rebuild_overlay: Annotated[
+        bool,
+        typer.Option("--rebuild-overlay", help="Force rebuilding the project overlay image"),
+    ] = False,
     ikwid: Annotated[
         bool,
         typer.Option(
@@ -528,6 +554,16 @@ def task_create(
     if should_pull:
         info(f"Pulling image: {image}")
         manager.pull_image(image, auto_clean=bool(config.get("auto_clean", True)))
+
+    image = apply_overlay_if_enabled(
+        manager=manager,
+        workspace_path=workspace_path,
+        agent=selected,
+        image=image,
+        agent_cfg=agent_cfg,
+        no_overlay=no_overlay,
+        rebuild_overlay=rebuild_overlay,
+    )
 
     base_command = spec.command
     entrypoint: list[str] | None = None

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -208,6 +208,15 @@ def get_project_config_path(cwd: Path | None = None) -> Path:
     return base / PROJECT_CONFIG_FILE
 
 
+def load_project_config(workspace: Path) -> dict[str, Any]:
+    """Return the raw project config committed in *workspace*, without merging.
+
+    get_config merges the project file of the *current* directory; use this
+    when the relevant project lives elsewhere (e.g. ``vp run -w /other``).
+    """
+    return _load_yaml(workspace / PROJECT_CONFIG_FILE)
+
+
 def get_config() -> dict[str, Any]:
     """Return merged effective config."""
     ensure_config_dirs()

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -399,12 +399,15 @@ class DockerManager:
             # missing id as "no confirmed image", never as a failure to report.
             return None
 
-    def build_image(self, context_tar: Any, tag: str, labels: dict[str, str]) -> None:
+    def build_image(
+        self, context_tar: Any, tag: str, labels: dict[str, str], *, nocache: bool = False
+    ) -> None:
         """Build *tag* from an in-memory custom-context tar, streaming output.
 
         The tar must contain a complete Dockerfile (see
         :func:`vibepod.core.overlay.build_context_tar`); nothing is written to
-        the host filesystem.
+        the host filesystem. *nocache* disables docker's layer cache so a
+        forced rebuild re-runs every instruction.
         """
         try:
             chunks = self.client.api.build(
@@ -413,6 +416,7 @@ class DockerManager:
                 tag=tag,
                 labels=labels,
                 rm=True,
+                nocache=nocache,
                 decode=True,
             )
             for chunk in chunks:

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -399,6 +399,60 @@ class DockerManager:
             # missing id as "no confirmed image", never as a failure to report.
             return None
 
+    def build_image(self, context_tar: Any, tag: str, labels: dict[str, str]) -> None:
+        """Build *tag* from an in-memory custom-context tar, streaming output.
+
+        The tar must contain a complete Dockerfile (see
+        :func:`vibepod.core.overlay.build_context_tar`); nothing is written to
+        the host filesystem.
+        """
+        try:
+            chunks = self.client.api.build(
+                fileobj=context_tar,
+                custom_context=True,
+                tag=tag,
+                labels=labels,
+                rm=True,
+                decode=True,
+            )
+            for chunk in chunks:
+                if "error" in chunk:
+                    raise DockerClientError(f"Failed to build image {tag}: {chunk['error']}")
+                stream = chunk.get("stream")
+                if stream and stream.strip():
+                    print(stream, end="" if stream.endswith("\n") else "\n")
+        except DockerClientError:
+            raise
+        except (APIError, DockerException) as exc:
+            raise DockerClientError(f"Failed to build image {tag}: {exc}") from exc
+
+    def remove_stale_overlays(self, overlay_key: str, keep_tag: str) -> int:
+        """Remove overlay images labeled with *overlay_key* except *keep_tag*.
+
+        Old content-addressed tags accumulate as the overlay evolves; each
+        successful build sweeps its predecessors. Images docker refuses to
+        remove (still used by a container) stay and are retried next build.
+        The label name is ``vibepod.core.overlay.OVERLAY_KEY_LABEL`` (kept as
+        a literal here to avoid an import cycle with that module).
+        """
+        try:
+            images = self.client.images.list(
+                filters={"label": [f"vibepod.overlay.key={overlay_key}"]}
+            )
+        except DockerException:
+            return 0
+
+        removed = 0
+        for image in images:
+            if keep_tag in (image.tags or []):
+                continue
+            try:
+                self.client.images.remove(str(image.id))
+            except DockerException:
+                continue
+            removed += 1
+        return removed
+
     def clean_untagged_images(self, namespace: str = IMAGE_NAMESPACE) -> int:
         """Remove untagged *namespace* images and return how many were removed.
 

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -416,6 +416,8 @@ class DockerManager:
                 decode=True,
             )
             for chunk in chunks:
+                if not isinstance(chunk, dict):
+                    continue
                 if "error" in chunk:
                     raise DockerClientError(f"Failed to build image {tag}: {chunk['error']}")
                 stream = chunk.get("stream")

--- a/src/vibepod/core/launch.py
+++ b/src/vibepod/core/launch.py
@@ -12,7 +12,9 @@ from typing import Any
 
 import typer
 
-from vibepod.utils.console import warning
+from vibepod.core import overlay
+from vibepod.core.docker import DockerClientError, DockerManager
+from vibepod.utils.console import error, warning
 
 CLAUDE_TOKEN_FILENAME = "oauth-token"
 
@@ -59,6 +61,26 @@ def parse_env_pairs(values: list[str]) -> dict[str, str]:
             raise typer.BadParameter("Environment variable key cannot be empty")
         parsed[key] = value
     return parsed
+
+
+def apply_overlay_if_enabled(
+    *,
+    manager: DockerManager,
+    workspace_path: Path,
+    agent: str,
+    image: str,
+    agent_cfg: dict[str, Any],
+    no_overlay: bool,
+    rebuild_overlay: bool,
+) -> str:
+    """Swap in the project overlay image unless disabled by flag or config."""
+    if no_overlay or agent_cfg.get("overlay") is False:
+        return image
+    try:
+        return overlay.apply_overlay(manager, workspace_path, agent, image, rebuild=rebuild_overlay)
+    except DockerClientError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
 
 
 def agent_init_commands(agent: str, agent_cfg: dict[str, Any]) -> list[str]:

--- a/src/vibepod/core/launch.py
+++ b/src/vibepod/core/launch.py
@@ -13,6 +13,7 @@ from typing import Any
 import typer
 
 from vibepod.core import overlay
+from vibepod.core.config import load_project_config
 from vibepod.core.docker import DockerClientError, DockerManager
 from vibepod.utils.console import error, warning
 
@@ -63,6 +64,20 @@ def parse_env_pairs(values: list[str]) -> dict[str, str]:
     return parsed
 
 
+def _overlay_setting(workspace_path: Path, agent: str, agent_cfg: dict[str, Any]) -> Any:
+    """``agents.<agent>.overlay`` with the launched workspace's config winning.
+
+    *agent_cfg* comes from get_config(), which merges the project file of the
+    *current* directory; with ``-w`` pointing at another project, that
+    project's own setting must decide whether its overlay applies.
+    """
+    agents = load_project_config(workspace_path).get("agents")
+    entry = agents.get(agent) if isinstance(agents, dict) else None
+    if isinstance(entry, dict) and "overlay" in entry:
+        return entry["overlay"]
+    return agent_cfg.get("overlay")
+
+
 def apply_overlay_if_enabled(
     *,
     manager: DockerManager,
@@ -74,7 +89,7 @@ def apply_overlay_if_enabled(
     rebuild_overlay: bool,
 ) -> str:
     """Swap in the project overlay image unless disabled by flag or config."""
-    if no_overlay or agent_cfg.get("overlay") is False:
+    if no_overlay or _overlay_setting(workspace_path, agent, agent_cfg) is False:
         return image
     try:
         return overlay.apply_overlay(manager, workspace_path, agent, image, rebuild=rebuild_overlay)

--- a/src/vibepod/core/overlay.py
+++ b/src/vibepod/core/overlay.py
@@ -87,12 +87,29 @@ def overlay_hash(base_ref: str, dockerfile: Path) -> str:
     context = dockerfile.parent
     for path in _context_files(dockerfile):
         digest.update(path.relative_to(context).as_posix().encode() + b"\n")
+        # The exec bit survives into the image via COPY, so a chmod must
+        # re-hash even when the content is unchanged.
+        digest.update(b"x" if path.stat().st_mode & 0o111 else b"-")
         digest.update(path.read_bytes())
     return digest.hexdigest()[:OVERLAY_HASH_LENGTH]
 
 
 def overlay_image_tag(agent: str, digest: str) -> str:
     return f"vibepod/overlay-{agent}:{digest}"
+
+
+def _normalize_member(member: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Keep the tar byte-stable across owners and checkouts.
+
+    Only the exec bit is build-relevant (and hashed by overlay_hash);
+    uid/gid/mtime would otherwise vary per machine while the cache key does
+    not, shipping contexts that differ from what was hashed.
+    """
+    member.mode = 0o755 if member.mode & 0o111 else 0o644
+    member.uid = member.gid = 0
+    member.uname = member.gname = ""
+    member.mtime = 0
+    return member
 
 
 def build_context_tar(base_image: str, dockerfile: Path) -> io.BytesIO:
@@ -111,7 +128,11 @@ def build_context_tar(base_image: str, dockerfile: Path) -> io.BytesIO:
         archive.addfile(info, io.BytesIO(synthesized))
         context = dockerfile.parent
         for path in _context_files(dockerfile):
-            archive.add(path, arcname=path.relative_to(context).as_posix())
+            archive.add(
+                path,
+                arcname=path.relative_to(context).as_posix(),
+                filter=_normalize_member,
+            )
     buffer.seek(0)
     return buffer
 

--- a/src/vibepod/core/overlay.py
+++ b/src/vibepod/core/overlay.py
@@ -28,10 +28,14 @@ OVERLAY_KEY_LABEL = "vibepod.overlay.key"
 
 
 def find_overlay_dockerfile(workspace: Path, agent: str) -> Path | None:
-    """Return the overlay Dockerfile for *agent*, agent-specific one first."""
+    """Return the overlay Dockerfile for *agent*, agent-specific one first.
+
+    Symlinked Dockerfiles are ignored like every other symlink in the
+    context: the target may live outside the committed overlay directory.
+    """
     base = workspace / OVERLAY_DIR
     for candidate in (base / agent / "Dockerfile", base / "Dockerfile"):
-        if candidate.is_file():
+        if candidate.is_file() and not candidate.is_symlink():
             return candidate
     return None
 
@@ -74,23 +78,19 @@ def _context_files(dockerfile: Path) -> list[Path]:
     return sorted(files, key=lambda p: p.relative_to(context).as_posix())
 
 
-def overlay_hash(base_ref: str, dockerfile: Path) -> str:
-    """Content-address the build inputs: base image ref + fragment + context.
+def overlay_hash(base_ref: str, context_tar: bytes) -> str:
+    """Content-address the build inputs: base image ref + build context tar.
 
     *base_ref* should be the base image's local id when it exists (so a moved
-    ``latest`` tag re-hashes) and the tag string otherwise. Context files are
-    keyed by relative path as well as content, so renames re-hash too.
+    ``latest`` tag re-hashes) and the tag string otherwise. *context_tar* is
+    the byte-stable tar from :func:`build_context_tar`: its headers frame
+    every member's path, mode, and content length, so distinct contexts can
+    never collide, and hashing the same snapshot that gets built keeps the
+    tag and the image content in lockstep even when files change mid-launch.
     """
     digest = hashlib.sha256()
     digest.update(base_ref.encode() + b"\n")
-    digest.update(dockerfile.read_bytes())
-    context = dockerfile.parent
-    for path in _context_files(dockerfile):
-        digest.update(path.relative_to(context).as_posix().encode() + b"\n")
-        # The exec bit survives into the image via COPY, so a chmod must
-        # re-hash even when the content is unchanged.
-        digest.update(b"x" if path.stat().st_mode & 0o111 else b"-")
-        digest.update(path.read_bytes())
+    digest.update(context_tar)
     return digest.hexdigest()[:OVERLAY_HASH_LENGTH]
 
 
@@ -118,7 +118,8 @@ def build_context_tar(base_image: str, dockerfile: Path) -> io.BytesIO:
     Contains a synthesized ``Dockerfile`` (``FROM base_image`` prepended to
     the fragment, which therefore never needs a FROM line) plus the context
     files, so ``COPY`` works without ever writing into the user's overlay
-    directory.
+    directory. The tar doubles as the snapshot fed to overlay_hash, so the
+    context is read exactly once per launch.
     """
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode="w") as archive:
@@ -162,7 +163,8 @@ def apply_overlay(
         return base_image
 
     base_ref = manager.image_id(base_image) or base_image
-    tag = overlay_image_tag(agent, overlay_hash(base_ref, dockerfile))
+    context_tar = build_context_tar(base_image, dockerfile)
+    tag = overlay_image_tag(agent, overlay_hash(base_ref, context_tar.getvalue()))
 
     if rebuild or manager.image_id(tag) is None:
         info(f"Building overlay image {tag} from {base_image} ({dockerfile})")
@@ -172,7 +174,9 @@ def apply_overlay(
             OVERLAY_KEY_LABEL: overlay_key,
             "vibepod.overlay.agent": agent,
         }
-        manager.build_image(build_context_tar(base_image, dockerfile), tag=tag, labels=labels)
+        # A forced rebuild must also bypass docker's layer cache, or RUN
+        # commands like package updates would replay from cached layers.
+        manager.build_image(context_tar, tag=tag, labels=labels, nocache=rebuild)
         manager.remove_stale_overlays(overlay_key, keep_tag=tag)
     else:
         info(f"Using cached overlay image {tag}")

--- a/src/vibepod/core/overlay.py
+++ b/src/vibepod/core/overlay.py
@@ -1,0 +1,143 @@
+"""Per-project image overlays (issue #113).
+
+A project may commit a ``FROM``-less Dockerfile fragment under
+``.vibepod/overlay/`` (shared) or ``.vibepod/overlay/<agent>/`` (per agent,
+wins). The fragment is appended to the agent's base image and built into a
+workspace-local image tagged content-addressed over the base image and the
+build inputs, so unchanged overlays never rebuild and switching branches with
+different overlays just switches images. The directory holding the Dockerfile
+is the build context, so fragments can ``COPY`` files committed next to them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tarfile
+from pathlib import Path
+from typing import Any
+
+from vibepod.constants import SUPPORTED_AGENTS
+from vibepod.utils.console import info
+
+OVERLAY_DIR = Path(".vibepod") / "overlay"
+OVERLAY_HASH_LENGTH = 12
+#: Image label carrying the workspace+agent identity; duplicated as a literal
+#: in DockerManager.remove_stale_overlays to avoid an import cycle.
+OVERLAY_KEY_LABEL = "vibepod.overlay.key"
+
+
+def find_overlay_dockerfile(workspace: Path, agent: str) -> Path | None:
+    """Return the overlay Dockerfile for *agent*, agent-specific one first."""
+    base = workspace / OVERLAY_DIR
+    for candidate in (base / agent / "Dockerfile", base / "Dockerfile"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _context_files(dockerfile: Path) -> list[Path]:
+    """Context files hashed alongside the fragment, sorted by relative path.
+
+    The Dockerfile itself is excluded (hashed separately as the fragment). For
+    the shared overlay root, per-agent overlay roots are excluded too — they
+    are separate build contexts with their own hashes.
+    """
+    context = dockerfile.parent
+    skipped_roots = []
+    for agent in SUPPORTED_AGENTS:
+        agent_root = context / agent
+        if (agent_root / "Dockerfile").is_file():
+            skipped_roots.append(agent_root)
+    files = []
+    for path in context.rglob("*"):
+        if not path.is_file() or path == dockerfile:
+            continue
+        if any(root in path.parents for root in skipped_roots):
+            continue
+        files.append(path)
+    return sorted(files, key=lambda p: p.relative_to(context).as_posix())
+
+
+def overlay_hash(base_ref: str, dockerfile: Path) -> str:
+    """Content-address the build inputs: base image ref + fragment + context.
+
+    *base_ref* should be the base image's local id when it exists (so a moved
+    ``latest`` tag re-hashes) and the tag string otherwise. Context files are
+    keyed by relative path as well as content, so renames re-hash too.
+    """
+    digest = hashlib.sha256()
+    digest.update(base_ref.encode() + b"\n")
+    digest.update(dockerfile.read_bytes())
+    context = dockerfile.parent
+    for path in _context_files(dockerfile):
+        digest.update(path.relative_to(context).as_posix().encode() + b"\n")
+        digest.update(path.read_bytes())
+    return digest.hexdigest()[:OVERLAY_HASH_LENGTH]
+
+
+def overlay_image_tag(agent: str, digest: str) -> str:
+    return f"vibepod/overlay-{agent}:{digest}"
+
+
+def build_context_tar(base_image: str, dockerfile: Path) -> io.BytesIO:
+    """Assemble the docker build context as an in-memory tar.
+
+    Contains a synthesized ``Dockerfile`` (``FROM base_image`` prepended to
+    the fragment, which therefore never needs a FROM line) plus the context
+    files, so ``COPY`` works without ever writing into the user's overlay
+    directory.
+    """
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        synthesized = f"FROM {base_image}\n".encode() + dockerfile.read_bytes()
+        info = tarfile.TarInfo("Dockerfile")
+        info.size = len(synthesized)
+        archive.addfile(info, io.BytesIO(synthesized))
+        context = dockerfile.parent
+        for path in _context_files(dockerfile):
+            archive.add(path, arcname=path.relative_to(context).as_posix())
+    buffer.seek(0)
+    return buffer
+
+
+def _overlay_key(workspace: Path, agent: str) -> str:
+    """Stable identity of (workspace, agent) used to sweep superseded builds."""
+    raw = f"{workspace.resolve().as_posix()}\n{agent}".encode()
+    return hashlib.sha256(raw).hexdigest()[:OVERLAY_HASH_LENGTH]
+
+
+def apply_overlay(
+    manager: Any,
+    workspace: Path,
+    agent: str,
+    base_image: str,
+    *,
+    rebuild: bool = False,
+) -> str:
+    """Return the image to run: the overlay image if the project has one.
+
+    Builds (or reuses) the content-addressed overlay image on top of
+    *base_image* and sweeps this workspace+agent's superseded overlay images
+    after a successful build.
+    """
+    dockerfile = find_overlay_dockerfile(workspace, agent)
+    if dockerfile is None:
+        return base_image
+
+    base_ref = manager.image_id(base_image) or base_image
+    tag = overlay_image_tag(agent, overlay_hash(base_ref, dockerfile))
+
+    if rebuild or manager.image_id(tag) is None:
+        info(f"Building overlay image {tag} from {base_image} ({dockerfile})")
+        overlay_key = _overlay_key(workspace, agent)
+        labels = {
+            "vibepod.managed": "true",
+            OVERLAY_KEY_LABEL: overlay_key,
+            "vibepod.overlay.agent": agent,
+        }
+        manager.build_image(build_context_tar(base_image, dockerfile), tag=tag, labels=labels)
+        manager.remove_stale_overlays(overlay_key, keep_tag=tag)
+    else:
+        info(f"Using cached overlay image {tag}")
+    return tag

--- a/src/vibepod/core/overlay.py
+++ b/src/vibepod/core/overlay.py
@@ -36,12 +36,25 @@ def find_overlay_dockerfile(workspace: Path, agent: str) -> Path | None:
     return None
 
 
+def _under_symlink(path: Path, context: Path) -> bool:
+    """True when any directory between *context* (exclusive) and *path* is a symlink."""
+    current = context
+    for part in path.relative_to(context).parts[:-1]:
+        current = current / part
+        if current.is_symlink():
+            return True
+    return False
+
+
 def _context_files(dockerfile: Path) -> list[Path]:
     """Context files hashed alongside the fragment, sorted by relative path.
 
     The Dockerfile itself is excluded (hashed separately as the fragment). For
     the shared overlay root, per-agent overlay roots are excluded too — they
-    are separate build contexts with their own hashes.
+    are separate build contexts with their own hashes. Symlinks (and anything
+    reached through one) are excluded outright: hashing would read the target
+    while the tar would ship the link, and a link can point outside the
+    committed overlay directory.
     """
     context = dockerfile.parent
     skipped_roots = []
@@ -51,9 +64,11 @@ def _context_files(dockerfile: Path) -> list[Path]:
             skipped_roots.append(agent_root)
     files = []
     for path in context.rglob("*"):
-        if not path.is_file() or path == dockerfile:
+        if path.is_symlink() or not path.is_file() or path == dockerfile:
             continue
         if any(root in path.parents for root in skipped_roots):
+            continue
+        if _under_symlink(path, context):
             continue
         files.append(path)
     return sorted(files, key=lambda p: p.relative_to(context).as_posix())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,3 +178,40 @@ def test_alias_forwards_extra_option_args_after_delimiter(monkeypatch) -> None:
     assert result.exit_code == 0
     assert called["agent"] == "claude"
     assert called["passthrough"] == ["--model", "sonnet", "hello"]
+
+
+def test_run_command_forwards_overlay_flags(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        called["agent"] = agent
+        called["no_overlay"] = kwargs.get("no_overlay")
+        called["rebuild_overlay"] = kwargs.get("rebuild_overlay")
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["run", "claude", "--no-overlay", "--rebuild-overlay"])
+    assert result.exit_code == 0
+    assert called["no_overlay"] is True
+    assert called["rebuild_overlay"] is True
+    assert called["passthrough"] == []
+
+
+def test_alias_forwards_overlay_flags(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        called["agent"] = agent
+        called["no_overlay"] = kwargs.get("no_overlay")
+        called["rebuild_overlay"] = kwargs.get("rebuild_overlay")
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["claude", "--no-overlay", "--rebuild-overlay"])
+    assert result.exit_code == 0
+    assert called["agent"] == "claude"
+    assert called["no_overlay"] is True
+    assert called["rebuild_overlay"] is True
+    assert called["passthrough"] == []

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -642,8 +642,21 @@ def test_build_image_streams_and_succeeds(mock_docker) -> None:
         tag="vibepod/overlay-claude:abc",
         labels={"a": "b"},
         rm=True,
+        nocache=False,
         decode=True,
     )
+
+
+@patch("vibepod.core.docker.docker")
+def test_build_image_forwards_nocache(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+    mock_client.api.build.return_value = iter([])
+
+    manager = DockerManager()
+    manager.build_image(io.BytesIO(b"tar"), tag="t:1", labels={}, nocache=True)
+
+    assert mock_client.api.build.call_args.kwargs["nocache"] is True
 
 
 @patch("vibepod.core.docker.docker")

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import socket
 import subprocess
 import tempfile
@@ -623,3 +624,91 @@ def test_init_fallback_failure_raises(mock_docker) -> None:
             DockerManager()
 
     assert "Docker is not available" in str(exc_info.value)
+
+
+@patch("vibepod.core.docker.docker")
+def test_build_image_streams_and_succeeds(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+    mock_client.api.build.return_value = iter([{"stream": "Step 1/2\n"}, {"stream": "Done\n"}])
+
+    manager = DockerManager()
+    context = io.BytesIO(b"tar")
+    manager.build_image(context, tag="vibepod/overlay-claude:abc", labels={"a": "b"})
+
+    mock_client.api.build.assert_called_once_with(
+        fileobj=context,
+        custom_context=True,
+        tag="vibepod/overlay-claude:abc",
+        labels={"a": "b"},
+        rm=True,
+        decode=True,
+    )
+
+
+@patch("vibepod.core.docker.docker")
+def test_build_image_raises_on_error_chunk(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+    mock_client.api.build.return_value = iter([{"stream": "Step 1/2\n"}, {"error": "boom"}])
+
+    manager = DockerManager()
+    with pytest.raises(DockerClientError, match="boom"):
+        manager.build_image(io.BytesIO(b"tar"), tag="t:1", labels={})
+
+
+@patch("vibepod.core.docker.docker")
+def test_build_image_wraps_api_error(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+    mock_client.api.build.side_effect = APIError("daemon down")
+
+    manager = DockerManager()
+    with pytest.raises(DockerClientError, match="Failed to build image"):
+        manager.build_image(io.BytesIO(b"tar"), tag="t:1", labels={})
+
+
+def _overlay_image(image_id: str, tags: list[str], key: str) -> MagicMock:
+    image = MagicMock()
+    image.id = image_id
+    image.tags = tags
+    image.labels = {"vibepod.overlay.key": key}
+    return image
+
+
+@patch("vibepod.core.docker.docker")
+def test_remove_stale_overlays_removes_same_key_other_tags(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+    keep = _overlay_image("sha256:keep", ["vibepod/overlay-claude:new1"], "k1")
+    stale = _overlay_image("sha256:old", ["vibepod/overlay-claude:old1"], "k1")
+    mock_client.images.list.return_value = [keep, stale]
+
+    manager = DockerManager()
+    removed = manager.remove_stale_overlays("k1", keep_tag="vibepod/overlay-claude:new1")
+
+    assert removed == 1
+    mock_client.images.list.assert_called_once_with(filters={"label": ["vibepod.overlay.key=k1"]})
+    mock_client.images.remove.assert_called_once_with("sha256:old")
+
+
+@patch("vibepod.core.docker.docker")
+def test_remove_stale_overlays_survives_remove_failure(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+    stale = _overlay_image("sha256:old", ["vibepod/overlay-claude:old1"], "k1")
+    mock_client.images.list.return_value = [stale]
+    mock_client.images.remove.side_effect = DockerException("in use")
+
+    manager = DockerManager()
+    assert manager.remove_stale_overlays("k1", keep_tag="vibepod/overlay-claude:new1") == 0
+
+
+@patch("vibepod.core.docker.docker")
+def test_remove_stale_overlays_survives_list_failure(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+    mock_client.images.list.side_effect = DockerException("daemon down")
+
+    manager = DockerManager()
+    assert manager.remove_stale_overlays("k1", keep_tag="t:1") == 0

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -658,6 +658,16 @@ def test_build_image_raises_on_error_chunk(mock_docker) -> None:
 
 
 @patch("vibepod.core.docker.docker")
+def test_build_image_skips_non_dict_chunks(mock_docker) -> None:
+    mock_client = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+    mock_client.api.build.return_value = iter(["error: not a dict", {"stream": "Done\n"}])
+
+    manager = DockerManager()
+    manager.build_image(io.BytesIO(b"tar"), tag="t:1", labels={})
+
+
+@patch("vibepod.core.docker.docker")
 def test_build_image_wraps_api_error(mock_docker) -> None:
     mock_client = MagicMock()
     mock_docker.from_env.return_value = mock_client

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -145,6 +145,36 @@ def test_build_context_tar_excludes_agent_subdirs_for_shared_overlay(tmp_path: P
     assert "gemini/Dockerfile" not in entries
 
 
+def _symlink_or_skip(target: Path, link: Path) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=target.is_dir())
+    except (OSError, NotImplementedError):  # pragma: no cover - Windows without privilege
+        pytest.skip("platform does not allow creating symlinks")
+
+
+def test_symlinks_excluded_from_hash_and_tar(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    secret = tmp_path / "outside.txt"
+    secret.write_bytes(b"secret\n")
+    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    _symlink_or_skip(secret, dockerfile.parent / "link.txt")
+    assert overlay.overlay_hash("sha256:abc", dockerfile) == before
+    entries = _read_tar(overlay.build_context_tar("base:latest", dockerfile))
+    assert "link.txt" not in entries
+
+
+def test_files_under_symlinked_dir_excluded(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "data.txt").write_bytes(b"data\n")
+    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    _symlink_or_skip(outside, dockerfile.parent / "linked")
+    assert overlay.overlay_hash("sha256:abc", dockerfile) == before
+    entries = _read_tar(overlay.build_context_tar("base:latest", dockerfile))
+    assert "linked/data.txt" not in entries
+
+
 class _FakeManager:
     def __init__(self, existing_images=(), image_ids=None):
         self.existing = set(existing_images)

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -49,58 +49,75 @@ def test_find_overlay_dockerfile_ignores_directory_named_dockerfile(tmp_path: Pa
     assert overlay.find_overlay_dockerfile(tmp_path, "claude") is None
 
 
+def _hash(base_ref: str, dockerfile: Path, base_image: str = "base:latest") -> str:
+    """Hash a context the way apply_overlay does: over the snapshot tar."""
+    return overlay.overlay_hash(
+        base_ref, overlay.build_context_tar(base_image, dockerfile).getvalue()
+    )
+
+
 def test_overlay_hash_is_stable(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    first = overlay.overlay_hash("sha256:abc", dockerfile)
-    second = overlay.overlay_hash("sha256:abc", dockerfile)
+    first = _hash("sha256:abc", dockerfile)
+    second = _hash("sha256:abc", dockerfile)
     assert first == second
     assert len(first) == 12
 
 
 def test_overlay_hash_changes_with_base_image(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    assert overlay.overlay_hash("sha256:abc", dockerfile) != overlay.overlay_hash(
-        "sha256:def", dockerfile
-    )
+    assert _hash("sha256:abc", dockerfile) != _hash("sha256:def", dockerfile)
 
 
 def test_overlay_hash_changes_with_fragment(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    before = _hash("sha256:abc", dockerfile)
     dockerfile.write_bytes(b"RUN apt-get update\n")
-    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+    assert _hash("sha256:abc", dockerfile) != before
 
 
 def test_overlay_hash_includes_context_files(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    before = _hash("sha256:abc", dockerfile)
     (dockerfile.parent / "requirements.txt").write_bytes(b"requests\n")
-    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+    assert _hash("sha256:abc", dockerfile) != before
 
 
 def test_overlay_hash_changes_when_context_file_renamed(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
     extra = dockerfile.parent / "a.txt"
     extra.write_bytes(b"data\n")
-    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    before = _hash("sha256:abc", dockerfile)
     extra.rename(dockerfile.parent / "b.txt")
-    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+    assert _hash("sha256:abc", dockerfile) != before
 
 
 def test_overlay_hash_walks_nested_context_dirs(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    before = _hash("sha256:abc", dockerfile)
     nested = dockerfile.parent / "scripts"
     nested.mkdir()
     (nested / "setup.sh").write_bytes(b"echo hi\n")
-    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+    assert _hash("sha256:abc", dockerfile) != before
 
 
 def test_shared_overlay_hash_excludes_agent_subdirs(tmp_path: Path) -> None:
     shared = _make_overlay(tmp_path)
-    before = overlay.overlay_hash("sha256:abc", shared)
+    before = _hash("sha256:abc", shared)
     _make_overlay(tmp_path, "gemini", content="RUN apt-get install -y jq\n")
-    assert overlay.overlay_hash("sha256:abc", shared) == before
+    assert _hash("sha256:abc", shared) == before
+
+
+def test_overlay_hash_distinguishes_file_boundaries(tmp_path: Path) -> None:
+    """Same concatenated bytes split differently across files must not collide."""
+    ws_a = tmp_path / "a"
+    ws_b = tmp_path / "b"
+    dockerfile_a = _make_overlay(ws_a)
+    dockerfile_b = _make_overlay(ws_b)
+    (dockerfile_a.parent / "f").write_bytes(b"hellog\n-world")
+    (dockerfile_b.parent / "f").write_bytes(b"hello")
+    (dockerfile_b.parent / "g").write_bytes(b"world")
+    assert _hash("sha256:abc", dockerfile_a) != _hash("sha256:abc", dockerfile_b)
 
 
 def test_overlay_image_tag_embeds_agent_and_hash() -> None:
@@ -157,9 +174,9 @@ def test_symlinks_excluded_from_hash_and_tar(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
     secret = tmp_path / "outside.txt"
     secret.write_bytes(b"secret\n")
-    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    before = _hash("sha256:abc", dockerfile)
     _symlink_or_skip(secret, dockerfile.parent / "link.txt")
-    assert overlay.overlay_hash("sha256:abc", dockerfile) == before
+    assert _hash("sha256:abc", dockerfile) == before
     entries = _read_tar(overlay.build_context_tar("base:latest", dockerfile))
     assert "link.txt" not in entries
 
@@ -169,11 +186,30 @@ def test_files_under_symlinked_dir_excluded(tmp_path: Path) -> None:
     outside = tmp_path / "outside"
     outside.mkdir()
     (outside / "data.txt").write_bytes(b"data\n")
-    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    before = _hash("sha256:abc", dockerfile)
     _symlink_or_skip(outside, dockerfile.parent / "linked")
-    assert overlay.overlay_hash("sha256:abc", dockerfile) == before
+    assert _hash("sha256:abc", dockerfile) == before
     entries = _read_tar(overlay.build_context_tar("base:latest", dockerfile))
     assert "linked/data.txt" not in entries
+
+
+def test_find_overlay_dockerfile_rejects_symlinked_dockerfile(tmp_path: Path) -> None:
+    outside = tmp_path / "outside-dockerfile"
+    outside.write_bytes(b"RUN echo outside\n")
+    link = tmp_path / ".vibepod" / "overlay" / "Dockerfile"
+    link.parent.mkdir(parents=True)
+    _symlink_or_skip(outside, link)
+    assert overlay.find_overlay_dockerfile(tmp_path, "claude") is None
+
+
+def test_find_overlay_dockerfile_symlinked_agent_falls_back_to_shared(tmp_path: Path) -> None:
+    shared = _make_overlay(tmp_path)
+    outside = tmp_path / "outside-dockerfile"
+    outside.write_bytes(b"RUN echo outside\n")
+    agent_link = tmp_path / ".vibepod" / "overlay" / "claude" / "Dockerfile"
+    agent_link.parent.mkdir(parents=True)
+    _symlink_or_skip(outside, agent_link)
+    assert overlay.find_overlay_dockerfile(tmp_path, "claude") == shared
 
 
 class _FakeManager:
@@ -188,8 +224,8 @@ class _FakeManager:
             return self.ids[image]
         return "sha256:built" if image in self.existing else None
 
-    def build_image(self, context_tar, tag, labels):
-        self.built.append((tag, labels))
+    def build_image(self, context_tar, tag, labels, nocache=False):
+        self.built.append((tag, labels, context_tar, nocache))
         self.existing.add(tag)
 
     def remove_stale_overlays(self, overlay_key, keep_tag):
@@ -211,34 +247,45 @@ def test_apply_overlay_builds_and_returns_overlay_tag(tmp_path: Path) -> None:
     (built,) = manager.built
     assert built[0] == result
     assert built[1]["vibepod.managed"] == "true"
+    assert built[3] is False
     assert manager.swept == [(built[1]["vibepod.overlay.key"], result)]
+
+
+def test_apply_overlay_builds_the_snapshot_it_hashed(tmp_path: Path) -> None:
+    """The tar handed to docker must be the exact bytes the tag was derived from."""
+    _make_overlay(tmp_path)
+    manager = _FakeManager(image_ids={"base:latest": "sha256:base"})
+    result = overlay.apply_overlay(manager, tmp_path, "claude", "base:latest")
+    ((tag, _, context_tar, _),) = manager.built
+    digest = overlay.overlay_hash("sha256:base", context_tar.getvalue())
+    assert tag == overlay.overlay_image_tag("claude", digest) == result
 
 
 def test_apply_overlay_skips_build_when_image_exists(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    digest = overlay.overlay_hash("sha256:base", dockerfile)
+    digest = _hash("sha256:base", dockerfile)
     tag = overlay.overlay_image_tag("claude", digest)
     manager = _FakeManager(existing_images=[tag], image_ids={"base:latest": "sha256:base"})
     assert overlay.apply_overlay(manager, tmp_path, "claude", "base:latest") == tag
     assert manager.built == []
 
 
-def test_apply_overlay_rebuild_forces_build(tmp_path: Path) -> None:
+def test_apply_overlay_rebuild_forces_uncached_build(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    digest = overlay.overlay_hash("sha256:base", dockerfile)
+    digest = _hash("sha256:base", dockerfile)
     tag = overlay.overlay_image_tag("claude", digest)
     manager = _FakeManager(existing_images=[tag], image_ids={"base:latest": "sha256:base"})
     assert overlay.apply_overlay(manager, tmp_path, "claude", "base:latest", rebuild=True) == tag
-    assert [built_tag for built_tag, _ in manager.built] == [tag]
+    ((built_tag, _, _, nocache),) = manager.built
+    assert built_tag == tag
+    assert nocache is True
 
 
 def test_apply_overlay_hashes_tag_when_base_not_local(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
     manager = _FakeManager()
     result = overlay.apply_overlay(manager, tmp_path, "claude", "base:latest")
-    assert result == overlay.overlay_image_tag(
-        "claude", overlay.overlay_hash("base:latest", dockerfile)
-    )
+    assert result == overlay.overlay_image_tag("claude", _hash("base:latest", dockerfile))
 
 
 def test_apply_overlay_key_differs_per_workspace_and_agent(tmp_path: Path) -> None:
@@ -250,8 +297,8 @@ def test_apply_overlay_key_differs_per_workspace_and_agent(tmp_path: Path) -> No
     manager_b = _FakeManager()
     overlay.apply_overlay(manager_a, ws_a, "claude", "base:latest")
     overlay.apply_overlay(manager_b, ws_b, "claude", "base:latest")
-    ((_, labels_a),) = manager_a.built
-    ((_, labels_b),) = manager_b.built
+    ((_, labels_a, _, _),) = manager_a.built
+    ((_, labels_b, _, _),) = manager_b.built
     assert labels_a["vibepod.overlay.key"] != labels_b["vibepod.overlay.key"]
 
 
@@ -314,6 +361,52 @@ def test_apply_overlay_if_enabled_respects_agent_config(
     assert result == "base:latest"
 
 
+def _write_project_config(workspace: Path, content: str) -> None:
+    config_path = workspace / ".vibepod" / "config.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(content, encoding="utf-8")
+
+
+def test_apply_overlay_if_enabled_respects_workspace_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """agents.<agent>.overlay: false in the *workspace* project config wins,
+    even when get_config() was resolved from a different current directory."""
+    monkeypatch.setattr(
+        launch.overlay, "apply_overlay", lambda *a, **k: pytest.fail("should not build")
+    )
+    _write_project_config(tmp_path, "agents:\n  claude:\n    overlay: false\n")
+    result = launch.apply_overlay_if_enabled(
+        manager="mgr",
+        workspace_path=tmp_path,
+        agent="claude",
+        image="base:latest",
+        agent_cfg={},
+        no_overlay=False,
+        rebuild_overlay=False,
+    )
+    assert result == "base:latest"
+
+
+def test_apply_overlay_if_enabled_workspace_config_overrides_cwd_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        launch.overlay, "apply_overlay", lambda *a, **k: "vibepod/overlay-claude:abc"
+    )
+    _write_project_config(tmp_path, "agents:\n  claude:\n    overlay: true\n")
+    result = launch.apply_overlay_if_enabled(
+        manager="mgr",
+        workspace_path=tmp_path,
+        agent="claude",
+        image="base:latest",
+        agent_cfg={"overlay": False},
+        no_overlay=False,
+        rebuild_overlay=False,
+    )
+    assert result == "vibepod/overlay-claude:abc"
+
+
 def test_apply_overlay_if_enabled_exits_on_build_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -339,11 +432,11 @@ def test_overlay_hash_changes_with_exec_bit(tmp_path: Path) -> None:
     script = dockerfile.parent / "setup.sh"
     script.write_bytes(b"#!/bin/sh\n")
     script.chmod(0o644)
-    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    before = _hash("sha256:abc", dockerfile)
 
     script.chmod(0o755)
 
-    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+    assert _hash("sha256:abc", dockerfile) != before
 
 
 @pytest.mark.skipif(os.name == "nt", reason="exec bits are POSIX-only")

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -16,7 +16,9 @@ from vibepod.core.docker import DockerClientError
 def _make_overlay(root: Path, *parts: str, content: str = "RUN true\n") -> Path:
     dockerfile = root.joinpath(".vibepod", "overlay", *parts, "Dockerfile")
     dockerfile.parent.mkdir(parents=True, exist_ok=True)
-    dockerfile.write_text(content)
+    # write_bytes, not write_text: text mode would turn \n into \r\n on
+    # Windows and break the exact-byte assertions on the tar contents.
+    dockerfile.write_bytes(content.encode())
     return dockerfile
 
 
@@ -64,21 +66,21 @@ def test_overlay_hash_changes_with_base_image(tmp_path: Path) -> None:
 def test_overlay_hash_changes_with_fragment(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
     before = overlay.overlay_hash("sha256:abc", dockerfile)
-    dockerfile.write_text("RUN apt-get update\n")
+    dockerfile.write_bytes(b"RUN apt-get update\n")
     assert overlay.overlay_hash("sha256:abc", dockerfile) != before
 
 
 def test_overlay_hash_includes_context_files(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
     before = overlay.overlay_hash("sha256:abc", dockerfile)
-    (dockerfile.parent / "requirements.txt").write_text("requests\n")
+    (dockerfile.parent / "requirements.txt").write_bytes(b"requests\n")
     assert overlay.overlay_hash("sha256:abc", dockerfile) != before
 
 
 def test_overlay_hash_changes_when_context_file_renamed(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
     extra = dockerfile.parent / "a.txt"
-    extra.write_text("data\n")
+    extra.write_bytes(b"data\n")
     before = overlay.overlay_hash("sha256:abc", dockerfile)
     extra.rename(dockerfile.parent / "b.txt")
     assert overlay.overlay_hash("sha256:abc", dockerfile) != before
@@ -89,7 +91,7 @@ def test_overlay_hash_walks_nested_context_dirs(tmp_path: Path) -> None:
     before = overlay.overlay_hash("sha256:abc", dockerfile)
     nested = dockerfile.parent / "scripts"
     nested.mkdir()
-    (nested / "setup.sh").write_text("echo hi\n")
+    (nested / "setup.sh").write_bytes(b"echo hi\n")
     assert overlay.overlay_hash("sha256:abc", dockerfile) != before
 
 
@@ -127,10 +129,10 @@ def test_build_context_tar_synthesizes_dockerfile(tmp_path: Path) -> None:
 
 def test_build_context_tar_includes_context_files(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    (dockerfile.parent / "requirements.txt").write_text("requests\n")
+    (dockerfile.parent / "requirements.txt").write_bytes(b"requests\n")
     nested = dockerfile.parent / "scripts"
     nested.mkdir()
-    (nested / "setup.sh").write_text("echo hi\n")
+    (nested / "setup.sh").write_bytes(b"echo hi\n")
     entries = _read_tar(overlay.build_context_tar("base:latest", dockerfile))
     assert entries["requirements.txt"] == b"requests\n"
     assert entries["scripts/setup.sh"] == b"echo hi\n"

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import os
 import tarfile
 from pathlib import Path
 
@@ -330,3 +331,37 @@ def test_apply_overlay_if_enabled_exits_on_build_failure(
             no_overlay=False,
             rebuild_overlay=False,
         )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="exec bits are POSIX-only")
+def test_overlay_hash_changes_with_exec_bit(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path, content="COPY setup.sh /setup.sh\n")
+    script = dockerfile.parent / "setup.sh"
+    script.write_bytes(b"#!/bin/sh\n")
+    script.chmod(0o644)
+    before = overlay.overlay_hash("sha256:abc", dockerfile)
+
+    script.chmod(0o755)
+
+    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+
+
+@pytest.mark.skipif(os.name == "nt", reason="exec bits are POSIX-only")
+def test_build_context_tar_normalizes_member_metadata(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path, content="COPY . /overlay\n")
+    script = dockerfile.parent / "setup.sh"
+    script.write_bytes(b"#!/bin/sh\n")
+    script.chmod(0o750)
+    data = dockerfile.parent / "config.txt"
+    data.write_bytes(b"x\n")
+    data.chmod(0o600)
+
+    buffer = overlay.build_context_tar("base:latest", dockerfile)
+
+    with tarfile.open(fileobj=buffer) as archive:
+        members = {member.name: member for member in archive.getmembers()}
+    assert members["setup.sh"].mode == 0o755
+    assert members["config.txt"].mode == 0o644
+    for member in members.values():
+        assert (member.uid, member.gid, member.uname, member.gname) == (0, 0, "", "")
+        assert member.mtime == 0

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,300 @@
+"""Tests for per-project image overlays (core/overlay.py)."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+import typer
+
+from vibepod.core import launch, overlay
+from vibepod.core.docker import DockerClientError
+
+
+def _make_overlay(root: Path, *parts: str, content: str = "RUN true\n") -> Path:
+    dockerfile = root.joinpath(".vibepod", "overlay", *parts, "Dockerfile")
+    dockerfile.parent.mkdir(parents=True, exist_ok=True)
+    dockerfile.write_text(content)
+    return dockerfile
+
+
+def test_find_overlay_dockerfile_returns_none_without_overlay(tmp_path: Path) -> None:
+    assert overlay.find_overlay_dockerfile(tmp_path, "claude") is None
+
+
+def test_find_overlay_dockerfile_finds_shared_overlay(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    assert overlay.find_overlay_dockerfile(tmp_path, "claude") == dockerfile
+
+
+def test_find_overlay_dockerfile_prefers_agent_overlay(tmp_path: Path) -> None:
+    _make_overlay(tmp_path)
+    agent_dockerfile = _make_overlay(tmp_path, "claude")
+    assert overlay.find_overlay_dockerfile(tmp_path, "claude") == agent_dockerfile
+
+
+def test_find_overlay_dockerfile_ignores_other_agent_dirs(tmp_path: Path) -> None:
+    _make_overlay(tmp_path, "gemini")
+    assert overlay.find_overlay_dockerfile(tmp_path, "claude") is None
+
+
+def test_find_overlay_dockerfile_ignores_directory_named_dockerfile(tmp_path: Path) -> None:
+    path = tmp_path / ".vibepod" / "overlay" / "Dockerfile"
+    path.mkdir(parents=True)
+    assert overlay.find_overlay_dockerfile(tmp_path, "claude") is None
+
+
+def test_overlay_hash_is_stable(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    first = overlay.overlay_hash("sha256:abc", dockerfile)
+    second = overlay.overlay_hash("sha256:abc", dockerfile)
+    assert first == second
+    assert len(first) == 12
+
+
+def test_overlay_hash_changes_with_base_image(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    assert overlay.overlay_hash("sha256:abc", dockerfile) != overlay.overlay_hash(
+        "sha256:def", dockerfile
+    )
+
+
+def test_overlay_hash_changes_with_fragment(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    dockerfile.write_text("RUN apt-get update\n")
+    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+
+
+def test_overlay_hash_includes_context_files(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    (dockerfile.parent / "requirements.txt").write_text("requests\n")
+    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+
+
+def test_overlay_hash_changes_when_context_file_renamed(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    extra = dockerfile.parent / "a.txt"
+    extra.write_text("data\n")
+    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    extra.rename(dockerfile.parent / "b.txt")
+    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+
+
+def test_overlay_hash_walks_nested_context_dirs(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    before = overlay.overlay_hash("sha256:abc", dockerfile)
+    nested = dockerfile.parent / "scripts"
+    nested.mkdir()
+    (nested / "setup.sh").write_text("echo hi\n")
+    assert overlay.overlay_hash("sha256:abc", dockerfile) != before
+
+
+def test_shared_overlay_hash_excludes_agent_subdirs(tmp_path: Path) -> None:
+    shared = _make_overlay(tmp_path)
+    before = overlay.overlay_hash("sha256:abc", shared)
+    _make_overlay(tmp_path, "gemini", content="RUN apt-get install -y jq\n")
+    assert overlay.overlay_hash("sha256:abc", shared) == before
+
+
+def test_overlay_image_tag_embeds_agent_and_hash() -> None:
+    assert overlay.overlay_image_tag("claude", "abc123def456") == (
+        "vibepod/overlay-claude:abc123def456"
+    )
+
+
+def _read_tar(buffer: io.BytesIO) -> dict[str, bytes]:
+    buffer.seek(0)
+    with tarfile.open(fileobj=buffer) as archive:
+        entries = {}
+        for member in archive.getmembers():
+            if not member.isfile():
+                continue
+            extracted = archive.extractfile(member)
+            assert extracted is not None
+            entries[member.name] = extracted.read()
+        return entries
+
+
+def test_build_context_tar_synthesizes_dockerfile(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path, content="RUN apt-get install -y jq\n")
+    entries = _read_tar(overlay.build_context_tar("vibepod/claude:latest", dockerfile))
+    assert entries["Dockerfile"] == b"FROM vibepod/claude:latest\nRUN apt-get install -y jq\n"
+
+
+def test_build_context_tar_includes_context_files(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    (dockerfile.parent / "requirements.txt").write_text("requests\n")
+    nested = dockerfile.parent / "scripts"
+    nested.mkdir()
+    (nested / "setup.sh").write_text("echo hi\n")
+    entries = _read_tar(overlay.build_context_tar("base:latest", dockerfile))
+    assert entries["requirements.txt"] == b"requests\n"
+    assert entries["scripts/setup.sh"] == b"echo hi\n"
+
+
+def test_build_context_tar_excludes_agent_subdirs_for_shared_overlay(tmp_path: Path) -> None:
+    shared = _make_overlay(tmp_path)
+    _make_overlay(tmp_path, "gemini")
+    entries = _read_tar(overlay.build_context_tar("base:latest", shared))
+    assert "gemini/Dockerfile" not in entries
+
+
+class _FakeManager:
+    def __init__(self, existing_images=(), image_ids=None):
+        self.existing = set(existing_images)
+        self.ids = image_ids or {}
+        self.built = []
+        self.swept = []
+
+    def image_id(self, image):
+        if image in self.ids:
+            return self.ids[image]
+        return "sha256:built" if image in self.existing else None
+
+    def build_image(self, context_tar, tag, labels):
+        self.built.append((tag, labels))
+        self.existing.add(tag)
+
+    def remove_stale_overlays(self, overlay_key, keep_tag):
+        self.swept.append((overlay_key, keep_tag))
+        return 0
+
+
+def test_apply_overlay_returns_base_image_without_overlay(tmp_path: Path) -> None:
+    manager = _FakeManager()
+    assert overlay.apply_overlay(manager, tmp_path, "claude", "base:latest") == "base:latest"
+    assert manager.built == []
+
+
+def test_apply_overlay_builds_and_returns_overlay_tag(tmp_path: Path) -> None:
+    _make_overlay(tmp_path)
+    manager = _FakeManager(image_ids={"base:latest": "sha256:base"})
+    result = overlay.apply_overlay(manager, tmp_path, "claude", "base:latest")
+    assert result.startswith("vibepod/overlay-claude:")
+    (built,) = manager.built
+    assert built[0] == result
+    assert built[1]["vibepod.managed"] == "true"
+    assert manager.swept == [(built[1]["vibepod.overlay.key"], result)]
+
+
+def test_apply_overlay_skips_build_when_image_exists(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    digest = overlay.overlay_hash("sha256:base", dockerfile)
+    tag = overlay.overlay_image_tag("claude", digest)
+    manager = _FakeManager(existing_images=[tag], image_ids={"base:latest": "sha256:base"})
+    assert overlay.apply_overlay(manager, tmp_path, "claude", "base:latest") == tag
+    assert manager.built == []
+
+
+def test_apply_overlay_rebuild_forces_build(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    digest = overlay.overlay_hash("sha256:base", dockerfile)
+    tag = overlay.overlay_image_tag("claude", digest)
+    manager = _FakeManager(existing_images=[tag], image_ids={"base:latest": "sha256:base"})
+    assert overlay.apply_overlay(manager, tmp_path, "claude", "base:latest", rebuild=True) == tag
+    assert [built_tag for built_tag, _ in manager.built] == [tag]
+
+
+def test_apply_overlay_hashes_tag_when_base_not_local(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    manager = _FakeManager()
+    result = overlay.apply_overlay(manager, tmp_path, "claude", "base:latest")
+    assert result == overlay.overlay_image_tag(
+        "claude", overlay.overlay_hash("base:latest", dockerfile)
+    )
+
+
+def test_apply_overlay_key_differs_per_workspace_and_agent(tmp_path: Path) -> None:
+    ws_a = tmp_path / "a"
+    ws_b = tmp_path / "b"
+    _make_overlay(ws_a)
+    _make_overlay(ws_b)
+    manager_a = _FakeManager()
+    manager_b = _FakeManager()
+    overlay.apply_overlay(manager_a, ws_a, "claude", "base:latest")
+    overlay.apply_overlay(manager_b, ws_b, "claude", "base:latest")
+    ((_, labels_a),) = manager_a.built
+    ((_, labels_b),) = manager_b.built
+    assert labels_a["vibepod.overlay.key"] != labels_b["vibepod.overlay.key"]
+
+
+def test_apply_overlay_if_enabled_calls_core(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls = {}
+
+    def fake_apply(manager, workspace, agent, base_image, *, rebuild=False):
+        calls["args"] = (manager, workspace, agent, base_image, rebuild)
+        return "vibepod/overlay-claude:abc"
+
+    monkeypatch.setattr(launch.overlay, "apply_overlay", fake_apply)
+    result = launch.apply_overlay_if_enabled(
+        manager="mgr",
+        workspace_path=tmp_path,
+        agent="claude",
+        image="base:latest",
+        agent_cfg={},
+        no_overlay=False,
+        rebuild_overlay=True,
+    )
+    assert result == "vibepod/overlay-claude:abc"
+    assert calls["args"] == ("mgr", tmp_path, "claude", "base:latest", True)
+
+
+def test_apply_overlay_if_enabled_respects_no_overlay_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        launch.overlay, "apply_overlay", lambda *a, **k: pytest.fail("should not build")
+    )
+    result = launch.apply_overlay_if_enabled(
+        manager="mgr",
+        workspace_path=tmp_path,
+        agent="claude",
+        image="base:latest",
+        agent_cfg={},
+        no_overlay=True,
+        rebuild_overlay=False,
+    )
+    assert result == "base:latest"
+
+
+def test_apply_overlay_if_enabled_respects_agent_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        launch.overlay, "apply_overlay", lambda *a, **k: pytest.fail("should not build")
+    )
+    result = launch.apply_overlay_if_enabled(
+        manager="mgr",
+        workspace_path=tmp_path,
+        agent="claude",
+        image="base:latest",
+        agent_cfg={"overlay": False},
+        no_overlay=False,
+        rebuild_overlay=False,
+    )
+    assert result == "base:latest"
+
+
+def test_apply_overlay_if_enabled_exits_on_build_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def failing_apply(*a, **k):
+        raise DockerClientError("build broke")
+
+    monkeypatch.setattr(launch.overlay, "apply_overlay", failing_apply)
+    with pytest.raises(typer.Exit):
+        launch.apply_overlay_if_enabled(
+            manager="mgr",
+            workspace_path=tmp_path,
+            agent="claude",
+            image="base:latest",
+            agent_cfg={},
+            no_overlay=False,
+            rebuild_overlay=False,
+        )


### PR DESCRIPTION
Introduces project overlays to VibePod, proposed in https://github.com/VibePod/vibepod-cli/issues/113, allowing users to customize agent container images with Dockerfile fragments committed in the project. Overlays are content-addressed, cached, and automatically managed, enabling persistent, shareable environment changes without the need for custom images or slow per-run setup. The implementation includes CLI options to control overlays and comprehensive documentation.

**Major features and changes:**

#### Project overlays feature

* Added support for per-project image overlays: users can commit a FROM-less Dockerfile fragment in `.vibepod/overlay/` (shared) or `.vibepod/overlay/<agent>/` (per-agent) to extend agent images. Overlays are built as content-addressed images, cached, and automatically garbage-collected. (`src/vibepod/core/overlay.py`)
* Introduced a new `overlay` key in agent configuration (`.vibepod/config.yaml`) to enable or disable overlays per agent. (`docs/configuration.md`)

#### CLI and command integration

* Added `--no-overlay` and `--rebuild-overlay` options to `vp run` and `vp task create/run` to control overlay usage and force rebuilds. (`src/vibepod/commands/run.py`, `src/vibepod/commands/task.py`)
* Integrated overlay application into the agent/container launch process via `apply_overlay_if_enabled`, which swaps in the overlay image unless disabled.

#### Docker management

* Added `build_image` and `remove_stale_overlays` methods to `DockerManager` for building overlay images from in-memory contexts and cleaning up superseded overlays. (`src/vibepod/core/docker.py`)

#### Documentation and UI

* Added a new documentation page explaining overlays, their usage, and comparison to other customization methods. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **project overlays**: extend agent base images using `FROM`-less Dockerfile fragments from `.vibepod/overlay/` (shared and per-agent).
  - Added overlay controls to `run` and `task` (including deprecated `task run`) with `--no-overlay` and `--rebuild-overlay`.
- **Documentation**
  - Added a **Project overlays** guide, updated README, and extended configuration docs with `agents.<agent>.claude.overlay` behavior; updated site navigation.
- **Tests**
  - Added/expanded CLI, overlay, and Docker overlay build/cleanup coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->