### PR TITLE
chore: CLI readability cleanups from ShipGate auto-fix pass

### DIFF
--- a/scripts/check_default_images.py
+++ b/scripts/check_default_images.py
@@ -29,10 +29,7 @@ def _check_image_exists(image: str) -> tuple[bool, str]:
     except subprocess.TimeoutExpired:
         return (
             False,
-            (
-                "timed out after "
-                f"{MANIFEST_CHECK_TIMEOUT_SECONDS}s while checking docker manifest"
-            ),
+            (f"timed out after {MANIFEST_CHECK_TIMEOUT_SECONDS}s while checking docker manifest"),
         )
     if proc.returncode == 0:
         return True, ""

--- a/src/vibepod/commands/attach.py
+++ b/src/vibepod/commands/attach.py
@@ -79,9 +79,7 @@ def attach(
 
     agent = (getattr(target, "labels", {}) or {}).get("vibepod.agent", "agent")
     info(f"Attaching to {target.name} ({agent})")
-    warning(
-        f"Close the terminal to leave it running, or stop it with `vp stop {target.name}`."
-    )
+    warning(f"Close the terminal to leave it running, or stop it with `vp stop {target.name}`.")
     try:
         manager.attach_interactive(target)
     except DockerClientError as exc:

--- a/src/vibepod/commands/doctor.py
+++ b/src/vibepod/commands/doctor.py
@@ -167,9 +167,7 @@ def claude() -> None:
             console.print(f"  {key}: {masked}")
     if not found_any:
         console.print("  none set on host")
-    console.print(
-        "  [dim]note: these are host-side; the container sees its own env.[/dim]"
-    )
+    console.print("  [dim]note: these are host-side; the container sees its own env.[/dim]")
 
     console.print()
     console.print("[bold]Effective auth mode on next `vp run claude`[/bold]")
@@ -196,12 +194,8 @@ def claude() -> None:
         "  • If `modified` on .credentials.json never updates past the original /login time,"
     )
     console.print("    the token is not being rotated. Re-run with:")
-    console.print(
-        "      [cyan]vp run claude -e ANTHROPIC_LOG=debug -e DEBUG=1[/cyan]"
-    )
-    console.print(
-        "    and look for [dim][API:auth][/dim] entries near/after expiry to confirm."
-    )
+    console.print("      [cyan]vp run claude -e ANTHROPIC_LOG=debug -e DEBUG=1[/cyan]")
+    console.print("    and look for [dim][API:auth][/dim] entries near/after expiry to confirm.")
     console.print(
         "  • For headless/CI, consider `claude setup-token` + "
         "`-e CLAUDE_CODE_OAUTH_TOKEN=...` to bypass refresh entirely."

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -625,11 +625,7 @@ def run(
     finally:
         logger.close_session(exit_reason)
 
-    if (
-        selected_agent == "claude"
-        and "setup-token" in passthrough_args
-        and exit_reason == "normal"
-    ):
+    if selected_agent == "claude" and "setup-token" in passthrough_args and exit_reason == "normal":
         _capture_claude_setup_token(config_dir)
 
 

--- a/src/vibepod/commands/skills.py
+++ b/src/vibepod/commands/skills.py
@@ -78,8 +78,7 @@ def add_cmd(
             if record.get("bundle"):
                 installed = record.get("installed", [])
                 success(
-                    f"Installed {len(installed)} skill(s) from bundle "
-                    f"{record.get('locator', '')}"
+                    f"Installed {len(installed)} skill(s) from bundle {record.get('locator', '')}"
                 )
                 for item in installed:
                     info(f"  + {item.get('id', '?')} ({item.get('name', '')})")

--- a/src/vibepod/compat.py
+++ b/src/vibepod/compat.py
@@ -9,9 +9,7 @@ _HTTP_RESPONSE_FLUSH_PATCH_ATTR = "_vibepod_python314_closed_file_patch"
 _CLOSED_FILE_ERROR = "I/O operation on closed file."
 
 
-def should_ignore_closed_http_response_flush_error(
-    response: object, exc: BaseException
-) -> bool:
+def should_ignore_closed_http_response_flush_error(response: object, exc: BaseException) -> bool:
     """Return True for Python 3.14's closed ``HTTPResponse.fp`` flush cleanup error.
 
     Python 3.14 can surface a ``ValueError`` while finalizing Docker SDK / urllib3

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -689,13 +689,9 @@ class DockerManager:
         try:
             container.stop(timeout=0 if force else 10)
         except APIError as exc:
-            raise DockerClientError(
-                f"Failed to stop container '{name_or_id}': {exc}"
-            ) from exc
+            raise DockerClientError(f"Failed to stop container '{name_or_id}': {exc}") from exc
         except DockerException as exc:
-            raise DockerClientError(
-                f"Failed to stop container '{name_or_id}': {exc}"
-            ) from exc
+            raise DockerClientError(f"Failed to stop container '{name_or_id}': {exc}") from exc
         return container
 
     def stop_all(self, force: bool = False) -> int:

--- a/src/vibepod/core/skills_engine.py
+++ b/src/vibepod/core/skills_engine.py
@@ -158,10 +158,9 @@ def run_engine(
 
             config = get_config()
             auto_pull_enabled = bool(config.get("auto_pull", True))
-            is_latest = (
-                ":" not in SKILLS_ENGINE_IMAGE.split("/")[-1]
-                or SKILLS_ENGINE_IMAGE.endswith(":latest")
-            )
+            is_latest = ":" not in SKILLS_ENGINE_IMAGE.split("/")[
+                -1
+            ] or SKILLS_ENGINE_IMAGE.endswith(":latest")
 
             if not image_exists:
                 manager.pull_image(
@@ -171,6 +170,7 @@ def run_engine(
             elif auto_pull_enabled and is_latest:
                 try:
                     from vibepod.utils.console import info
+
                     info("Checking for skills-engine image updates…")
                     manager.pull_if_newer(
                         SKILLS_ENGINE_IMAGE,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -178,7 +178,6 @@ def test_llm_env_overrides(monkeypatch, tmp_path: Path) -> None:
     assert llm["model"] == "llama3"
 
 
-
 # ---------------------------------------------------------------------------
 # allow-dir / remove-dir / list-allowed-dirs subcommand tests
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -23,9 +23,7 @@ def test_doctor_missing_dir(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_doctor_valid_token(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path
-    )
+    monkeypatch.setattr("vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path)
     future_ms = int((time.time() + 3600) * 1000)
     (tmp_path / ".credentials.json").write_text(
         json.dumps(
@@ -46,9 +44,7 @@ def test_doctor_valid_token(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_doctor_expired_token(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path
-    )
+    monkeypatch.setattr("vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     past_ms = int((time.time() - 3600) * 1000)
@@ -70,16 +66,12 @@ def test_doctor_expired_token(tmp_path: Path, monkeypatch) -> None:
 
 def test_doctor_expired_creds_but_stored_token_is_ok(tmp_path: Path, monkeypatch) -> None:
     """Expired credentials.json should NOT exit 2 when a stored token covers auth."""
-    monkeypatch.setattr(
-        "vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path
-    )
+    monkeypatch.setattr("vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     past_ms = int((time.time() - 3600) * 1000)
     (tmp_path / ".credentials.json").write_text(
-        json.dumps(
-            {"claudeAiOauth": {"accessToken": "a", "expiresAt": past_ms}}
-        )
+        json.dumps({"claudeAiOauth": {"accessToken": "a", "expiresAt": past_ms}})
     )
     (tmp_path / "oauth-token").write_text("sk-stored\n", encoding="utf-8")
     result = runner.invoke(app, ["doctor", "claude"])
@@ -88,9 +80,7 @@ def test_doctor_expired_creds_but_stored_token_is_ok(tmp_path: Path, monkeypatch
 
 
 def test_doctor_missing_refresh_token(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path
-    )
+    monkeypatch.setattr("vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path)
     future_ms = int((time.time() + 3600) * 1000)
     (tmp_path / ".credentials.json").write_text(
         json.dumps(
@@ -108,9 +98,7 @@ def test_doctor_missing_refresh_token(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_doctor_reports_stored_token_mode(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path
-    )
+    monkeypatch.setattr("vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     (tmp_path / "oauth-token").write_text("sk-xyz\n", encoding="utf-8")
@@ -120,9 +108,7 @@ def test_doctor_reports_stored_token_mode(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_doctor_reports_host_env_mode(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path
-    )
+    monkeypatch.setattr("vibepod.commands.doctor.agent_config_dir", lambda _agent: tmp_path)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "host-token-abc")
     result = runner.invoke(app, ["doctor", "claude"])

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -679,9 +679,9 @@ def test_paste_images_flag_adds_x11_volumes_and_env(monkeypatch, tmp_path: Path)
 
     run_cmd.run(agent="claude", workspace=tmp_path, detach=True, paste_images=True)
 
-    assert ("/tmp/.X11-unix", "/tmp/.X11-unix", "rw") in captured.get(
-        "extra_volumes", []
-    ), f"X11 socket not found in extra_volumes: {captured.get('extra_volumes')}"
+    assert ("/tmp/.X11-unix", "/tmp/.X11-unix", "rw") in captured.get("extra_volumes", []), (
+        f"X11 socket not found in extra_volumes: {captured.get('extra_volumes')}"
+    )
 
 
 def test_paste_images_flag_mounts_xauth_cookie(monkeypatch, tmp_path: Path) -> None:
@@ -1900,7 +1900,6 @@ def test_run_sets_default_term_when_host_term_missing(monkeypatch, tmp_path: Pat
     assert env["TERM"] == "xterm-256color"
 
 
-
 # ---------------------------------------------------------------------------
 # Directory permission tests
 # ---------------------------------------------------------------------------
@@ -1942,9 +1941,7 @@ def _make_capturing_docker_manager():
     return _CapturingDockerManager, captured
 
 
-def test_run_aborts_when_dir_not_allowed_and_non_interactive(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_run_aborts_when_dir_not_allowed_and_non_interactive(monkeypatch, tmp_path: Path) -> None:
     """Non-interactive stdin + disallowed dir → Exit(1) with no prompt."""
     monkeypatch.setattr(run_cmd, "is_dir_allowed", lambda p: False)
     monkeypatch.setattr(run_cmd, "is_protected_dir", lambda p: False)

--- a/tests/test_skills_engine_driver.py
+++ b/tests/test_skills_engine_driver.py
@@ -19,8 +19,10 @@ def mock_docker_manager(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeDockerManager:
         def __init__(self) -> None:
             self.client = MagicMock()
+
         def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pass
+
         def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
             return False
 
@@ -80,9 +82,7 @@ def test_run_engine_explicit_local_scope_creates_local_skills_dir(
     skills_engine.list_skills("local", cwd=tmp_path)
 
     local = tmp_path / ".vibepod" / "skills"
-    mount_args = [
-        arg for i, arg in enumerate(captured["cmd"]) if captured["cmd"][i - 1] == "-v"
-    ]
+    mount_args = [arg for i, arg in enumerate(captured["cmd"]) if captured["cmd"][i - 1] == "-v"]
     assert local.is_dir()
     assert f"{local}:/vibepod/local-skills" in mount_args
 
@@ -150,8 +150,7 @@ def test_add_accepts_github_tree_url(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     url = (
-        "https://github.com/alirezarezvani/claude-skills/tree/main/"
-        "product-team/skills/spec-to-repo"
+        "https://github.com/alirezarezvani/claude-skills/tree/main/product-team/skills/spec-to-repo"
     )
     skills_engine.add(url, scope="user", cwd=tmp_path)
 
@@ -232,9 +231,7 @@ def test_add_does_not_mount_remote_locators(
         assert "-w" not in cmd, locator
 
 
-def test_add_expands_tilde_local_locator(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_add_expands_tilde_local_locator(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     home = tmp_path / "home"
     source = home / "skills" / "foo"
     source.mkdir(parents=True)
@@ -308,8 +305,10 @@ def test_run_engine_pulls_image_when_missing(
         def __init__(self) -> None:
             self.client = MagicMock()
             self.client.images.get.side_effect = NotFound("not found")
+
         def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pulled_images.append((image, auto_clean))
+
         def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
             checked_images.append(image)
             return False
@@ -341,8 +340,10 @@ def test_run_engine_checks_updates_when_latest(
         def __init__(self) -> None:
             self.client = MagicMock()
             self.client.images.get.return_value = MagicMock()
+
         def pull_image(self, image: str, auto_clean: bool = False) -> None:
             pulled_images.append((image, auto_clean))
+
         def pull_if_newer(self, image: str, auto_clean: bool = False) -> bool:
             checked_images.append((image, auto_clean))
             return False

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -1012,6 +1012,7 @@ def test_task_create_preserves_host_user_for_non_podman(
     monkeypatch, tmp_path, tmp_task_store
 ) -> None:
     import os
+
     class _DockerDockerManager(_CapturingDockerManager):
         def is_rootless_podman(self) -> bool:
             return False
@@ -1021,15 +1022,14 @@ def test_task_create_preserves_host_user_for_non_podman(
     monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
 
     import dataclasses
+
     original_get_agent_spec = task_cmd.get_agent_spec
     spec = original_get_agent_spec("claude")
     modified_spec = dataclasses.replace(spec, run_as_host_user=True)
     monkeypatch.setattr(
         task_cmd,
         "get_agent_spec",
-        lambda agent: (
-            modified_spec if agent == "claude" else original_get_agent_spec(agent)
-        ),
+        lambda agent: modified_spec if agent == "claude" else original_get_agent_spec(agent),
     )
     monkeypatch.setattr(os, "getuid", lambda: 1234, raising=False)
     monkeypatch.setattr(os, "getgid", lambda: 5678, raising=False)


### PR DESCRIPTION
Small readability cleanups in the VibePod CLI core (`src/vibepod`) and related tests from a ShipGate auto-fix pass.

## Summary

*Review run with ShipGate 0.1.7.*

ShipGate reported **~252 lint findings** in the full check suite. This PR applies safe ruff/format fixes in core CLI modules; see the linked gist for raw captures.

Hotspots and improvement notes below are scoped to **Python (`*.py`)** source.
### File hotspots

| File | Issues | Action |
| --- | ---: | --- |
| `src/vibepod/commands/task.py` | ~53 lint | extract repeated strings; review private helpers |
| `src/vibepod/core/docker.py` | ~35 lint | simplify docker helper surface |
| `src/vibepod/commands/run.py` | ~22 lint | trim private helpers; review fixture overlap in tests only |
| `tests/test_run.py` | ~15 lint | align test helpers with production visibility |
| `tests/test_overlay.py` | ~13 lint | tighten type hints in overlay tests |
| `src/vibepod/commands/skills.py` | ~11 lint | reduce complexity in skills command |
| `tests/test_task_cmd.py` | ~11 lint | fix subscriptable/type issues in task tests |
| `src/vibepod/core/skills_engine.py` | ~10 lint | private helper cleanup |
### Refactor hints (optional apply)

*No hint-tier refactor opportunities in scope (or `refactor-strict.out` empty).*
## What you are doing right

- **Dead code:** vulture/deadcode found few or no unused symbols in production modules.
- **Tests:** `pytest` passed locally (349 passed, 1 skipped).

## What you could improve

- **Duplication (~5.4%):** jscpd reports duplicate blocks — review clustered paths in hotspots.
- **Complexity:** radon flagged modules above cyclomatic-complexity gates.
- **Hotspot:** `src/vibepod/commands/task.py` concentrates the most findings.

## Changes

| Pass | Files | Fixes / rules | Manual? |
| --- | ---: | --- | --- |
| `shipgate format` + `ruff --fix` | 13 | readability / import / minor style on `src/vibepod` + tests | no |
| `tests` | — | `python -m pytest -q` green locally | no |
| **Total** | **13** | ~37 insertions / ~76 deletions | — |
