### PR TITLE
Configurable port publishing for agent containers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,6 +253,12 @@ agents:
       - "3000"                 # container port on a random host port
 ```
 
+!!! warning "Always quote port entries"
+    YAML 1.1 parses unquoted `host:container` pairs as base-60 numbers:
+    `- 22:22` loads as the integer `1342` and would publish the wrong port.
+    Out-of-range results (e.g. `3000:30` → `180030`) are rejected at startup,
+    but in-range ones are not detectable — quote every entry.
+
 Like other agent keys, a project-level `ports` list replaces the global one for that agent. The list applies to both `vp run` and `vp task` containers; note that two containers cannot publish the same host port at the same time, so a fixed host port limits you to one such container per agent.
 
 ## The built-in proxy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ agents:
     auto_pull: null  # Per-agent override: true/false, or null to use global auto_pull
     env: {}       # Extra environment variables passed to the container
     volumes: []   # Reserved for future use
+    ports: []     # Ports to publish on the host, `docker run -p` syntax
     init: []      # Optional shell commands run before agent startup
     overlay: true # Set false to ignore the project's .vibepod/overlay/ (see Project overlays)
 
@@ -59,6 +60,7 @@ agents:
     image: vibepod/gemini:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
   opencode:
@@ -66,6 +68,7 @@ agents:
     image: vibepod/opencode:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
   devstral:
@@ -73,6 +76,7 @@ agents:
     image: vibepod/devstral:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
   auggie:
@@ -80,6 +84,7 @@ agents:
     image: vibepod/auggie:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
   copilot:
@@ -87,6 +92,7 @@ agents:
     image: vibepod/copilot:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
   codex:
@@ -94,6 +100,7 @@ agents:
     image: vibepod/codex:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
   pi:
@@ -101,6 +108,7 @@ agents:
     image: vibepod/pi:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
   agy:
@@ -108,6 +116,7 @@ agents:
     image: vibepod/agy:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
   tau:
@@ -115,6 +124,7 @@ agents:
     image: vibepod/tau:latest
     env: {}
     volumes: []
+    ports: []
     init: []
 
 # Connect agents to a local or remote LLM server (Ollama, vLLM, etc.)
@@ -227,6 +237,23 @@ agents:
 `agents.<agent>.init` runs inside the container before the agent process starts. Commands run with `/bin/sh -lc` and `set -e` (startup stops on the first failed command).
 
 Commit this file to share project defaults with your team.
+
+## Publishing ports
+
+By default no user-defined ports are published, so anything the agent starts inside the container — a dev server, web UI, or debugger — is unreachable from the host. `agents.<agent>.ports` publishes container ports on the host using the same syntax as `docker run -p`:
+
+```yaml
+# .vibepod/config.yaml
+agents:
+  claude:
+    ports:
+      - "8000:8000"            # host:container
+      - "127.0.0.1:9229:9229"  # bind to a specific host interface
+      - "6000:6000/udp"        # UDP
+      - "3000"                 # container port on a random host port
+```
+
+Like other agent keys, a project-level `ports` list replaces the global one for that agent. The list applies to both `vp run` and `vp task` containers; note that two containers cannot publish the same host port at the same time, so a fixed host port limits you to one such container per agent.
 
 ## The built-in proxy
 

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -32,6 +32,9 @@ from vibepod.core.launch import (
     agent_init_commands as _agent_init_commands,
 )
 from vibepod.core.launch import (
+    agent_port_bindings as _agent_port_bindings,
+)
+from vibepod.core.launch import (
     apply_overlay_if_enabled,
 )
 from vibepod.core.launch import (
@@ -340,12 +343,17 @@ def run(
         **{str(k): str(v) for k, v in agent_cfg.get("env", {}).items()},
         **_parse_env_pairs(env or []),
     }
-    agent_ports: dict[str, Any] | None = None
+    agent_ports: dict[str, Any] | None = _agent_port_bindings(selected_agent, agent_cfg) or None
     if codex_oauth_login:
         # Tell the codex image to start the loopback forwarder, and publish it to
         # the host on the port Codex's redirect URI expects.
         merged_env["VIBEPOD_OAUTH_FORWARD_PORT"] = str(CODEX_OAUTH_FORWARD_PORT)
-        agent_ports = {f"{CODEX_OAUTH_FORWARD_PORT}/tcp": CODEX_OAUTH_CALLBACK_PORT}
+        # Merged last so a configured binding for the same container port loses:
+        # during `codex login` the callback forwarder must own this port.
+        agent_ports = {
+            **(agent_ports or {}),
+            f"{CODEX_OAUTH_FORWARD_PORT}/tcp": CODEX_OAUTH_CALLBACK_PORT,
+        }
         info(
             "codex login: publishing the OAuth callback on "
             f"http://localhost:{CODEX_OAUTH_CALLBACK_PORT}/auth/callback "

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -349,7 +349,10 @@ def run(
         # the host on the port Codex's redirect URI expects.
         merged_env["VIBEPOD_OAUTH_FORWARD_PORT"] = str(CODEX_OAUTH_FORWARD_PORT)
         # Merged last so a configured binding for the same container port loses:
-        # during `codex login` the callback forwarder must own this port.
+        # during `codex login` the callback forwarder must own this port. A
+        # proto-less config key ("1456") survives this literal merge, but
+        # docker-py normalizes both keys to "1456/tcp" and insertion order
+        # still makes the OAuth binding win.
         agent_ports = {
             **(agent_ports or {}),
             f"{CODEX_OAUTH_FORWARD_PORT}/tcp": CODEX_OAUTH_CALLBACK_PORT,

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -29,6 +29,7 @@ from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag
 from vibepod.core.launch import (
     agent_extra_volumes,
     agent_init_commands,
+    agent_port_bindings,
     apply_overlay_if_enabled,
     get_container_ip,
     host_identity_env,
@@ -491,6 +492,7 @@ def task_create(
 
     agent_cfg = config.get("agents", {}).get(selected, {})
     init_commands = agent_init_commands(selected, agent_cfg)
+    agent_ports = agent_port_bindings(selected, agent_cfg) or None
     merged_env = {
         **host_identity_env(),
         **terminal_env_defaults(),
@@ -663,6 +665,7 @@ def task_create(
         name=name,
         version=__version__,
         network=network_name,
+        ports=agent_ports,
         extra_volumes=extra_volumes,
         platform=spec.platform,
         user=container_user,

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -42,6 +42,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "gemini": {
@@ -50,6 +51,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "opencode": {
@@ -58,6 +60,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "devstral": {
@@ -66,6 +69,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "auggie": {
@@ -74,6 +78,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "copilot": {
@@ -82,6 +87,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "codex": {
@@ -90,6 +96,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "pi": {
@@ -98,6 +105,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "agy": {
@@ -106,6 +114,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
             "tau": {
@@ -114,6 +123,7 @@ def _default_config() -> dict[str, Any]:
                 "auto_pull": None,
                 "env": {},
                 "volumes": [],
+                "ports": [],
                 "init": [],
             },
         },

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -618,7 +618,10 @@ class DockerManager:
                     "host_config": host_config,
                 }
                 if ports:
-                    create_kwargs["ports"] = list(ports.keys())
+                    # (port, proto) tuples: raw "1456/tcp" keys would be
+                    # re-suffixed by docker-py's exposed-port normalization
+                    # into "1456/tcp/tcp".
+                    create_kwargs["ports"] = [tuple(p.split("/", 1)) for p in ports]
                 if platform:
                     create_kwargs["platform"] = platform
                 if user:

--- a/src/vibepod/core/launch.py
+++ b/src/vibepod/core/launch.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import typer
+from docker.utils.ports import build_port_bindings
 
 from vibepod.core import overlay
 from vibepod.core.config import load_project_config
@@ -126,6 +127,43 @@ def agent_init_commands(agent: str, agent_cfg: dict[str, Any]) -> list[str]:
             )
         commands.append(command)
     return commands
+
+
+def agent_port_bindings(agent: str, agent_cfg: dict[str, Any]) -> dict[str, Any]:
+    """Read and validate per-agent published ports from config.
+
+    Entries use `docker run -p` syntax (`8000:8000`, `127.0.0.1:8080:80`,
+    `6000:6000/udp`, ...) and are returned in docker-py port-bindings form.
+    """
+    raw_ports = agent_cfg.get("ports", [])
+    if raw_ports is None:
+        return {}
+
+    if isinstance(raw_ports, (str, int)) and not isinstance(raw_ports, bool):
+        items: list[Any] = [raw_ports]
+    elif isinstance(raw_ports, list):
+        items = raw_ports
+    else:
+        raise typer.BadParameter(
+            f"Invalid agents.{agent}.ports value, expected a string or list of strings."
+        )
+
+    bindings: dict[str, Any] = {}
+    for index, item in enumerate(items, start=1):
+        if isinstance(item, bool) or not isinstance(item, (str, int)):
+            raise typer.BadParameter(
+                f"Invalid agents.{agent}.ports[{index}] value, expected a string like '8000:8000'."
+            )
+        entry = str(item).strip()
+        try:
+            parsed = build_port_bindings([entry])
+        except ValueError as exc:
+            raise typer.BadParameter(
+                f"Invalid agents.{agent}.ports[{index}] value '{entry}': {exc}"
+            ) from exc
+        for internal, binds in parsed.items():
+            bindings.setdefault(internal, []).extend(binds)
+    return bindings
 
 
 def init_entrypoint(init_commands: list[str]) -> list[str]:

--- a/src/vibepod/core/launch.py
+++ b/src/vibepod/core/launch.py
@@ -129,6 +129,22 @@ def agent_init_commands(agent: str, agent_cfg: dict[str, Any]) -> list[str]:
     return commands
 
 
+def _check_publish_port(value: Any, *, minimum: int, agent: str, index: int, entry: str) -> None:
+    """Reject port numbers docker-py's syntax-only parser lets through.
+
+    Catches YAML 1.1 sexagesimal surprises: an unquoted `3000:30` loads as the
+    int 180030 and would otherwise silently publish the wrong port.
+    """
+    if value is None:
+        return
+    text = str(value)
+    if text.isdigit() and not minimum <= int(text) <= 65535:
+        raise typer.BadParameter(
+            f"Invalid agents.{agent}.ports[{index}] value '{entry}': "
+            f"port {text} is out of range {minimum}-65535."
+        )
+
+
 def agent_port_bindings(agent: str, agent_cfg: dict[str, Any]) -> dict[str, Any]:
     """Read and validate per-agent published ports from config.
 
@@ -145,7 +161,8 @@ def agent_port_bindings(agent: str, agent_cfg: dict[str, Any]) -> dict[str, Any]
         items = raw_ports
     else:
         raise typer.BadParameter(
-            f"Invalid agents.{agent}.ports value, expected a string or list of strings."
+            f"Invalid agents.{agent}.ports value, "
+            "expected a string like '8000:8000' or a list of them."
         )
 
     bindings: dict[str, Any] = {}
@@ -162,6 +179,12 @@ def agent_port_bindings(agent: str, agent_cfg: dict[str, Any]) -> dict[str, Any]
                 f"Invalid agents.{agent}.ports[{index}] value '{entry}': {exc}"
             ) from exc
         for internal, binds in parsed.items():
+            container_port = internal.split("/", 1)[0]
+            _check_publish_port(container_port, minimum=1, agent=agent, index=index, entry=entry)
+            for bind in binds:
+                host_port = bind[1] if isinstance(bind, tuple) else bind
+                # Host port 0 is valid: the daemon assigns an ephemeral port.
+                _check_publish_port(host_port, minimum=0, agent=agent, index=index, entry=entry)
             bindings.setdefault(internal, []).extend(binds)
     return bindings
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,6 +126,16 @@ def test_default_config_exposes_agent_init(monkeypatch, tmp_path: Path) -> None:
         assert agents[agent]["init"] == []
 
 
+def test_default_config_exposes_agent_ports(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    config = get_config()
+    agents = config.get("agents", {})
+    assert isinstance(agents, dict)
+
+    for agent in SUPPORTED_AGENTS:
+        assert agents[agent]["ports"] == []
+
+
 def test_default_config_exposes_agent_auto_pull(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
     config = get_config()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -164,6 +164,27 @@ def test_agent_port_bindings_rejects_invalid_entries() -> None:
         launch.agent_port_bindings("claude", {"ports": {"8000": 8000}})
 
 
+def test_agent_port_bindings_rejects_out_of_range_ports() -> None:
+    # Container port out of range.
+    with pytest.raises(typer.BadParameter, match=r"out of range"):
+        launch.agent_port_bindings("claude", {"ports": ["8000:70000"]})
+
+    # Host port out of range.
+    with pytest.raises(typer.BadParameter, match=r"out of range"):
+        launch.agent_port_bindings("claude", {"ports": ["99999:8000"]})
+
+    # YAML 1.1 sexagesimal surprise: unquoted `3000:30` loads as the int
+    # 180030, which must not silently publish container port 180030.
+    with pytest.raises(typer.BadParameter, match=r"agents\.claude\.ports\[1\].*out of range"):
+        launch.agent_port_bindings("claude", {"ports": [180030]})
+
+    # Port 0 stays valid on the host side (daemon assigns an ephemeral port)
+    # but not as a container port.
+    assert launch.agent_port_bindings("claude", {"ports": ["0:80"]}) == {"80": ["0"]}
+    with pytest.raises(typer.BadParameter, match=r"out of range"):
+        launch.agent_port_bindings("claude", {"ports": ["8000:0"]})
+
+
 def test_skills_mounts_for_agent_ignores_malformed_lockfiles(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -115,6 +115,55 @@ def test_agent_extra_volumes_for_opencode(tmp_path: Path) -> None:
     ]
 
 
+def test_agent_port_bindings_empty_config() -> None:
+    assert launch.agent_port_bindings("claude", {}) == {}
+    assert launch.agent_port_bindings("claude", {"ports": None}) == {}
+    assert launch.agent_port_bindings("claude", {"ports": []}) == {}
+
+
+def test_agent_port_bindings_supports_docker_publish_syntax() -> None:
+    bindings = launch.agent_port_bindings(
+        "claude",
+        {
+            "ports": [
+                "8000:8000",
+                "127.0.0.1:8080:80",
+                "6000:6000/udp",
+                9000,
+                "127.0.0.1::5000",
+            ]
+        },
+    )
+    assert bindings == {
+        "8000": ["8000"],
+        "80": [("127.0.0.1", "8080")],
+        "6000/udp": ["6000"],
+        "9000": [None],
+        "5000": [("127.0.0.1", None)],
+    }
+
+
+def test_agent_port_bindings_accepts_single_string_and_merges_duplicates() -> None:
+    assert launch.agent_port_bindings("claude", {"ports": "8000:80"}) == {"80": [("8000")]}
+
+    bindings = launch.agent_port_bindings("claude", {"ports": ["8000:80", "9000:80"]})
+    assert bindings == {"80": ["8000", "9000"]}
+
+
+def test_agent_port_bindings_rejects_invalid_entries() -> None:
+    with pytest.raises(typer.BadParameter, match=r"agents\.claude\.ports\[2\]"):
+        launch.agent_port_bindings("claude", {"ports": ["8000:8000", "not-a-port"]})
+
+    with pytest.raises(typer.BadParameter, match=r"agents\.gemini\.ports\[1\]"):
+        launch.agent_port_bindings("gemini", {"ports": [""]})
+
+    with pytest.raises(typer.BadParameter, match=r"agents\.claude\.ports\[1\]"):
+        launch.agent_port_bindings("claude", {"ports": [{"host": 8000}]})
+
+    with pytest.raises(typer.BadParameter, match=r"agents\.claude\.ports"):
+        launch.agent_port_bindings("claude", {"ports": {"8000": 8000}})
+
+
 def test_skills_mounts_for_agent_ignores_malformed_lockfiles(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -473,7 +522,7 @@ def test_run_agent_uses_low_level_api_for_podman_keep_id(tmp_path: Path) -> None
         name="vibepod-pi-test",
         version="0.14.0",
         network="vibepod-network",
-        ports={"1456/tcp": 1455},
+        ports={"1456/tcp": 1455, "6000/udp": ["6000"], "9000": [None]},
         extra_volumes=[(str(config_dir / "extra"), "/extra", "ro")],
         platform="linux/amd64",
         user="1000:1000",
@@ -492,7 +541,7 @@ def test_run_agent_uses_low_level_api_for_podman_keep_id(tmp_path: Path) -> None
         ],
         "auto_remove": True,
         "network_mode": "vibepod-network",
-        "port_bindings": {"1456/tcp": 1455},
+        "port_bindings": {"1456/tcp": 1455, "6000/udp": ["6000"], "9000": [None]},
     }
     assert client.api.host_config is not None
     assert client.api.host_config["UsernsMode"] == "keep-id"
@@ -503,10 +552,140 @@ def test_run_agent_uses_low_level_api_for_podman_keep_id(tmp_path: Path) -> None
     assert client.api.create_kwargs["labels"]["vibepod.agent"] == "pi"
     assert client.api.create_kwargs["environment"] == {"USER_UID": "0"}
     assert client.api.create_kwargs["working_dir"] == "/workspace"
-    assert client.api.create_kwargs["ports"] == ["1456/tcp"]
+    # (port, proto) tuples: raw "1456/tcp" strings would be re-suffixed by
+    # docker-py's exposed-port normalization into "1456/tcp/tcp".
+    assert client.api.create_kwargs["ports"] == [("1456", "tcp"), ("6000", "udp"), ("9000",)]
     assert client.api.create_kwargs["platform"] == "linux/amd64"
     assert client.api.create_kwargs["user"] == "1000:1000"
     assert client.api.create_kwargs["entrypoint"] == ["/entrypoint.sh"]
+
+
+class _PortCapturingManager:
+    """DockerManager stub that records run_agent kwargs for `vp run` wiring tests."""
+
+    def __init__(self) -> None:
+        self.run_kwargs: dict | None = None
+
+    def ensure_network(self, name: str) -> None:
+        pass
+
+    def networks_with_running_containers(self) -> list[str]:
+        return []
+
+    def is_rootless_podman(self) -> bool:
+        return False
+
+    def pull_image(self, image: str, auto_clean: bool = False) -> None:
+        pass
+
+    def pull_if_newer(self, image: str, auto_clean: bool = False) -> None:
+        pass
+
+    def ensure_proxy(self, **kwargs) -> None:
+        pass
+
+    def resolve_launch_command(self, image: str, command: list[str] | None) -> list[str]:
+        return command or []
+
+    def run_agent(self, **kwargs):
+        self.run_kwargs = kwargs
+        return type(
+            "_Container",
+            (),
+            {
+                "id": "cid123456789012",
+                "name": kwargs.get("name") or "vibepod-claude-abcdef",
+                "status": "running",
+                "attrs": {"NetworkSettings": {"Networks": {}}},
+                "reload": lambda self: None,
+                "labels": {},
+                "logs": lambda self, **kw: b"",
+            },
+        )()
+
+
+def _ports_config(agent: str, ports) -> dict:
+    agent_cfg: dict = {"env": {}, "init": []}
+    if ports is not None:
+        agent_cfg["ports"] = ports
+    return {
+        "default_agent": "claude",
+        "auto_pull": False,
+        "auto_remove": True,
+        "network": "vibepod-network",
+        "agents": {agent: agent_cfg},
+        "proxy": {"enabled": False},
+        "logging": {"enabled": False},
+    }
+
+
+@pytest.fixture
+def _tmp_config_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path / "config"))
+    return tmp_path
+
+
+def test_run_publishes_configured_ports(monkeypatch, _tmp_config_root) -> None:
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _PortCapturingManager()
+    monkeypatch.setattr(
+        run_cmd, "get_config", lambda: _ports_config("claude", ["8000:8000", "6000:6000/udp"])
+    )
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    result = CliRunner().invoke(app, ["run", "claude", "-w", str(workspace), "--detach"])
+
+    assert result.exit_code == 0, result.output
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["ports"] == {"8000": ["8000"], "6000/udp": ["6000"]}
+
+
+def test_run_without_configured_ports_publishes_none(monkeypatch, _tmp_config_root) -> None:
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _PortCapturingManager()
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _ports_config("claude", None))
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    result = CliRunner().invoke(app, ["run", "claude", "-w", str(workspace), "--detach"])
+
+    assert result.exit_code == 0, result.output
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["ports"] is None
+
+
+def test_run_codex_oauth_ports_merge_with_configured_ports(monkeypatch, _tmp_config_root) -> None:
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _PortCapturingManager()
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _ports_config("codex", ["8000:8000"]))
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    result = CliRunner().invoke(
+        app, ["run", "codex", "-w", str(workspace), "--detach", "login"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["ports"] == {
+        "8000": ["8000"],
+        f"{run_cmd.CODEX_OAUTH_FORWARD_PORT}/tcp": run_cmd.CODEX_OAUTH_CALLBACK_PORT,
+    }
+
+
+def test_run_rejects_invalid_configured_ports(monkeypatch, _tmp_config_root) -> None:
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _PortCapturingManager()
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _ports_config("claude", ["not-a-port"]))
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    result = CliRunner().invoke(app, ["run", "claude", "-w", str(workspace), "--detach"])
+
+    assert result.exit_code != 0
+    assert "agents.claude.ports" in result.output
+    assert stub.run_kwargs is None
 
 
 def test_run_agent_is_rootless_podman_detects_podman_engine() -> None:

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -172,6 +172,22 @@ def test_task_create_publishes_configured_ports(monkeypatch, tmp_path, tmp_task_
     assert stub.run_kwargs["ports"] == {"8000": ["8000"], "6000/udp": ["6000"]}
 
 
+def test_task_create_rejects_invalid_ports_before_docker(
+    monkeypatch, tmp_path, tmp_task_store
+) -> None:
+    stub = _CapturingDockerManager()
+    cfg = _make_config()
+    cfg["agents"]["claude"]["ports"] = ["not-a-port"]
+    monkeypatch.setattr(task_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    with pytest.raises(typer.BadParameter, match=r"agents\.claude\.ports\[1\]"):
+        task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
+
+    assert stub.run_kwargs is None
+    assert tmp_task_store.list() == []
+
+
 def test_task_create_without_configured_ports_publishes_none(
     monkeypatch, tmp_path, tmp_task_store
 ) -> None:

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -159,6 +159,32 @@ def test_task_create_claude_builds_headless_command(monkeypatch, tmp_path, tmp_t
     assert stub.run_kwargs["agent"] == "claude"
 
 
+def test_task_create_publishes_configured_ports(monkeypatch, tmp_path, tmp_task_store) -> None:
+    stub = _CapturingDockerManager()
+    cfg = _make_config()
+    cfg["agents"]["claude"]["ports"] = ["8000:8000", "6000:6000/udp"]
+    monkeypatch.setattr(task_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
+
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["ports"] == {"8000": ["8000"], "6000/udp": ["6000"]}
+
+
+def test_task_create_without_configured_ports_publishes_none(
+    monkeypatch, tmp_path, tmp_task_store
+) -> None:
+    stub = _CapturingDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
+
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["ports"] is None
+
+
 def test_task_create_codex_uses_exec_subcommand(monkeypatch, tmp_path, tmp_task_store) -> None:
     stub = _CapturingDockerManager()
     monkeypatch.setattr(task_cmd, "get_config", _make_config)


### PR DESCRIPTION
Introduces support for per-agent published ports in VibePod, allowing users to expose container ports on the host using Docker's `-p` syntax. It adds a `ports` configuration option for each agent, updates the documentation and default config, and implements robust validation to prevent common YAML and port-mapping mistakes. The changes also include comprehensive tests to ensure correct and safe handling of port configurations.

**Agent port publishing support:**

* Added a `ports` configuration key for each agent in both the documentation and the default config, allowing users to specify host-to-container port mappings using Docker's `-p` syntax.
* Implemented the `agent_port_bindings` function in `core/launch.py`, which parses, validates, and converts the `ports` config into Docker-compatible port bindings, including checks for YAML parsing pitfalls and invalid port ranges.
* Updated the `run` and `task_create` commands to use the new `agent_port_bindings` logic, ensuring published ports are correctly set up when launching agents.

**Validation and error handling:**

* Added detailed validation and error reporting for malformed or out-of-range port entries, including safeguards against YAML 1.1 sexagesimal parsing issues.

**Documentation and testing:**

* Extended the documentation with a new section explaining how to use the `ports` option and the importance of quoting port mappings in YAML.
* Added tests to verify correct parsing, merging, and validation of port bindings, including edge cases and error scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-agent port publishing configuration for both interactive runs and background tasks.
  - Supports Docker-style mappings, protocols, host addresses, and container-only ports.
  - Added validation for invalid or out-of-range port values.
  - Preserves configured ports while correctly handling Codex OAuth callback ports.

- **Documentation**
  - Documented port publishing syntax, YAML quoting requirements, and host-port limitations.

- **Tests**
  - Added coverage for configuration defaults, port parsing, validation, run commands, and task creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->