### PR TITLE
Show vibepod resume command after agent exit

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -406,6 +406,30 @@ vp attach
 
 `vp attach` only works for containers that are already running and managed by VibePod. When you are done, close the terminal to leave it running, or stop it explicitly with `vp stop <container>`, `vp stop <agent>`, or `vp stop --all`.
 
+## Resume hints after a session ends
+
+Several agents print their own resume instruction when they exit — Claude, for
+example:
+
+```text
+Resume this session with:
+claude --resume 39bf1a93-ea1f-4b0a-a894-0a662e5a1d4e
+```
+
+When VibePod recognizes such a hint in the session output (supported for
+Claude, Codex, Pi, Copilot, Jcode, and Freebuff), it prints the equivalent
+VibePod command after the agent exits:
+
+```text
+Resume this session with:
+  vp run claude -- --resume 39bf1a93-ea1f-4b0a-a894-0a662e5a1d4e
+```
+
+The suggested command wraps the agent's own resume arguments in passthrough
+form (after `--`), so it works because each agent's session state lives in the
+persisted config mount. If no hint is recognized, exiting behaves as before and
+nothing extra is printed.
+
 ## Connecting to a Docker Compose network
 
 When your workspace contains a `docker-compose.yml` or `compose.yml`, VibePod detects it and offers to connect the agent container to an existing network so it can reach your running services.

--- a/src/vibepod/commands/attach.py
+++ b/src/vibepod/commands/attach.py
@@ -8,6 +8,7 @@ import typer
 
 from vibepod.constants import CONTAINER_LABEL_MANAGED, EXIT_DOCKER_NOT_RUNNING
 from vibepod.core.docker import DockerClientError, DockerManager
+from vibepod.core.resume import show_resume_hint
 from vibepod.utils.console import error, info, warning
 
 
@@ -83,7 +84,8 @@ def attach(
         f"Close the terminal to leave it running, or stop it with `vp stop {target.name}`.",
     )
     try:
-        manager.attach_interactive(target)
+        output_tail = manager.attach_interactive(target)
     except DockerClientError as exc:
         error(str(exc))
         raise typer.Exit(1) from exc
+    show_resume_hint(agent, output_tail)

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -89,6 +89,7 @@ from vibepod.core.launch import (
     x11_volumes_and_env as _x11_volumes_and_env,
 )
 from vibepod.core.profiles import resolve_profile
+from vibepod.core.resume import show_resume_hint
 from vibepod.core.session_logger import SessionLogger
 from vibepod.utils.console import error, info, success, warning
 
@@ -702,9 +703,10 @@ def run(
     )
 
     exit_reason = "normal"
+    output_tail = b""
     warning("Attached to container. Use Ctrl+C to stop.")
     try:
-        manager.attach_interactive(container, logger=logger)
+        output_tail = manager.attach_interactive(container, logger=logger)
     except KeyboardInterrupt:
         exit_reason = "keyboard_interrupt"
         info("Stopping container...")
@@ -721,6 +723,9 @@ def run(
 
     if selected_agent == "claude" and "setup-token" in passthrough_args and exit_reason == "normal":
         _capture_claude_setup_token(config_dir)
+
+    if exit_reason == "normal":
+        show_resume_hint(selected_agent, output_tail)
 
 
 def _read_masked_line(prompt: str) -> str:

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -69,6 +69,10 @@ _PODMAN_HINT = (
 #: Image namespace owned by vibepod; the only one auto_clean ever sweeps.
 IMAGE_NAMESPACE = "vibepod"
 
+# How much trailing container output attach_interactive keeps for post-exit
+# inspection (resume hints appear in the last few lines of a session).
+ATTACH_TAIL_LIMIT = 64 * 1024
+
 
 def _run_podman(podman: str, args: list[str]) -> str | None:
     """Run a Podman subcommand, returning its trimmed stdout on success."""
@@ -852,8 +856,13 @@ class DockerManager:
 
         return self.client.containers.run(**run_kwargs)
 
-    def attach_interactive(self, container: Any, logger: Any = None) -> None:
-        """Attach local stdin/stdout to a running container TTY."""
+    def attach_interactive(self, container: Any, logger: Any = None) -> bytes:
+        """Attach local stdin/stdout to a running container TTY.
+
+        Returns the tail (last ``ATTACH_TAIL_LIMIT`` bytes) of the container
+        output, so callers can inspect it after the session ends (e.g. for
+        agent resume hints).
+        """
 
         def resize_tty() -> None:
             size = shutil.get_terminal_size(fallback=(120, 40))
@@ -879,6 +888,7 @@ class DockerManager:
         sock = getattr(sock_wrapper, "_sock", sock_wrapper)
         resize_tty()
 
+        output_tail = bytearray()
         stdin_fd = None
         old_tty = None
         old_winch_handler = None
@@ -920,6 +930,9 @@ class DockerManager:
                         break
                     sys.stdout.buffer.write(data)
                     sys.stdout.buffer.flush()
+                    output_tail.extend(data)
+                    if len(output_tail) > ATTACH_TAIL_LIMIT:
+                        del output_tail[:-ATTACH_TAIL_LIMIT]
 
                 if stdin_fd is not None and sys.stdin in ready:
                     user_data = os.read(stdin_fd, 1024)
@@ -941,3 +954,4 @@ class DockerManager:
                 signal.signal(sigwinch, old_winch_handler)
             if stdin_fd is not None and old_tty is not None and termios is not None:
                 termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_tty)
+        return bytes(output_tail)

--- a/src/vibepod/core/resume.py
+++ b/src/vibepod/core/resume.py
@@ -1,0 +1,125 @@
+"""Detect agent-printed resume hints and map them to VibePod commands."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+from vibepod.utils.console import console, info
+
+_ANSI_RE = re.compile(
+    r"\x1b\[[0-9;?]*[ -/]*[@-~]"  # CSI sequences (colors, cursor movement)
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC sequences (titles, hyperlinks)
+    r"|\x1b[@-Z\\-_]",  # other single-character escapes
+)
+
+# Session identifiers / names / file names as agents print them. May contain
+# dots (file names) but never end with one, so sentence punctuation around the
+# hint is not captured.
+_TOKEN = r"[A-Za-z0-9](?:[A-Za-z0-9._/-]*[A-Za-z0-9_/-])?"
+
+# The binary name must not be preceded by a word/path character, so hints in
+# prose match but occurrences inside paths or our own `vp run <agent> -- ...`
+# output do not.
+_BOUNDARY = r"(?<![\w./-])"
+
+
+def _fixed(args: str) -> Callable[[re.Match[str]], str]:
+    def _format(match: re.Match[str]) -> str:
+        del match
+        return args
+
+    return _format
+
+
+def _with_id(prefix: str) -> Callable[[re.Match[str]], str]:
+    def _format(match: re.Match[str]) -> str:
+        return f"{prefix} {match.group(1)}"
+
+    return _format
+
+
+# Per-agent resume hint patterns. Hints must appear on a single line: patterns
+# only allow spaces/tabs between tokens so unrelated text on following lines is
+# never mistaken for a session identifier. Each formatter rebuilds the agent's
+# own suggested arguments, which are then passed through after `--`.
+_HINT_PATTERNS: dict[str, tuple[tuple[re.Pattern[str], Callable[[re.Match[str]], str]], ...]] = {
+    "claude": (
+        (
+            re.compile(rf"{_BOUNDARY}claude[ \t]+(?:-r|--resume)[ \t]+({_TOKEN})"),
+            _with_id("--resume"),
+        ),
+        (re.compile(rf"{_BOUNDARY}claude[ \t]+--continue(?![\w-])"), _fixed("--continue")),
+    ),
+    "codex": (
+        (re.compile(rf"{_BOUNDARY}codex[ \t]+resume[ \t]+({_TOKEN})"), _with_id("resume")),
+        (
+            re.compile(rf"{_BOUNDARY}codex[ \t]+resume[ \t]+--last(?![\w-])"),
+            _fixed("resume --last"),
+        ),
+    ),
+    "pi": (
+        (re.compile(rf"{_BOUNDARY}pi[ \t]+(?:-r|--resume)[ \t]+({_TOKEN})"), _with_id("--resume")),
+        (re.compile(rf"{_BOUNDARY}pi[ \t]+(?:-c|--continue)(?![\w-])"), _fixed("--continue")),
+    ),
+    "copilot": (
+        (
+            re.compile(rf"{_BOUNDARY}copilot[ \t]+(?:-r|--resume)[ \t]+({_TOKEN})"),
+            _with_id("--resume"),
+        ),
+        (re.compile(rf"{_BOUNDARY}copilot[ \t]+--continue(?![\w-])"), _fixed("--continue")),
+    ),
+    "jcode": (
+        (
+            re.compile(rf"{_BOUNDARY}jcode[ \t]+(?:-r|--resume)[ \t]+({_TOKEN})"),
+            _with_id("--resume"),
+        ),
+    ),
+    "freebuff": (
+        (
+            re.compile(rf"{_BOUNDARY}freebuff[ \t]+--continue[ \t]+({_TOKEN})"),
+            _with_id("--continue"),
+        ),
+        (re.compile(rf"{_BOUNDARY}freebuff[ \t]+--continue(?![\w-])"), _fixed("--continue")),
+    ),
+}
+
+
+def _clean(output: str) -> str:
+    text = _ANSI_RE.sub("", output)
+    # Carriage returns act as line resets in raw TTY output; treat them as
+    # line breaks so redrawn fragments never merge into one line.
+    return text.replace("\r", "\n")
+
+
+def build_resume_hint(agent: str, output: str) -> str | None:
+    """Return the ``vp`` command resuming the session suggested in *output*.
+
+    Scans the (ANSI-stripped) session output for the agent's own resume
+    instruction and wraps its arguments in ``vp run <agent> -- ...``. Returns
+    ``None`` when no recognizable hint is present, so exiting stays silent
+    rather than risking an incorrect command.
+    """
+    patterns = _HINT_PATTERNS.get(agent)
+    if not patterns:
+        return None
+    text = _clean(output)
+    best: tuple[int, str] | None = None
+    for pattern, formatter in patterns:
+        for match in pattern.finditer(text):
+            if best is None or match.end() > best[0]:
+                best = (match.end(), formatter(match))
+    if best is None:
+        return None
+    return f"vp run {agent} -- {best[1]}"
+
+
+def show_resume_hint(agent: str, output_tail: bytes | None) -> None:
+    """Print the VibePod resume command for a finished session, if detectable."""
+    if not output_tail:
+        return
+    hint = build_resume_hint(agent, output_tail.decode("utf-8", errors="replace"))
+    if hint is None:
+        return
+    info("Resume this session with:")
+    console.print(f"  {hint}", markup=False, highlight=False)

--- a/src/vibepod/core/resume.py
+++ b/src/vibepod/core/resume.py
@@ -39,6 +39,10 @@ def _with_id(prefix: str) -> Callable[[re.Match[str]], str]:
     return _format
 
 
+def _verbatim(match: re.Match[str]) -> str:
+    return match.group(1)
+
+
 # Per-agent resume hint patterns. Hints must appear on a single line: patterns
 # only allow spaces/tabs between tokens so unrelated text on following lines is
 # never mistaken for a session identifier. Each formatter rebuilds the agent's
@@ -58,8 +62,17 @@ _HINT_PATTERNS: dict[str, tuple[tuple[re.Pattern[str], Callable[[re.Match[str]],
             _fixed("resume --last"),
         ),
     ),
+    # Pi prints "To resume this session: pi [--session-dir <dir>] --session
+    # <id>"; its -r/--resume and -c/--continue flags are bare toggles (session
+    # picker / last session) and never carry an identifier.
     "pi": (
-        (re.compile(rf"{_BOUNDARY}pi[ \t]+(?:-r|--resume)[ \t]+({_TOKEN})"), _with_id("--resume")),
+        (
+            re.compile(
+                rf"{_BOUNDARY}pi[ \t]+"
+                rf"((?:--session-dir[ \t]+/?{_TOKEN}[ \t]+)?--session[ \t]+{_TOKEN})",
+            ),
+            _verbatim,
+        ),
         (re.compile(rf"{_BOUNDARY}pi[ \t]+(?:-c|--continue)(?![\w-])"), _fixed("--continue")),
     ),
     "copilot": (

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import socket
 import threading
 import types
@@ -254,3 +255,87 @@ def test_attach_interactive_forwards_windows_console_input_without_termios(
         sock_writer.close()
 
     assert sent == b"h"
+
+
+def _attach_and_capture(
+    monkeypatch: pytest.MonkeyPatch,
+    payload_chunks: list[bytes],
+) -> tuple[bytes | None, bytes]:
+    sock_reader, sock_writer = socket.socketpair()
+
+    class _FakeSocketWrapper:
+        _sock = sock_reader
+
+        def close(self) -> None:
+            pass
+
+    class _FakeApi:
+        def attach_socket(self, container_id: str, params: dict[str, int]) -> _FakeSocketWrapper:
+            del container_id, params
+            return _FakeSocketWrapper()
+
+        def resize(self, container_id: str, height: int, width: int) -> None:
+            del container_id, height, width
+
+    manager = object.__new__(DockerManager)
+    manager.client = types.SimpleNamespace(api=_FakeApi())  # type: ignore[assignment]
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return False
+
+    fake_stdout = types.SimpleNamespace(buffer=io.BytesIO())
+    monkeypatch.setattr(docker_mod.sys, "stdin", _FakeStdin())
+    monkeypatch.setattr(docker_mod.sys, "stdout", fake_stdout)
+    monkeypatch.setattr(docker_mod, "msvcrt", None)
+
+    def _feed() -> None:
+        for chunk in payload_chunks:
+            sock_writer.sendall(chunk)
+        sock_writer.close()
+
+    feeder = threading.Thread(target=_feed, daemon=True)
+    feeder.start()
+    try:
+        result = manager.attach_interactive(types.SimpleNamespace(id="container-1"))
+    finally:
+        feeder.join(timeout=5)
+        sock_reader.close()
+    return result, fake_stdout.buffer.getvalue()
+
+
+def test_attach_interactive_returns_output_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [b"transcript...\r\n", b"claude --resume abc-123\r\n"]
+    tail, written = _attach_and_capture(monkeypatch, payload)
+    assert tail == b"transcript...\r\nclaude --resume abc-123\r\n"
+    assert written == b"".join(payload)
+
+
+def test_attach_interactive_bounds_output_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    marker = b"claude --resume abc-123\r\n"
+    payload = [b"x" * 8192 for _ in range(20)] + [marker]
+    tail, written = _attach_and_capture(monkeypatch, payload)
+    assert tail is not None
+    assert tail.endswith(marker)
+    assert len(tail) <= docker_mod.ATTACH_TAIL_LIMIT
+    assert len(written) == 20 * 8192 + len(marker)
+
+
+def test_attach_prints_resume_hint_after_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = _managed_container("vibepod-claude-hint")
+
+    class _Manager:
+        def get_container(self, name_or_id: str):
+            return target
+
+        def attach_interactive(self, container, logger=None):  # noqa: ARG002
+            return b"Resume this session with:\r\nclaude --resume abc-123\r\n"
+
+    monkeypatch.setattr(attach_cmd, "DockerManager", lambda: _Manager())
+
+    attach_cmd.attach(container="vibepod-claude-hint")
+
+    assert "vp run claude -- --resume abc-123" in capsys.readouterr().out

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,119 @@
+"""Resume-hint detection tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from vibepod.core.resume import build_resume_hint
+
+CLAUDE_ID = "39bf1a93-ea1f-4b0a-a894-0a662e5a1d4e"
+
+
+def test_detects_claude_resume_hint() -> None:
+    output = f"Some transcript...\nResume this session with:\nclaude --resume {CLAUDE_ID}\n"
+    assert build_resume_hint("claude", output) == f"vp run claude -- --resume {CLAUDE_ID}"
+
+
+def test_detects_claude_short_flag_hint() -> None:
+    output = f"claude -r {CLAUDE_ID}\n"
+    assert build_resume_hint("claude", output) == f"vp run claude -- --resume {CLAUDE_ID}"
+
+
+def test_detects_claude_continue_hint() -> None:
+    output = "Run claude --continue to resume.\n"
+    assert build_resume_hint("claude", output) == "vp run claude -- --continue"
+
+
+def test_detects_codex_resume_hint() -> None:
+    session = "0198a2c3-1111-7222-8333-444455556666"
+    output = f"To continue this session, run codex resume {session}.\n"
+    assert build_resume_hint("codex", output) == f"vp run codex -- resume {session}"
+
+
+def test_detects_codex_resume_last_hint() -> None:
+    output = "Tip: codex resume --last\n"
+    assert build_resume_hint("codex", output) == "vp run codex -- resume --last"
+
+
+def test_detects_pi_resume_hint() -> None:
+    output = "pi --resume session-2026-08-18.jsonl\n"
+    assert build_resume_hint("pi", output) == "vp run pi -- --resume session-2026-08-18.jsonl"
+
+
+def test_detects_pi_continue_hint() -> None:
+    output = "Continue with pi --continue\n"
+    assert build_resume_hint("pi", output) == "vp run pi -- --continue"
+
+
+def test_detects_jcode_resume_hint() -> None:
+    output = "jcode --resume my-session\n"
+    assert build_resume_hint("jcode", output) == "vp run jcode -- --resume my-session"
+
+
+def test_detects_freebuff_continue_hint() -> None:
+    output = "freebuff --continue conv-42\n"
+    assert build_resume_hint("freebuff", output) == "vp run freebuff -- --continue conv-42"
+
+
+def test_strips_ansi_escape_sequences() -> None:
+    output = f"\x1b[1mResume:\x1b[0m \x1b[36mclaude --resume {CLAUDE_ID}\x1b[39m\r\n"
+    assert build_resume_hint("claude", output) == f"vp run claude -- --resume {CLAUDE_ID}"
+
+
+def test_uses_last_hint_in_output() -> None:
+    other = "11111111-2222-3333-4444-555555555555"
+    output = f"claude --resume {other}\n...\nclaude --resume {CLAUDE_ID}\n"
+    assert build_resume_hint("claude", output) == f"vp run claude -- --resume {CLAUDE_ID}"
+
+
+def test_returns_none_without_hint() -> None:
+    assert build_resume_hint("claude", "Goodbye!\n") is None
+
+
+def test_returns_none_for_agent_without_patterns() -> None:
+    assert build_resume_hint("gemini", f"claude --resume {CLAUDE_ID}\n") is None
+
+
+def test_returns_none_for_unknown_agent() -> None:
+    assert build_resume_hint("not-an-agent", "whatever") is None
+
+
+def test_does_not_match_other_agents_binary() -> None:
+    # A stray mention of another binary must not produce a command for this agent.
+    assert build_resume_hint("codex", f"claude --resume {CLAUDE_ID}\n") is None
+
+
+def test_does_not_rematch_own_vibepod_hint() -> None:
+    # Our own printed hint replayed in scrollback must not create a match:
+    # "claude -- --resume <id>" has "--" between binary and flag.
+    output = f"vp run claude -- --resume {CLAUDE_ID}\n"
+    assert build_resume_hint("claude", output) is None
+
+
+@pytest.mark.parametrize("agent", ["claude", "codex", "pi"])
+def test_requires_identifier_for_resume_flag(agent: str) -> None:
+    # Bare "--resume" / "resume" without an identifier is not a usable hint.
+    assert build_resume_hint(agent, f"{agent} --resume\n{agent} resume\n") is None
+
+
+def test_show_resume_hint_prints_command(capsys: pytest.CaptureFixture[str]) -> None:
+    from vibepod.core.resume import show_resume_hint
+
+    show_resume_hint("claude", b"Resume this session with:\r\nclaude --resume abc-123\r\n")
+    out = capsys.readouterr().out
+    assert "Resume this session" in out
+    assert "vp run claude -- --resume abc-123" in out
+
+
+def test_show_resume_hint_silent_without_hint(capsys: pytest.CaptureFixture[str]) -> None:
+    from vibepod.core.resume import show_resume_hint
+
+    show_resume_hint("claude", b"Goodbye!\r\n")
+    assert capsys.readouterr().out == ""
+
+
+def test_show_resume_hint_handles_undecodable_bytes(capsys: pytest.CaptureFixture[str]) -> None:
+    from vibepod.core.resume import show_resume_hint
+
+    show_resume_hint("claude", b"\xff\xfe claude --resume abc-123\r\n")
+    assert "vp run claude -- --resume abc-123" in capsys.readouterr().out

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -35,9 +35,26 @@ def test_detects_codex_resume_last_hint() -> None:
     assert build_resume_hint("codex", output) == "vp run codex -- resume --last"
 
 
-def test_detects_pi_resume_hint() -> None:
-    output = "pi --resume session-2026-08-18.jsonl\n"
-    assert build_resume_hint("pi", output) == "vp run pi -- --resume session-2026-08-18.jsonl"
+def test_detects_pi_session_hint() -> None:
+    # Pi prints "To resume this session: pi --session <id>" on exit; its
+    # --resume flag is a bare session-picker toggle and never carries an id.
+    session = "0198a2c3-1111-7222-8333-444455556666"
+    output = f"To resume this session: pi --session {session}\n"
+    assert build_resume_hint("pi", output) == f"vp run pi -- --session {session}"
+
+
+def test_detects_pi_session_hint_with_session_dir() -> None:
+    output = "To resume this session: pi --session-dir /workspace/.pi-sessions --session my-id\n"
+    assert (
+        build_resume_hint("pi", output)
+        == "vp run pi -- --session-dir /workspace/.pi-sessions --session my-id"
+    )
+
+
+def test_pi_resume_flag_with_argument_is_not_a_hint() -> None:
+    # "pi --resume <word>" is a picker toggle plus a prompt word, not a
+    # resumable session reference — emitting it would be an incorrect command.
+    assert build_resume_hint("pi", "pi --resume session-2026-08-18.jsonl\n") is None
 
 
 def test_detects_pi_continue_hint() -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -679,6 +679,9 @@ class _PortCapturingManager:
     def networks_with_running_containers(self) -> list[str]:
         return []
 
+    def attach_interactive(self, container, logger=None):  # type: ignore[no-untyped-def]
+        return getattr(self, "attach_tail", b"")
+
     def is_rootless_podman(self) -> bool:
         return False
 
@@ -1244,6 +1247,9 @@ class _StubDockerManager:
 
     def networks_with_running_containers(self) -> list[str]:
         return []
+
+    def attach_interactive(self, container, logger=None):  # type: ignore[no-untyped-def]
+        return getattr(self, "attach_tail", b"")
 
 
 def _make_config(
@@ -2389,3 +2395,18 @@ def test_run_explicit_pull_failure_raises(monkeypatch, tmp_path: Path) -> None:
 
     with pytest.raises(DockerClientError):
         run_cmd.run(agent="claude", workspace=tmp_path, pull=True, detach=True)
+
+
+def test_run_prints_resume_hint_after_attach(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stub = _StubDockerManager()
+    stub.attach_tail = b"Resume this session with:\r\nclaude --resume abc-123\r\n"
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    run_cmd.run(agent="claude", workspace=tmp_path, detach=False)
+
+    assert "vp run claude -- --resume abc-123" in capsys.readouterr().out


### PR DESCRIPTION
Adds support for automatically detecting and displaying agent-specific "resume session" hints after an agent session ends in VibePod. When an agent such as Claude, Codex, Pi, Copilot, Jcode, or Freebuff prints its own resume command at the end of a session, VibePod now parses this output and prints the corresponding `vp run <agent> -- ...` command for the user. This makes it easier to resume sessions without manually copying and editing agent-specific commands. The implementation includes robust output parsing, handling of ANSI escape codes, and comprehensive tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Displays a suggested `vp run ...` command when supported coding agents provide resume instructions after a session ends.
  - Supports resume hints from Claude, Codex, Pi, Copilot, Jcode, and Freebuff.
  - Preserves session output needed to identify resume instructions while maintaining existing interactive behavior.

- **Documentation**
  - Added guidance explaining resume hints, persisted session state, and behavior when no hint is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->