### PR TITLE
docs(pi): document local models via models.json

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -704,8 +704,16 @@ The `api` / `baseUrl` / `models` fields are documented in Pi's
 [llama.cpp](https://pi.dev/docs/latest/llama-cpp) guides. The `apiKey` value is
 arbitrary for local servers that don't check it. Start Pi as usual
 (`vp run pi`) and pick the model with the `/model` command — providers from
-`models.json` appear alongside the built-in ones. The first provider entry
-determines the default model.
+`models.json` appear alongside the built-in ones, and the file is re-read
+every time you open `/model`, so you can edit it mid-session.
+
+Note that adding `models.json` does **not** change which model Pi starts
+with: the startup model comes from the `defaultModel` setting in
+`/config/.pi/agent/settings.json` (on the host:
+`~/.config/vibepod/agents/pi/.pi/agent/settings.json`). Select the local
+model via `/model`, or set `defaultModel` explicitly, so an existing
+configuration does not silently keep sending requests to a remote metered
+provider.
 
 !!! note "Linux: expose the server to Docker"
     On Linux, `host.docker.internal` resolves to the Docker bridge gateway

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -644,6 +644,91 @@ Pi has a per-project **trust/approval system**: before loading project-local ext
 - `--ikwid`: appends `--approve`, trusting project-local files for that run (see [IKWID mode](#ikwid-mode---ikwid)).
 - Non-interactive modes (`-p`, `--mode json`, `--mode rpc`) show no prompt and fall back to `defaultProjectTrust` in `/config/.pi/agent/settings.json` (`ask` | `always` | `never`). Pre-seed this file if you need unattended runs to trust projects automatically.
 
+#### Local models (Ollama, LM Studio, Lemonade, llama.cpp)
+
+Pi supports custom OpenAI-compatible providers through a
+[`models.json`](https://pi.dev/docs/latest/models) file in its agent directory.
+Inside the container that directory is `PI_CODING_AGENT_DIR`
+(`/config/.pi/agent/`), which is part of the persisted config mount — so you
+create the file **on the host** and it is picked up on every run:
+
+```bash
+vp config path
+# Global:  ~/.config/vibepod/config.yaml
+```
+
+The agent directory lives next to that config file:
+
+```text
+~/.config/vibepod/agents/pi/.pi/agent/models.json
+```
+
+Point each provider's `baseUrl` at `host.docker.internal` so the container can
+reach the server running on your host (VibePod maps this hostname on Linux,
+macOS, and Windows automatically):
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://host.docker.internal:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "models": [
+        { "id": "qwen3.6:35b" },
+        { "id": "gemma4:12b" }
+      ]
+    },
+    "lmstudio": {
+      "baseUrl": "http://host.docker.internal:1234/v1",
+      "api": "openai-completions",
+      "apiKey": "lmstudio",
+      "models": [
+        { "id": "poolside/laguna-s-2.1" }
+      ]
+    },
+    "lemonade": {
+      "baseUrl": "http://host.docker.internal:13305/v1",
+      "api": "openai-completions",
+      "apiKey": "lemonade",
+      "models": [
+        { "id": "Devstral-Small-2507-GGUF:latest" }
+      ]
+    }
+  }
+}
+```
+
+The `api` / `baseUrl` / `models` fields are documented in Pi's
+[models](https://pi.dev/docs/latest/models) and
+[llama.cpp](https://pi.dev/docs/latest/llama-cpp) guides. The `apiKey` value is
+arbitrary for local servers that don't check it. Start Pi as usual
+(`vp run pi`) and pick the model with the `/model` command — providers from
+`models.json` appear alongside the built-in ones. The first provider entry
+determines the default model.
+
+!!! note "Linux: expose the server to Docker"
+    On Linux, `host.docker.internal` resolves to the Docker bridge gateway
+    (typically `172.17.0.1`), so a server bound to `127.0.0.1` — the default
+    for Ollama, LM Studio, and Lemonade — refuses connections from the
+    container. Bind it to `0.0.0.0` or to the bridge gateway IP, e.g.:
+
+    ```bash
+    OLLAMA_HOST=0.0.0.0 ollama serve
+    LEMONADE_HOST=0.0.0.0 lemonade-server serve
+    ```
+
+    In LM Studio, enable **Serve on Local Network** in the server settings.
+    For systemd-managed services, set the variable via
+    `sudo systemctl edit <service>` and restart. See
+    [Using OSS models](../llm.md#quick-start-with-ollama) for the full
+    Ollama systemd walkthrough and the security implications of binding to
+    `0.0.0.0`.
+
+    On macOS and Windows (Docker Desktop), `host.docker.internal` reaches the
+    host's loopback interface directly, so the default `127.0.0.1` binding
+    works without changes.
+
 ### Agy / Antigravity (Google)
 
 ```bash

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -702,7 +702,10 @@ macOS, and Windows automatically):
 The `api` / `baseUrl` / `models` fields are documented in Pi's
 [models](https://pi.dev/docs/latest/models) and
 [llama.cpp](https://pi.dev/docs/latest/llama-cpp) guides. The `apiKey` value is
-arbitrary for local servers that don't check it. Start Pi as usual
+arbitrary for local servers that don't check it. Each model `id` must match an
+identifier your server actually exposes (`GET /v1/models` lists them) — the
+ids above are examples, replace them with the models you have installed.
+Start Pi as usual
 (`vp run pi`) and pick the model with the `/model` command — providers from
 `models.json` appear alongside the built-in ones, and the file is re-read
 every time you open `/model`, so you can edit it mid-session.
@@ -719,14 +722,19 @@ provider.
     On Linux, `host.docker.internal` resolves to the Docker bridge gateway
     (typically `172.17.0.1`), so a server bound to `127.0.0.1` — the default
     for Ollama, LM Studio, and Lemonade — refuses connections from the
-    container. Bind it to `0.0.0.0` or to the bridge gateway IP, e.g.:
+    container. Bind it to the bridge gateway IP (preferred when only VibePod
+    needs access) or to `0.0.0.0`, e.g.:
 
     ```bash
     OLLAMA_HOST=0.0.0.0 ollama serve
     LEMONADE_HOST=0.0.0.0 lemonade-server serve
     ```
 
-    In LM Studio, enable **Serve on Local Network** in the server settings.
+    In LM Studio, enable **Serve on Local Network** in the server settings,
+    and turn on **Require Authentication** there (then use the generated API
+    token as the provider's `apiKey` in `models.json`). Ollama and Lemonade
+    have no built-in authentication, so when binding those to `0.0.0.0`
+    restrict access with firewall rules instead.
     For systemd-managed services, set the variable via
     `sudo systemctl edit <service>` and restart. See
     [Using OSS models](../llm.md#quick-start-with-ollama) for the full

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -11,6 +11,13 @@ VibePod can connect agents to external LLM servers that expose OpenAI- or Anthro
 
 Other agents do not yet have LLM mapping and will not receive any LLM configuration.
 
+Some agents configure local models through their own native mechanism instead:
+
+- **pi** — custom providers via `models.json`, see [Pi: Local models](agents/index.md#local-models-ollama-lm-studio-lemonade-llamacpp)
+- **tau** — custom providers via `catalog.toml`, see [Tau](agents/index.md#tau-hugging-face)
+- **jcode** — supports Ollama, LM Studio, and custom OpenAI-compatible endpoints via `config.toml`, see [Jcode](agents/index.md#jcode-1jehuang)
+- **qwen** — any OpenAI-compatible endpoint via `OPENAI_BASE_URL` / `OPENAI_MODEL`, see [Qwen Code](agents/index.md#qwen-code-qwen)
+
 ## Quick start with Ollama
 
 ### 1. Start Ollama and pull a model

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -607,6 +607,7 @@ class DockerManager:
                     auto_remove=auto_remove,
                     network_mode=network,
                     port_bindings=ports,
+                    extra_hosts={"host.docker.internal": "host-gateway"},
                 )
                 # docker-py validates userns_mode against Docker's enum and rejects
                 # Podman's `keep-id`, so set the Docker-compatible HostConfig field
@@ -654,6 +655,11 @@ class DockerManager:
                 "volumes": volumes,
                 "working_dir": "/workspace",
                 "network": network,
+                # Docker Desktop resolves host.docker.internal natively, but Docker
+                # Engine on Linux and Podman only do so with an explicit
+                # host-gateway mapping. Local LLM servers (Ollama, LM Studio, ...)
+                # are documented against this hostname, so map it unconditionally.
+                "extra_hosts": {"host.docker.internal": "host-gateway"},
             }
             if ports:
                 # Maps "<container_port>/tcp" -> host_port. Used to publish the

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -421,6 +421,7 @@ def test_run_agent_supports_duplicate_host_mounts(tmp_path: Path) -> None:
     assert f"{config_dir}:/config:rw" in volumes
     assert f"{augment_dir}:/root/.augment:rw" in volumes
     assert f"{augment_dir}:/home/node/.augment:rw" in volumes
+    assert run_kwargs["extra_hosts"] == {"host.docker.internal": "host-gateway"}
 
 
 def test_run_agent_forwards_platform_and_user(tmp_path: Path) -> None:
@@ -647,6 +648,7 @@ def test_run_agent_uses_low_level_api_for_podman_keep_id(tmp_path: Path) -> None
         "auto_remove": True,
         "network_mode": "vibepod-network",
         "port_bindings": {"1456/tcp": 1455, "6000/udp": ["6000"], "9000": [None]},
+        "extra_hosts": {"host.docker.internal": "host-gateway"},
     }
     assert client.api.host_config is not None
     assert client.api.host_config["UsernsMode"] == "keep-id"


### PR DESCRIPTION
Covers Ollama, LM Studio, Lemonade, and llama.cpp setup for the pi agent through the persisted config mount, plus the Linux bridge-gateway binding caveat. Cross-links native local-model mechanisms from the LLM guide. Closes #139.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring local OpenAI-compatible models with Ollama, LM Studio, and Lemonade.
  * Documented platform-specific host connectivity and Linux bind-address requirements.
  * Added native local-model configuration details for Pi, Tau, JCode, and Qwen, including supported providers and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->