### PR TITLE
Fixes qualified name for container overlay image builds

### DIFF
--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -12,7 +12,9 @@ toolchains, CLIs — by committing a `FROM`-less Dockerfile fragment:
 
 On `vp run` (and `vp task create`), VibePod appends the fragment to the agent's
 base image and builds a workspace-local image tagged
-`vibepod/overlay-<agent>:<hash>`. The hash covers the base image, the fragment,
+`localhost/vibepod/overlay-<agent>:<hash>` (the explicit `localhost/` registry
+keeps Podman from resolving the name against `docker.io`). The hash covers the
+base image, the fragment,
 and every file in the overlay directory, so:
 
 - unchanged overlays never rebuild — the cached image is reused instantly

--- a/src/vibepod/core/overlay.py
+++ b/src/vibepod/core/overlay.py
@@ -95,7 +95,16 @@ def overlay_hash(base_ref: str, context_tar: bytes) -> str:
 
 
 def overlay_image_tag(agent: str, digest: str) -> str:
-    return f"vibepod/overlay-{agent}:{digest}"
+    """Fully qualified local tag for the overlay image.
+
+    The explicit ``localhost/`` registry keeps the name literal under Podman,
+    which otherwise qualifies the unqualified name to ``docker.io/...`` at
+    build time but resolves it against ``localhost/`` on later lookups — so
+    the cached image is never found again (and the sweep in
+    ``remove_stale_overlays`` would even delete the build it should keep).
+    Docker treats the name as a plain literal either way.
+    """
+    return f"localhost/vibepod/overlay-{agent}:{digest}"
 
 
 def _normalize_member(member: tarfile.TarInfo) -> tarfile.TarInfo:

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -121,9 +121,12 @@ def test_overlay_hash_distinguishes_file_boundaries(tmp_path: Path) -> None:
     assert _hash("sha256:abc", dockerfile_a) != _hash("sha256:abc", dockerfile_b)
 
 
-def test_overlay_image_tag_embeds_agent_and_hash() -> None:
+def test_overlay_image_tag_is_fully_qualified() -> None:
+    # An unqualified name lets Podman normalize it differently at build
+    # (docker.io/...) and lookup (localhost/...); the explicit localhost
+    # registry makes the name literal for both Docker and Podman.
     assert overlay.overlay_image_tag("claude", "abc123def456") == (
-        "vibepod/overlay-claude:abc123def456"
+        "localhost/vibepod/overlay-claude:abc123def456"
     )
 
 
@@ -244,7 +247,7 @@ def test_apply_overlay_builds_and_returns_overlay_tag(tmp_path: Path) -> None:
     _make_overlay(tmp_path)
     manager = _FakeManager(image_ids={"base:latest": "sha256:base"})
     result = overlay.apply_overlay(manager, tmp_path, "claude", "base:latest")
-    assert result.startswith("vibepod/overlay-claude:")
+    assert result.startswith("localhost/vibepod/overlay-claude:")
     (built,) = manager.built
     assert built[0] == result
     assert built[1]["vibepod.managed"] == "true"


### PR DESCRIPTION
This pull request updates how overlay image tags are constructed and referenced to ensure consistent behavior between Docker and Podman. The main change is to explicitly prefix overlay image tags with `localhost/`, which prevents Podman from incorrectly resolving image names and ensures reliable image caching and lookup. Documentation and tests have also been updated to reflect this change.

**Overlay image tag qualification:**

* Updated the `overlay_image_tag` function in `src/vibepod/core/overlay.py` to return image tags prefixed with `localhost/`, ensuring Podman treats the name as a literal and preventing cache misses and accidental deletions.
* Updated the documentation in `docs/overlays.md` to describe the new `localhost/` prefix and explain its necessity for Podman compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Overlay image tags now use an explicit local registry prefix, preventing accidental resolution from Docker Hub.
  * Overlay image identification now reflects the base image, selected fragment, and all overlay files for more accurate change tracking.

* **Documentation**
  * Updated overlay documentation to describe the fully qualified local image tags and expanded image hash details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->