### PR TITLE
Fixes runtime display in vp version command

### DIFF
--- a/src/vibepod/commands/update.py
+++ b/src/vibepod/commands/update.py
@@ -8,7 +8,12 @@ from typing import Annotated, Any
 import typer
 
 from vibepod import __version__
-from vibepod.core.docker import DockerClientError, DockerManager, _version_is_podman
+from vibepod.core.docker import (
+    DockerClientError,
+    DockerException,
+    DockerManager,
+    _version_is_podman,
+)
 
 
 def _runtime_info() -> tuple[str | None, str]:
@@ -16,7 +21,8 @@ def _runtime_info() -> tuple[str | None, str]:
     try:
         manager = DockerManager()
         version_info: dict[str, Any] = manager.client.version()
-    except DockerClientError:
+    except (DockerClientError, DockerException):
+        # DockerException covers the engine disconnecting between ping() and version().
         return None, "unavailable"
     name = "Podman" if _version_is_podman(version_info) else "Docker"
     return name, str(version_info.get("Version", "unknown"))

--- a/src/vibepod/commands/update.py
+++ b/src/vibepod/commands/update.py
@@ -8,26 +8,31 @@ from typing import Annotated, Any
 import typer
 
 from vibepod import __version__
-from vibepod.core.docker import DockerClientError, DockerManager
+from vibepod.core.docker import DockerClientError, DockerManager, _version_is_podman
 
 
-def _docker_version() -> str:
+def _runtime_info() -> tuple[str | None, str]:
+    """Return (engine name, engine version) of the connected container runtime."""
     try:
         manager = DockerManager()
         version_info: dict[str, Any] = manager.client.version()
-        return str(version_info.get("Version", "unknown"))
     except DockerClientError:
-        return "unavailable"
+        return None, "unavailable"
+    name = "Podman" if _version_is_podman(version_info) else "Docker"
+    return name, str(version_info.get("Version", "unknown"))
 
 
 def version(
     as_json: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
 ) -> None:
     """Show version and runtime information."""
+    runtime_name, runtime_version = _runtime_info()
     info = {
         "vibepod": __version__,
         "python": platform.python_version(),
-        "docker": _docker_version(),
+        "runtime": runtime_name,
+        # Kept for backward compatibility: the engine version regardless of runtime.
+        "docker": runtime_version,
     }
 
     if as_json:
@@ -36,6 +41,7 @@ def version(
         print(json.dumps(info, indent=2))
         return
 
+    runtime_display = f"{runtime_name} {runtime_version}" if runtime_name else runtime_version
     print(f"VibePod CLI: {info['vibepod']}")
     print(f"Python:      {info['python']}")
-    print(f"Docker:      {info['docker']}")
+    print(f"Runtime:     {runtime_display}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,71 @@ def test_version() -> None:
     assert "VibePod CLI" in result.stdout
 
 
+def _fake_manager(version_info: dict) -> object:
+    client = SimpleNamespace(version=lambda: version_info)
+    return SimpleNamespace(client=client)
+
+
+def test_version_reports_podman_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vibepod.commands import update as update_cmd
+
+    version_info = {
+        "Version": "4.9.3",
+        "Components": [{"Name": "Podman Engine", "Version": "4.9.3"}],
+    }
+    monkeypatch.setattr(update_cmd, "DockerManager", lambda: _fake_manager(version_info))
+
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "Runtime:     Podman 4.9.3" in result.stdout
+
+
+def test_version_reports_docker_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vibepod.commands import update as update_cmd
+
+    version_info = {
+        "Version": "27.5.1",
+        "Platform": {"Name": "Docker Engine - Community"},
+    }
+    monkeypatch.setattr(update_cmd, "DockerManager", lambda: _fake_manager(version_info))
+
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "Runtime:     Docker 27.5.1" in result.stdout
+
+
+def test_version_json_includes_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    from vibepod.commands import update as update_cmd
+
+    version_info = {
+        "Version": "4.9.3",
+        "Components": [{"Name": "Podman Engine", "Version": "4.9.3"}],
+    }
+    monkeypatch.setattr(update_cmd, "DockerManager", lambda: _fake_manager(version_info))
+
+    result = runner.invoke(app, ["version", "--json"])
+    assert result.exit_code == 0
+    info = json.loads(result.stdout)
+    assert info["runtime"] == "Podman"
+    assert info["docker"] == "4.9.3"
+
+
+def test_version_runtime_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vibepod.commands import update as update_cmd
+    from vibepod.core.docker import DockerClientError
+
+    def _raise() -> object:
+        raise DockerClientError("no engine")
+
+    monkeypatch.setattr(update_cmd, "DockerManager", _raise)
+
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "Runtime:     unavailable" in result.stdout
+
+
 def test_python314_http_response_flush_filter_matches_closed_fp_error() -> None:
     response = SimpleNamespace(fp=SimpleNamespace(closed=True))
     exc = ValueError("I/O operation on closed file.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,21 @@ def test_version_runtime_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Runtime:     unavailable" in result.stdout
 
 
+def test_version_runtime_disconnects_after_init(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vibepod.commands import update as update_cmd
+    from vibepod.core.docker import DockerException
+
+    def _raise_version() -> dict:
+        raise DockerException("connection aborted")
+
+    client = SimpleNamespace(version=_raise_version)
+    monkeypatch.setattr(update_cmd, "DockerManager", lambda: SimpleNamespace(client=client))
+
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "Runtime:     unavailable" in result.stdout
+
+
 def test_python314_http_response_flush_filter_matches_closed_fp_error() -> None:
     response = SimpleNamespace(fp=SimpleNamespace(closed=True))
     exc = ValueError("I/O operation on closed file.")


### PR DESCRIPTION
This pull request updates the `version` command to improve how container runtime information is reported, supporting both Docker and Podman engines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime detection for both Docker and Podman.
  * Version information now identifies the connected runtime and its version.
  * JSON output includes a `runtime` field while preserving the existing `docker` field for compatibility.
  * Human-readable version output now displays the runtime name.

* **Bug Fixes**
  * Improved handling and reporting when no container runtime is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->