### PR TITLE
chore: bump version to 0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vibepod"
-version = "0.19.0"
+version = "0.20.0"
 description = "One CLI for containerized AI coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/vibepod/__init__.py
+++ b/src/vibepod/__init__.py
@@ -1,3 +1,3 @@
 """VibePod package."""
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from platformdirs import user_config_dir
 
 APP_NAME = "vibepod"
-VERSION = "0.19.0"
+VERSION = "0.20.0"
 
 CONFIG_DIR = Path(user_config_dir(APP_NAME))
 GLOBAL_CONFIG_FILE = CONFIG_DIR / "config.yaml"


### PR DESCRIPTION
This pull request updates the version of the `vibepod` package from `0.19.0` to `0.20.0` across the codebase to ensure consistency.

Version bump:

* Updated the version string to `0.20.0` in `pyproject.toml` to reflect the new release.
* Updated `__version__` in `src/vibepod/__init__.py` to `0.20.0`.
* Updated the `VERSION` constant in `src/vibepod/constants.py` to `0.20.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.20.0 across the project.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->