### PR TITLE
Name overlay images per project

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 - 🐳 **Isolated agents** — each agent runs in its own Docker or Podman container
 - 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau, Jcode, Freebuff, Qwen & more
 - 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
-- 🧱 **Project overlays** — commit a `FROM`-less Dockerfile fragment in `.vibepod/overlay/` and VibePod auto-builds a cached, content-addressed image layer on top of the agent's base image ([docs](https://vibepod.dev/docs/overlays/))
+- 🧱 **Project overlays** — commit a `FROM`-less Dockerfile fragment in `.vibepod/overlay/` and VibePod auto-builds a cached, content-addressed image layer on top of the agent's base image — one clearly named image per project and agent ([docs](https://vibepod.dev/docs/overlays/))
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics
 - 🐑 **Herdr aware** — `vp run` inside a [herdr](https://herdr.dev/) pane reports agent state automatically
 - ⚖️ **Agent comparison** — benchmark multiple agents against each other in the dashboard

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -283,6 +283,10 @@ vp list --running    # shows only running agents
 vp list --json       # machine-readable output
 ```
 
+When the current project has [overlays](../overlays.md), `vp list` adds a
+**Project Overlays** table naming the overlay image each agent resolves to and
+whether it is already built.
+
 Stop a specific agent, a single container, or all agents:
 
 ```bash

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -12,14 +12,27 @@ toolchains, CLIs — by committing a `FROM`-less Dockerfile fragment:
 
 On `vp run` (and `vp task create`), VibePod appends the fragment to the agent's
 base image and builds a workspace-local image tagged
-`localhost/vibepod/overlay-<agent>:<hash>` (the explicit `localhost/` registry
-keeps Podman from resolving the name against `docker.io`). The hash covers the
-base image, the fragment,
-and every file in the overlay directory, so:
+`localhost/vibepod/overlay-<agent>-<project>:<hash>` (the explicit `localhost/`
+registry keeps Podman from resolving the name against `docker.io`). `<project>`
+is the workspace directory name, lowercased and reduced to characters a
+repository name allows; the hash covers the base image, the fragment, every
+file in the overlay directory, and the workspace identity, so:
 
+- every project gets its own image — running ten projects through the same
+  agent gives ten readable rows in `docker images`, not ten identical names
 - unchanged overlays never rebuild — the cached image is reused instantly
 - switching branches with different overlays just switches images
 - pulling a newer base image rebuilds the overlay on top of it
+
+```console
+$ docker images | grep vibepod/overlay
+localhost/vibepod/overlay-claude-vibepod-cli   f1e2d3c4b5a6
+localhost/vibepod/overlay-claude-my-app        9a8b7c6d5e4f
+localhost/vibepod/overlay-qwen-my-app          4c5d6e7f8a9b
+```
+
+Two projects that happen to share a directory name share the repository name
+but never the tag: the workspace path is part of the hash.
 
 The overlay directory is the docker build context, so the fragment can `COPY`
 files committed next to it:
@@ -49,6 +62,11 @@ machine or may point outside the committed project.
 
 ## Controls
 
+- `vp list` — shows a **Project Overlays** table for the current project: the
+  overlay image each agent resolves to, and whether it is `built`, `not built`,
+  `disabled`, or still waiting on its base image (`base not pulled` — the hash
+  follows the base image id, so until that image is local only the repository
+  name is known)
 - `vp run <agent> --no-overlay` — skip the overlay for one run
 - `vp run <agent> --rebuild-overlay` — force a rebuild, bypassing docker's
   layer cache so every instruction re-runs

--- a/src/vibepod/commands/list_cmd.py
+++ b/src/vibepod/commands/list_cmd.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Annotated, Any
 
 import typer
 from rich.table import Table
 
 from vibepod.constants import DEFAULT_IMAGES, EXIT_DOCKER_NOT_RUNNING, SUPPORTED_AGENTS
-from vibepod.core.agents import get_agent_shortcut
+from vibepod.core import overlay
+from vibepod.core.agents import effective_agent_image, get_agent_shortcut
+from vibepod.core.config import get_config
 from vibepod.core.docker import DockerClientError, DockerManager
+from vibepod.core.launch import overlay_enabled
 from vibepod.utils.console import console, error
 
 
@@ -44,6 +48,63 @@ def _running_rows(containers: list[Any]) -> list[dict[str, str]]:
     return sorted(rows, key=lambda row: (row["agent"], row["container"]))
 
 
+def _overlay_rows(manager: DockerManager | None) -> list[dict[str, str]]:
+    """Overlay images the current project resolves to, one row per agent.
+
+    Reports what a launch from here would use — including whether the image
+    is already built — so the opaque content hashes in ``docker images`` can
+    be traced back to a project without guessing.
+
+    Every agent with an overlay gets a row even when the answer is not a tag:
+    omitting the undecidable ones would read as "this project has no overlay
+    for that agent".
+    """
+    workspace = Path.cwd()
+    config = get_config()
+    rows: list[dict[str, str]] = []
+    for agent in SUPPORTED_AGENTS:
+        if overlay.find_overlay_dockerfile(workspace, agent) is None:
+            continue
+        agent_cfg = config.get("agents", {}).get(agent) or {}
+        if not overlay_enabled(workspace, agent, agent_cfg):
+            # Config alone decides this, so it is still reportable with no
+            # working docker.
+            rows.append({"agent": agent, "image": "-", "state": "disabled"})
+            continue
+        if manager is None:
+            rows.append({"agent": agent, "image": "-", "state": "docker unavailable"})
+            continue
+        try:
+            resolved = overlay.resolve_overlay_image(
+                manager,
+                workspace,
+                agent,
+                effective_agent_image(agent, config),
+            )
+        except (DockerClientError, OSError):
+            # Listing is read-only: an unreadable overlay context or a
+            # hiccupping daemon must not take the whole command down.
+            continue
+        if resolved is None:
+            continue
+        if not resolved.base_local:
+            # The digest follows the base image id, which `vp run` pulls
+            # before building. Naming a tag derived from the bare image
+            # string would print one no launch ever produces.
+            rows.append(
+                {"agent": agent, "image": resolved.repository, "state": "base not pulled"},
+            )
+            continue
+        rows.append(
+            {
+                "agent": agent,
+                "image": resolved.tag,
+                "state": "built" if resolved.built else "not built",
+            },
+        )
+    return rows
+
+
 def list_agents(
     running: Annotated[
         bool,
@@ -52,6 +113,7 @@ def list_agents(
     as_json: Annotated[bool, typer.Option("--json", help="Output JSON")] = False,
 ) -> None:
     """List available agents and running containers."""
+    manager: DockerManager | None = None
     try:
         manager = DockerManager()
         containers = manager.list_managed(all_containers=True)
@@ -59,10 +121,12 @@ def list_agents(
         if running:
             error(str(exc))
             raise typer.Exit(EXIT_DOCKER_NOT_RUNNING) from exc
+        manager = None
         containers = []
 
     running_rows = _running_rows(containers)
     configured_rows = _configured_agent_rows()
+    overlay_rows = [] if running else _overlay_rows(manager)
 
     if as_json:
         import json
@@ -70,6 +134,7 @@ def list_agents(
         payload: dict[str, Any] = {"running": running_rows}
         if not running:
             payload["agents"] = configured_rows
+            payload["overlays"] = overlay_rows
         print(json.dumps(payload, indent=2))
         return
 
@@ -96,3 +161,17 @@ def list_agents(
     for row in configured_rows:
         reference_table.add_row(row["short"], row["agent"], row["image"])
     console.print(reference_table)
+
+    if not overlay_rows:
+        return
+
+    console.print()
+    overlay_table = Table(title="Project Overlays", title_justify="left")
+    overlay_table.add_column("AGENT", style="cyan")
+    # fold, not the default ellipsis: a truncated tag cannot be copied into a
+    # docker command.
+    overlay_table.add_column("OVERLAY IMAGE", style="magenta", overflow="fold")
+    overlay_table.add_column("STATE")
+    for row in overlay_rows:
+        overlay_table.add_row(row["agent"], row["image"], row["state"])
+    console.print(overlay_table)

--- a/src/vibepod/core/launch.py
+++ b/src/vibepod/core/launch.py
@@ -79,6 +79,11 @@ def _overlay_setting(workspace_path: Path, agent: str, agent_cfg: dict[str, Any]
     return agent_cfg.get("overlay")
 
 
+def overlay_enabled(workspace_path: Path, agent: str, agent_cfg: dict[str, Any]) -> bool:
+    """True when config lets *agent* use *workspace_path*'s overlay."""
+    return _overlay_setting(workspace_path, agent, agent_cfg) is not False
+
+
 def apply_overlay_if_enabled(
     *,
     manager: DockerManager,
@@ -90,7 +95,7 @@ def apply_overlay_if_enabled(
     rebuild_overlay: bool,
 ) -> str:
     """Swap in the project overlay image unless disabled by flag or config."""
-    if no_overlay or _overlay_setting(workspace_path, agent, agent_cfg) is False:
+    if no_overlay or not overlay_enabled(workspace_path, agent, agent_cfg):
         return image
     try:
         return overlay.apply_overlay(manager, workspace_path, agent, image, rebuild=rebuild_overlay)

--- a/src/vibepod/core/overlay.py
+++ b/src/vibepod/core/overlay.py
@@ -7,13 +7,20 @@ workspace-local image tagged content-addressed over the base image and the
 build inputs, so unchanged overlays never rebuild and switching branches with
 different overlays just switches images. The directory holding the Dockerfile
 is the build context, so fragments can ``COPY`` files committed next to them.
+
+Every project gets its own image repository — ``overlay-<agent>-<project>``
+(issue #145) — so a machine running several projects through the same agent
+shows one readable row per project in ``docker images`` instead of a stack of
+identically named ones.
 """
 
 from __future__ import annotations
 
 import hashlib
 import io
+import re
 import tarfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +32,11 @@ OVERLAY_HASH_LENGTH = 12
 #: Image label carrying the workspace+agent identity; duplicated as a literal
 #: in DockerManager.remove_stale_overlays to avoid an import cycle.
 OVERLAY_KEY_LABEL = "vibepod.overlay.key"
+#: Longest project slug embedded in an image name; keeps `docker images` rows
+#: readable when a project directory has a very long name.
+SLUG_MAX_LENGTH = 24
+#: Slug used when a workspace has no usable directory name (e.g. ``/``).
+SLUG_FALLBACK = "workspace"
 
 
 def find_overlay_dockerfile(workspace: Path, agent: str) -> Path | None:
@@ -78,8 +90,31 @@ def _context_files(dockerfile: Path) -> list[Path]:
     return sorted(files, key=lambda p: p.relative_to(context).as_posix())
 
 
-def overlay_hash(base_ref: str, context_tar: bytes) -> str:
-    """Content-address the build inputs: base image ref + build context tar.
+def _slugify(name: str) -> str:
+    """Reduce *name* to a single repository path component.
+
+    Such a component must match ``[a-z0-9]+([._-][a-z0-9]+)*``, so runs of
+    anything else collapse to a single dash and the edges are trimmed (after
+    truncation, which can itself expose a trailing dash). A name that carries
+    no usable character at all falls back to :data:`SLUG_FALLBACK`.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower())
+    slug = slug[:SLUG_MAX_LENGTH].strip("-")
+    return slug or SLUG_FALLBACK
+
+
+def project_slug(workspace: Path) -> str:
+    """Docker-safe, human-recognizable name for *workspace*.
+
+    The workspace directory name is the part a user recognizes, so that — not
+    the full path, which would leak the host layout into image names — is what
+    goes into the image repository.
+    """
+    return _slugify(workspace.resolve().name)
+
+
+def overlay_hash(base_ref: str, context_tar: bytes, overlay_key: str) -> str:
+    """Content-address the build inputs: base image ref + context tar + key.
 
     *base_ref* should be the base image's local id when it exists (so a moved
     ``latest`` tag re-hashes) and the tag string otherwise. *context_tar* is
@@ -87,15 +122,24 @@ def overlay_hash(base_ref: str, context_tar: bytes) -> str:
     every member's path, mode, and content length, so distinct contexts can
     never collide, and hashing the same snapshot that gets built keeps the
     tag and the image content in lockstep even when files change mid-launch.
+    *overlay_key* makes the digest per-workspace: two projects with byte-identical
+    overlays would otherwise land on one image, of which only the first
+    builder's ``OVERLAY_KEY_LABEL`` is recorded — so the other project's
+    sweep would delete an image still in use elsewhere.
     """
     digest = hashlib.sha256()
     digest.update(base_ref.encode() + b"\n")
+    digest.update(overlay_key.encode() + b"\n")
     digest.update(context_tar)
     return digest.hexdigest()[:OVERLAY_HASH_LENGTH]
 
 
-def overlay_image_tag(agent: str, digest: str) -> str:
-    """Fully qualified local tag for the overlay image.
+def overlay_repository(agent: str, slug: str) -> str:
+    """Fully qualified repository (the tag without its digest).
+
+    *slug* names the project (see :func:`project_slug`) so that every project
+    owns a distinct repository and ``docker images`` stays readable when
+    several projects run the same agent.
 
     The explicit ``localhost/`` registry keeps the name literal under Podman,
     which otherwise qualifies the unqualified name to ``docker.io/...`` at
@@ -104,7 +148,12 @@ def overlay_image_tag(agent: str, digest: str) -> str:
     ``remove_stale_overlays`` would even delete the build it should keep).
     Docker treats the name as a plain literal either way.
     """
-    return f"localhost/vibepod/overlay-{agent}:{digest}"
+    return f"localhost/vibepod/overlay-{agent}-{slug}"
+
+
+def overlay_image_tag(agent: str, slug: str, digest: str) -> str:
+    """Fully qualified local tag for the overlay image."""
+    return f"{overlay_repository(agent, slug)}:{digest}"
 
 
 def _normalize_member(member: tarfile.TarInfo) -> tarfile.TarInfo:
@@ -153,6 +202,60 @@ def _overlay_key(workspace: Path, agent: str) -> str:
     return hashlib.sha256(raw).hexdigest()[:OVERLAY_HASH_LENGTH]
 
 
+@dataclass(frozen=True)
+class ResolvedOverlay:
+    """The overlay image a workspace+agent resolves to, built or not yet."""
+
+    tag: str
+    #: The tag without its digest — the part that does not move with the base
+    #: image, and the only part a caller can trust when *base_local* is False.
+    repository: str
+    dockerfile: Path
+    key: str
+    #: Build context snapshot the tag was hashed over, ready to hand to docker.
+    context_tar: io.BytesIO
+    #: True when the tag already exists locally, i.e. a launch would reuse it.
+    built: bool
+    #: True when the base image was present locally, so its id — not the bare
+    #: tag string — went into the digest. False means *tag* is provisional:
+    #: ``vp run`` pulls the base first and would hash a different ref.
+    base_local: bool
+
+
+def resolve_overlay_image(
+    manager: Any,
+    workspace: Path,
+    agent: str,
+    base_image: str,
+) -> ResolvedOverlay | None:
+    """Resolve the overlay image for *workspace*+*agent* without building it.
+
+    Returns None when the project has no overlay for *agent*. Reading the
+    context is the only cost, so callers that merely report the image (``vp
+    list``) get the answer a launch would compute — as long as the base image
+    is already local, which ``base_local`` tells them.
+    """
+    dockerfile = find_overlay_dockerfile(workspace, agent)
+    if dockerfile is None:
+        return None
+
+    base_id = manager.image_id(base_image)
+    key = _overlay_key(workspace, agent)
+    context_tar = build_context_tar(base_image, dockerfile)
+    repository = overlay_repository(agent, project_slug(workspace))
+    digest = overlay_hash(base_id or base_image, context_tar.getvalue(), key)
+    tag = f"{repository}:{digest}"
+    return ResolvedOverlay(
+        tag=tag,
+        repository=repository,
+        dockerfile=dockerfile,
+        key=key,
+        context_tar=context_tar,
+        built=manager.image_id(tag) is not None,
+        base_local=base_id is not None,
+    )
+
+
 def apply_overlay(
     manager: Any,
     workspace: Path,
@@ -167,26 +270,26 @@ def apply_overlay(
     *base_image* and sweeps this workspace+agent's superseded overlay images
     after a successful build.
     """
-    dockerfile = find_overlay_dockerfile(workspace, agent)
-    if dockerfile is None:
+    resolved = resolve_overlay_image(manager, workspace, agent, base_image)
+    if resolved is None:
         return base_image
 
-    base_ref = manager.image_id(base_image) or base_image
-    context_tar = build_context_tar(base_image, dockerfile)
-    tag = overlay_image_tag(agent, overlay_hash(base_ref, context_tar.getvalue()))
-
-    if rebuild or manager.image_id(tag) is None:
-        info(f"Building overlay image {tag} from {base_image} ({dockerfile})")
-        overlay_key = _overlay_key(workspace, agent)
+    if rebuild or not resolved.built:
+        info(
+            f"Building overlay image {resolved.tag} from {base_image} ({resolved.dockerfile})",
+        )
+        # The workspace is identified by the opaque OVERLAY_KEY_LABEL only:
+        # image metadata travels, and an absolute path would carry the host's
+        # username and directory layout with it.
         labels = {
             "vibepod.managed": "true",
-            OVERLAY_KEY_LABEL: overlay_key,
+            OVERLAY_KEY_LABEL: resolved.key,
             "vibepod.overlay.agent": agent,
         }
         # A forced rebuild must also bypass docker's layer cache, or RUN
         # commands like package updates would replay from cached layers.
-        manager.build_image(context_tar, tag=tag, labels=labels, nocache=rebuild)
-        manager.remove_stale_overlays(overlay_key, keep_tag=tag)
+        manager.build_image(resolved.context_tar, tag=resolved.tag, labels=labels, nocache=rebuild)
+        manager.remove_stale_overlays(resolved.key, keep_tag=resolved.tag)
     else:
-        info(f"Using cached overlay image {tag}")
-    return tag
+        info(f"Using cached overlay image {resolved.tag}")
+    return resolved.tag

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -3,14 +3,45 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from typer.testing import CliRunner
 
 from vibepod.cli import app
 from vibepod.commands import list_cmd
-from vibepod.constants import AGENT_SHORTCUTS, SUPPORTED_AGENTS
+from vibepod.constants import AGENT_SHORTCUTS, DEFAULT_IMAGES, SUPPORTED_AGENTS
+from vibepod.core.docker import DockerClientError
 
 runner = CliRunner()
+
+
+class _FakeDocker:
+    """Docker with no containers and *local_images* present locally."""
+
+    def __init__(self, local_images=()) -> None:
+        self.local = set(local_images)
+
+    def list_managed(self, all_containers: bool = True):  # noqa: ARG002
+        return []
+
+    def image_id(self, image: str) -> str | None:
+        return f"sha256:{image}" if image in self.local else None
+
+
+def _fake_docker(monkeypatch, local_images=()) -> None:
+    monkeypatch.setattr(list_cmd, "DockerManager", lambda: _FakeDocker(local_images))
+
+
+def _base_images_present() -> list[str]:
+    """Every agent's base image, as on a machine that has already pulled them."""
+    return list(DEFAULT_IMAGES.values())
+
+
+def _write_overlay(workspace: Path, *parts: str) -> Path:
+    dockerfile = workspace.joinpath(".vibepod", "overlay", *parts, "Dockerfile")
+    dockerfile.parent.mkdir(parents=True, exist_ok=True)
+    dockerfile.write_text("RUN true\n", encoding="utf-8")
+    return dockerfile
 
 
 def test_list_json_includes_short_and_full_agent_names(monkeypatch) -> None:
@@ -74,3 +105,118 @@ def test_list_running_json_preserves_multiple_instances(monkeypatch) -> None:
     assert [row["container"] for row in rows] == ["vibepod-claude-1", "vibepod-claude-2"]
     assert {row["context"] for row in rows} == {"/workspace/a", "/workspace/b"}
     assert all(set(row) == {"agent", "container", "context"} for row in rows)
+
+
+def test_list_json_reports_project_overlay_image(monkeypatch, tmp_path: Path) -> None:
+    """The opaque overlay hash in `docker images` is traceable back to a project."""
+    _fake_docker(monkeypatch, _base_images_present())
+    workspace = tmp_path / "my-project"
+    _write_overlay(workspace, "claude")
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+
+    (row,) = json.loads(result.stdout)["overlays"]
+    assert row["agent"] == "claude"
+    assert row["image"].startswith("localhost/vibepod/overlay-claude-my-project:")
+    assert row["state"] == "not built"
+
+
+def test_list_json_reports_built_overlay_image(monkeypatch, tmp_path: Path) -> None:
+    workspace = tmp_path / "my-project"
+    _write_overlay(workspace, "claude")
+    monkeypatch.chdir(workspace)
+    _fake_docker(monkeypatch, _base_images_present())
+
+    # Learn the tag the project resolves to, then present it as already built.
+    (pending,) = json.loads(runner.invoke(app, ["list", "--json"]).stdout)["overlays"]
+    _fake_docker(monkeypatch, [*_base_images_present(), pending["image"]])
+
+    (row,) = json.loads(runner.invoke(app, ["list", "--json"]).stdout)["overlays"]
+    assert (row["image"], row["state"]) == (pending["image"], "built")
+
+
+def test_list_json_names_only_the_repository_when_base_image_is_missing(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """`vp run` pulls the base first, so its id — and the digest — is unknowable here."""
+    _fake_docker(monkeypatch)
+    workspace = tmp_path / "my-project"
+    _write_overlay(workspace, "claude")
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+
+    (row,) = json.loads(result.stdout)["overlays"]
+    assert (row["image"], row["state"]) == (
+        "localhost/vibepod/overlay-claude-my-project",
+        "base not pulled",
+    )
+
+
+def test_list_json_reports_shared_overlay_for_every_agent(monkeypatch, tmp_path: Path) -> None:
+    _fake_docker(monkeypatch, _base_images_present())
+    workspace = tmp_path / "my-project"
+    _write_overlay(workspace)
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+
+    rows = json.loads(result.stdout)["overlays"]
+    assert {row["agent"] for row in rows} == set(SUPPORTED_AGENTS)
+    # One image per agent: the fragment sits on a different base image each time.
+    assert len({row["image"] for row in rows}) == len(rows)
+
+
+def test_list_json_marks_disabled_overlay(monkeypatch, tmp_path: Path) -> None:
+    _fake_docker(monkeypatch, _base_images_present())
+    workspace = tmp_path / "my-project"
+    _write_overlay(workspace, "claude")
+    (workspace / ".vibepod" / "config.yaml").write_text(
+        "agents:\n  claude:\n    overlay: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+
+    (row,) = json.loads(result.stdout)["overlays"]
+    assert (row["agent"], row["image"], row["state"]) == ("claude", "-", "disabled")
+
+
+def test_list_json_reports_overlays_without_docker(monkeypatch, tmp_path: Path) -> None:
+    """Config answers `disabled` on its own; the rest is undecidable, not absent."""
+
+    def _no_docker():
+        raise DockerClientError("docker is not running")
+
+    monkeypatch.setattr(list_cmd, "DockerManager", _no_docker)
+    workspace = tmp_path / "my-project"
+    _write_overlay(workspace, "claude")
+    _write_overlay(workspace, "qwen")
+    (workspace / ".vibepod" / "config.yaml").write_text(
+        "agents:\n  claude:\n    overlay: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+
+    rows = {row["agent"]: row for row in json.loads(result.stdout)["overlays"]}
+    assert rows["claude"]["state"] == "disabled"
+    assert rows["qwen"]["state"] == "docker unavailable"
+
+
+def test_list_json_omits_overlays_without_project_overlay(monkeypatch, tmp_path: Path) -> None:
+    _fake_docker(monkeypatch, _base_images_present())
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["overlays"] == []

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import os
+import re
 import tarfile
 from pathlib import Path
 
@@ -49,11 +50,26 @@ def test_find_overlay_dockerfile_ignores_directory_named_dockerfile(tmp_path: Pa
     assert overlay.find_overlay_dockerfile(tmp_path, "claude") is None
 
 
-def _hash(base_ref: str, dockerfile: Path, base_image: str = "base:latest") -> str:
+def _hash(
+    base_ref: str,
+    dockerfile: Path,
+    base_image: str = "base:latest",
+    key: str = "test-key",
+) -> str:
     """Hash a context the way apply_overlay does: over the snapshot tar."""
     return overlay.overlay_hash(
         base_ref,
         overlay.build_context_tar(base_image, dockerfile).getvalue(),
+        key,
+    )
+
+
+def _expected_tag(workspace: Path, dockerfile: Path, base_ref: str, agent: str = "claude") -> str:
+    """The tag apply_overlay must produce for this workspace and context."""
+    return overlay.overlay_image_tag(
+        agent,
+        overlay.project_slug(workspace),
+        _hash(base_ref, dockerfile, key=overlay._overlay_key(workspace, agent)),
     )
 
 
@@ -125,9 +141,48 @@ def test_overlay_image_tag_is_fully_qualified() -> None:
     # An unqualified name lets Podman normalize it differently at build
     # (docker.io/...) and lookup (localhost/...); the explicit localhost
     # registry makes the name literal for both Docker and Podman.
-    assert overlay.overlay_image_tag("claude", "abc123def456") == (
-        "localhost/vibepod/overlay-claude:abc123def456"
+    assert overlay.overlay_image_tag("claude", "my-app", "abc123def456") == (
+        "localhost/vibepod/overlay-claude-my-app:abc123def456"
     )
+    assert overlay.overlay_repository("claude", "my-app") == (
+        "localhost/vibepod/overlay-claude-my-app"
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("vibepod-cli", "vibepod-cli"),
+        ("My_App", "my-app"),
+        ("weird!!name??", "weird-name"),
+        (".hidden", "hidden"),
+        ("...", "workspace"),
+        ("a" * 40, "a" * 24),
+        # Truncation must not leave the trailing dash a repository name forbids.
+        ("abcdefghijklmnopqrstuvw-xyz", "abcdefghijklmnopqrstuvw"),
+    ],
+)
+def test_slugify_is_repository_safe(name: str, expected: str) -> None:
+    # Strings, not real directories: names like "weird!!name??" cannot be
+    # created on Windows and "..." collapses into its parent there.
+    slug = overlay._slugify(name)
+    assert slug == expected
+    assert re.fullmatch(r"[a-z0-9]+([._-][a-z0-9]+)*", slug)
+
+
+def test_project_slug_uses_the_workspace_directory_name(tmp_path: Path) -> None:
+    workspace = tmp_path / "My_App"
+    workspace.mkdir()
+    assert overlay.project_slug(workspace) == "my-app"
+
+
+def test_project_slug_falls_back_for_nameless_workspace() -> None:
+    assert overlay.project_slug(Path(Path(os.sep).anchor)) == "workspace"
+
+
+def test_overlay_hash_differs_per_workspace_key(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    assert _hash("sha256:abc", dockerfile, key="a") != _hash("sha256:abc", dockerfile, key="b")
 
 
 def _read_tar(buffer: io.BytesIO) -> dict[str, bytes]:
@@ -247,10 +302,13 @@ def test_apply_overlay_builds_and_returns_overlay_tag(tmp_path: Path) -> None:
     _make_overlay(tmp_path)
     manager = _FakeManager(image_ids={"base:latest": "sha256:base"})
     result = overlay.apply_overlay(manager, tmp_path, "claude", "base:latest")
-    assert result.startswith("localhost/vibepod/overlay-claude:")
+    assert result.startswith(f"localhost/vibepod/overlay-claude-{overlay.project_slug(tmp_path)}:")
     (built,) = manager.built
     assert built[0] == result
     assert built[1]["vibepod.managed"] == "true"
+    # Image metadata travels; the workspace is identified by an opaque key, not
+    # by a host path carrying the user's name and directory layout.
+    assert not any("/" in value for value in built[1].values())
     assert built[3] is False
     assert manager.swept == [(built[1]["vibepod.overlay.key"], result)]
 
@@ -260,15 +318,19 @@ def test_apply_overlay_builds_the_snapshot_it_hashed(tmp_path: Path) -> None:
     _make_overlay(tmp_path)
     manager = _FakeManager(image_ids={"base:latest": "sha256:base"})
     result = overlay.apply_overlay(manager, tmp_path, "claude", "base:latest")
-    ((tag, _, context_tar, _),) = manager.built
-    digest = overlay.overlay_hash("sha256:base", context_tar.getvalue())
-    assert tag == overlay.overlay_image_tag("claude", digest) == result
+    ((tag, labels, context_tar, _),) = manager.built
+    digest = overlay.overlay_hash(
+        "sha256:base",
+        context_tar.getvalue(),
+        labels["vibepod.overlay.key"],
+    )
+    assert tag == overlay.overlay_image_tag("claude", overlay.project_slug(tmp_path), digest)
+    assert tag == result
 
 
 def test_apply_overlay_skips_build_when_image_exists(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    digest = _hash("sha256:base", dockerfile)
-    tag = overlay.overlay_image_tag("claude", digest)
+    tag = _expected_tag(tmp_path, dockerfile, "sha256:base")
     manager = _FakeManager(existing_images=[tag], image_ids={"base:latest": "sha256:base"})
     assert overlay.apply_overlay(manager, tmp_path, "claude", "base:latest") == tag
     assert manager.built == []
@@ -276,8 +338,7 @@ def test_apply_overlay_skips_build_when_image_exists(tmp_path: Path) -> None:
 
 def test_apply_overlay_rebuild_forces_uncached_build(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
-    digest = _hash("sha256:base", dockerfile)
-    tag = overlay.overlay_image_tag("claude", digest)
+    tag = _expected_tag(tmp_path, dockerfile, "sha256:base")
     manager = _FakeManager(existing_images=[tag], image_ids={"base:latest": "sha256:base"})
     assert overlay.apply_overlay(manager, tmp_path, "claude", "base:latest", rebuild=True) == tag
     ((built_tag, _, _, nocache),) = manager.built
@@ -289,7 +350,75 @@ def test_apply_overlay_hashes_tag_when_base_not_local(tmp_path: Path) -> None:
     dockerfile = _make_overlay(tmp_path)
     manager = _FakeManager()
     result = overlay.apply_overlay(manager, tmp_path, "claude", "base:latest")
-    assert result == overlay.overlay_image_tag("claude", _hash("base:latest", dockerfile))
+    assert result == _expected_tag(tmp_path, dockerfile, "base:latest")
+
+
+def test_apply_overlay_tag_names_the_project(tmp_path: Path) -> None:
+    workspace = tmp_path / "My Project"
+    _make_overlay(workspace)
+    result = overlay.apply_overlay(_FakeManager(), workspace, "claude", "base:latest")
+    assert result.startswith("localhost/vibepod/overlay-claude-my-project:")
+
+
+def test_apply_overlay_tags_differ_between_projects_with_identical_overlays(
+    tmp_path: Path,
+) -> None:
+    """Same agent, same base, byte-identical overlay: still one image per project.
+
+    A shared tag would leave the second project running an image labeled with
+    the first project's overlay key, so the first project's next sweep would
+    delete an image the second one still uses.
+    """
+    ws_a = tmp_path / "alpha"
+    ws_b = tmp_path / "beta"
+    _make_overlay(ws_a)
+    _make_overlay(ws_b)
+    tag_a = overlay.apply_overlay(_FakeManager(), ws_a, "claude", "base:latest")
+    tag_b = overlay.apply_overlay(_FakeManager(), ws_b, "claude", "base:latest")
+    assert tag_a != tag_b
+
+
+def test_apply_overlay_tags_differ_for_same_named_projects(tmp_path: Path) -> None:
+    """Two checkouts with the same directory name share a repository, not a tag."""
+    ws_a = tmp_path / "one" / "app"
+    ws_b = tmp_path / "two" / "app"
+    _make_overlay(ws_a)
+    _make_overlay(ws_b)
+    tag_a = overlay.apply_overlay(_FakeManager(), ws_a, "claude", "base:latest")
+    tag_b = overlay.apply_overlay(_FakeManager(), ws_b, "claude", "base:latest")
+    assert tag_a.rsplit(":", 1)[0] == tag_b.rsplit(":", 1)[0]
+    assert tag_a != tag_b
+
+
+def test_resolve_overlay_image_returns_none_without_overlay(tmp_path: Path) -> None:
+    assert overlay.resolve_overlay_image(_FakeManager(), tmp_path, "claude", "base:latest") is None
+
+
+def test_resolve_overlay_image_reports_built_state_without_building(tmp_path: Path) -> None:
+    dockerfile = _make_overlay(tmp_path)
+    tag = _expected_tag(tmp_path, dockerfile, "sha256:base")
+    manager = _FakeManager(image_ids={"base:latest": "sha256:base"})
+
+    pending = overlay.resolve_overlay_image(manager, tmp_path, "claude", "base:latest")
+    assert pending is not None
+    assert (pending.tag, pending.built, pending.dockerfile) == (tag, False, dockerfile)
+    assert pending.repository == tag.rsplit(":", 1)[0]
+    assert pending.base_local is True
+    assert manager.built == []
+
+    manager.existing.add(tag)
+    resolved = overlay.resolve_overlay_image(manager, tmp_path, "claude", "base:latest")
+    assert resolved is not None
+    assert resolved.built is True
+
+
+def test_resolve_overlay_image_flags_a_missing_base_image(tmp_path: Path) -> None:
+    """Without the base image locally the digest is provisional: `vp run` pulls first."""
+    _make_overlay(tmp_path)
+    resolved = overlay.resolve_overlay_image(_FakeManager(), tmp_path, "claude", "base:latest")
+    assert resolved is not None
+    assert resolved.base_local is False
+    assert resolved.repository == resolved.tag.rsplit(":", 1)[0]
 
 
 def test_apply_overlay_key_differs_per_workspace_and_agent(tmp_path: Path) -> None:


### PR DESCRIPTION
Introduces significant improvements to how VibePod manages and reports project overlay images for agents. Now, each project gets a uniquely named overlay image per agent, making it much easier to trace and manage overlays across multiple projects. The `vp list` command has been enhanced to display a new "Project Overlays" table, showing which overlay image each agent resolves to and whether it is built, both in CLI and JSON output. These changes improve transparency, usability, and maintainability when working with multiple projects and agents.

**Overlay Image Management and Naming:**

* Overlay images are now named per project and agent (`overlay-<agent>-<project>:<hash>`), using a slug derived from the workspace directory name, ensuring that running the same agent in different projects produces distinct, human-readable image names in `docker images`. This avoids confusion from identically named images and makes cleanup and inspection much easier.
* The overlay hash now incorporates a per-workspace key, preventing accidental image collisions between projects with identical overlays.

* The `vp list` command now reports a "Project Overlays" table for the current project, showing the overlay image tag each agent resolves to and whether it is built, both in the CLI output and in the `--json` output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Project overlay images are now uniquely identified per project and agent.
  - `vp list` displays a Project Overlays table with resolved image names and build status.
  - JSON listing output now includes project overlay details.
  - Overlay status distinguishes disabled, built, and not-yet-built images.
  - Project-specific image naming prevents collisions between similarly named workspaces.

- **Documentation**
  - Updated overlay and agent management documentation with project-specific naming, examples, and listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->