### PR TITLE
feat(config): show config dir and proxy DB in vp config path

### DIFF
--- a/src/vibepod/commands/config.py
+++ b/src/vibepod/commands/config.py
@@ -17,7 +17,12 @@ from vibepod.core.allowed_dirs import (
     load_allowed_dirs,
     remove_allowed_dir,
 )
-from vibepod.core.config import get_config, get_global_config_path, get_project_config_path
+from vibepod.core.config import (
+    get_config,
+    get_config_root,
+    get_global_config_path,
+    get_project_config_path,
+)
 from vibepod.utils.console import console, error, success
 
 app = typer.Typer(help="Manage configuration")
@@ -129,7 +134,7 @@ def path(
         typer.Option("--project", help="Show project config path only"),
     ] = False,
 ) -> None:
-    """Show config and logs paths."""
+    """Show configuration, logs, and proxy database paths."""
     global_path = get_global_config_path()
     project_path = get_project_config_path()
 
@@ -144,14 +149,22 @@ def path(
         print(project_path)
         return
 
+    config = get_config()
+    config_root = get_config_root()
     logs_path = Path(
-        str(get_config().get("logging", {}).get("db_path", "~/.config/vibepod/logs.db")),
+        str(config.get("logging", {}).get("db_path", "~/.config/vibepod/logs.db")),
     )
     logs_path = logs_path.expanduser().resolve()
+    proxy_db_path = Path(
+        str(config.get("proxy", {}).get("db_path", "~/.config/vibepod/proxy/proxy.db")),
+    )
+    proxy_db_path = proxy_db_path.expanduser().resolve()
 
+    print(f"Config:  {config_root}")
     print(f"Global:  {global_path}")
     print(f"Project: {project_path}")
     print(f"Logs:    {logs_path}")
+    print(f"Proxy:   {proxy_db_path}")
 
 
 @app.command("allow-dir")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,6 +120,52 @@ def test_config_init_with_agent_fails_when_agent_already_configured(
     assert loaded["agents"]["claude"]["enabled"] is True
 
 
+def test_config_path_shows_config_dir_and_proxy_db(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["config", "path"])
+    assert result.exit_code == 0
+    config_root = tmp_path.resolve()
+    assert f"Config:  {config_root}" in result.stdout
+    assert f"Global:  {config_root / 'config.yaml'}" in result.stdout
+    assert f"Project: {config_root / '.vibepod' / 'config.yaml'}" in result.stdout
+    assert f"Logs:    {config_root / 'logs.db'}" in result.stdout
+    assert f"Proxy:   {config_root / 'proxy' / 'proxy.db'}" in result.stdout
+
+
+def test_config_path_reports_configured_proxy_db(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    global_config = tmp_path / "config.yaml"
+    global_config.write_text(
+        f"proxy:\n  db_path: {tmp_path / 'custom' / 'proxy.db'}\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["config", "path"])
+    assert result.exit_code == 0
+    assert f"Proxy:   {tmp_path.resolve() / 'custom' / 'proxy.db'}" in result.stdout
+
+
+def test_config_path_global_only_prints_single_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["config", "path", "--global"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == str(tmp_path.resolve() / "config.yaml")
+
+
+def test_config_path_project_only_prints_single_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["config", "path", "--project"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == str(tmp_path / ".vibepod" / "config.yaml")
+
+
 def test_default_config_exposes_agent_init(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
     config = get_config()


### PR DESCRIPTION
Enhances the `config path` command to display additional configuration paths and improves test coverage to ensure correct behavior. The main updates include showing the configuration root and proxy database paths, as well as adding new tests for these features.

* The output now includes the configuration root directory and the proxy database path, in addition to the existing global, project, and logs paths.
* The help text for the command has been updated to reflect the expanded output.
