### PR TITLE
Add dsh to supported agents constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 
 - ⚡ **Zero config** — no setup required; `vp run <agent>` just works. Optional YAML for custom configuration
 - 🐳 **Isolated agents** — each agent runs in its own Docker or Podman container
-- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau, Jcode, Freebuff, Qwen & more
+- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau, Jcode, Freebuff, Qwen, Dsh & more
 - 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
 - 🧱 **Project overlays** — commit a `FROM`-less Dockerfile fragment in `.vibepod/overlay/` and VibePod auto-builds a cached, content-addressed image layer on top of the agent's base image — one clearly named image per project and agent ([docs](https://vibepod.dev/docs/overlays/))
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics
@@ -90,6 +90,7 @@ Use `--ikwid` to append each agent's auto-approval / permission-skip flag when s
 | `jcode` | Not supported |
 | `freebuff` | Not supported |
 | `qwen` | `--approval-mode=yolo` |
+| `dsh` | Not supported |
 
 ![VibePod CLI preview](https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/preview.png)
 
@@ -159,6 +160,7 @@ Current defaults:
 - `jcode` -> `vibepod/jcode:latest`
 - `freebuff` -> `vibepod/freebuff:latest`
 - `qwen` -> `vibepod/qwen:latest`
+- `dsh` -> `vibepod/dsh:latest`
 - `datasette` -> `vibepod/datasette:latest`
 - `proxy` -> `vibepod/proxy:latest` ([repo](https://github.com/VibePod/vibepod-proxy))
 
@@ -181,6 +183,7 @@ VP_IMAGE_TAU=vibepod/tau:latest vp run tau
 VP_IMAGE_JCODE=vibepod/jcode:latest vp run jcode
 VP_IMAGE_FREEBUFF=vibepod/freebuff:latest vp run freebuff
 VP_IMAGE_QWEN=vibepod/qwen:latest vp run qwen
+VP_IMAGE_DSH=vibepod/dsh:latest vp run dsh
 VP_DATASETTE_IMAGE=vibepod/datasette:latest vp logs start
 VP_SKILLS_ENGINE_IMAGE=vibepod/skills-engine:latest vp skills list
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 
 - ⚡ **Zero config** — no setup required; `vp run <agent>` just works. Optional YAML for custom configuration
 - 🐳 **Isolated agents** — each agent runs in its own Docker or Podman container
-- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau, Jcode, Freebuff, Qwen, Dsh & more
+- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau, Jcode, Freebuff, Qwen, dsh & more
 - 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
 - 🧱 **Project overlays** — commit a `FROM`-less Dockerfile fragment in `.vibepod/overlay/` and VibePod auto-builds a cached, content-addressed image layer on top of the agent's base image — one clearly named image per project and agent ([docs](https://vibepod.dev/docs/overlays/))
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -19,9 +19,71 @@ VibePod manages each agent as a Docker or Podman container. Credentials and conf
 | `jcode` | 1jehuang | `vp j` | `vibepod/jcode:latest` |
 | `freebuff` | CodebuffAI | `vp fb` | `vibepod/freebuff:latest` |
 | `qwen` | Qwen (Alibaba) | `vp q` | `vibepod/qwen:latest` |
+| `dsh` (DeepSeek Harness) | DeepSeek | `vp ds` | `vibepod/dsh:latest` |
 
-Alias note: `vp run vibe` resolves to `vp run devstral`, and `vp run qwen-cli`
-resolves to `vp run qwen`.
+Alias note: `vp run vibe` resolves to `vp run devstral`, `vp run qwen-cli`
+resolves to `vp run qwen`, and `vp run deepseek` / `vp run deepseek-harness`
+resolve to `vp run dsh`.
+
+## DeepSeek Harness (`dsh`) — Web UI agent
+
+dsh is Web-UI-first: `vp run dsh` starts the harness's browser UI and prints
+its URL (default `http://127.0.0.1:3080`, published loopback-only on the
+host). The terminal stays attached to the container logs; Ctrl+C stops it.
+Sessions, profiles, plugins, and credentials persist in the agent config dir
+(`~/.config/vibepod/agents/dsh/`, mounted as the container's home).
+
+> **Developer preview:** upstream warns of compatibility-breaking changes.
+> The `vibepod/dsh` image pins an exact version; VibePod prints a preview
+> notice on every run.
+
+**First-run setup (one time):** the Web UI needs a workspace and a model
+before the first session; both persist in the agent config dir.
+
+1. Open the printed URL and click the workspace path in the top bar (or
+   **Choose workspace**). Navigate to `/workspace` — the project mount — via
+   the root breadcrumb or the path editor, and select it. Don't use the
+   new-folder input: `/workspace` already exists, and the input only accepts a
+   single folder name. Every project is mounted at `/workspace`, so this
+   registration carries over to all of them.
+2. Configure a model under **Settings → Models** (see below).
+
+**Auth:** enter a DeepSeek API key in the Web UI (Settings → Models) — it
+persists across restarts — or pass it from the host:
+
+```bash
+vp run dsh -e DEEPSEEK_API_KEY=$DEEPSEEK_API_KEY
+```
+
+**Other providers:** no DeepSeek account is required. Any OpenAI-compatible
+endpoint works — in **Settings → Models** pick the `openai` provider, set a
+custom base URL (e.g. a local [Ollama](https://ollama.com/) server), fill in
+any non-empty token if the endpoint doesn't check one, and enter the model
+name manually.
+
+**Headless one-shot** (uses dsh's `headless` profile, no server, prints the
+final answer):
+
+```bash
+vp task create dsh "summarize this repository"
+```
+
+**Changing the host port:** override the published port in your config; the
+container-side port stays `3081` (the image's internal forwarder):
+
+```yaml
+agents:
+  dsh:
+    ports:
+      - "127.0.0.1:3090:3081"
+```
+
+dsh's browser-trust fence expects the canonical authority; on a non-default
+host port also pass `vp run dsh -- --trusted-host 127.0.0.1:3090`.
+
+**Customizing:** dsh composes profiles from patch layers. Edit
+`~/.config/vibepod/agents/dsh/.dsh/cordis.patch.yml` on the host — changes
+hot-reload into the running server.
 
 ## First run & authentication
 
@@ -80,7 +142,7 @@ agents:
 
 ## Image customization workflows
 
-VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`, `tau`, `jcode`, `freebuff`, `qwen`). The CLI also supports the aliases `vibe` (→ `devstral`) and `qwen-cli` (→ `qwen`). Image customization means changing the image used for one of those IDs.
+VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`, `tau`, `jcode`, `freebuff`, `qwen`, `dsh`). The CLI also supports the aliases `vibe` (→ `devstral`), `qwen-cli` (→ `qwen`), and `deepseek` / `deepseek-harness` (→ `dsh`). Image customization means changing the image used for one of those IDs.
 
 ### 1. Extend an existing image for an agent
 
@@ -210,6 +272,7 @@ Use `--ikwid` to enable each agent's built-in auto-approval / permission-skip mo
 | `jcode` | Not supported |
 | `freebuff` | Not supported |
 | `qwen` | `--approval-mode=yolo` |
+| `dsh` | Not supported |
 
 Example:
 
@@ -328,6 +391,7 @@ Task mode applies a finite timeout by default: **2 hours**. Override it per task
 | `tau` | `tau -p "<prompt>"` |
 | `jcode` | `jcode run "<prompt>"` |
 | `qwen` | `qwen -p "<prompt>"` |
+| `dsh` | `dsh --profile headless "<prompt>"` |
 
 Other agents error with a clear message; support can be added by setting `headless_prefix` (or `headless_command` for agents whose one-shot invocation differs from their interactive command) on their `AgentSpec`.
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -329,7 +329,7 @@ Task mode applies a finite timeout by default: **2 hours**. Override it per task
 | `jcode` | `jcode run "<prompt>"` |
 | `qwen` | `qwen -p "<prompt>"` |
 
-Other agents error with a clear message; support can be added by setting `headless_prefix` on their `AgentSpec`.
+Other agents error with a clear message; support can be added by setting `headless_prefix` (or `headless_command` for agents whose one-shot invocation differs from their interactive command) on their `AgentSpec`.
 
 ### Managing tasks
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -79,8 +79,20 @@ agents:
       - "127.0.0.1:3090:3081"
 ```
 
+For a one-off run, the [`-p/--publish` flag](../configuration.md#publishing-ports)
+replaces the configured list instead:
+
+```bash
+vp run dsh -p 127.0.0.1:3090:3081
+```
+
+A host port of `0` (e.g. `127.0.0.1:0:3081`) lets the Docker daemon pick a
+free port — useful for running dsh in several projects at once; the printed
+Web UI URL shows the assigned port.
+
 dsh's browser-trust fence expects the canonical authority; on a non-default
-host port also pass `vp run dsh -- --trusted-host 127.0.0.1:3090`.
+host port also pass `vp run dsh -- --trusted-host 127.0.0.1:3090` (with the
+actual port when the daemon assigned one).
 
 **Customizing:** dsh composes profiles from patch layers. Edit
 `~/.config/vibepod/agents/dsh/.dsh/cordis.patch.yml` on the host — changes

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -34,8 +34,9 @@ Sessions, profiles, plugins, and credentials persist in the agent config dir
 (`~/.config/vibepod/agents/dsh/`, mounted as the container's home).
 
 > **Developer preview:** upstream warns of compatibility-breaking changes.
-> The `vibepod/dsh` image pins an exact version; VibePod prints a preview
-> notice on every run.
+> The default `vibepod/dsh` image pins an exact harness (npm) version — the
+> `:latest` docker tag refers to the image build, not the harness inside.
+> VibePod prints a preview notice on every run.
 
 **First-run setup (one time):** the Web UI needs a workspace and a model
 before the first session; both persist in the agent config dir.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,15 @@ agents:
     ports: []
     init: []
 
+  dsh:
+    enabled: true
+    image: vibepod/dsh:latest
+    env: {}
+    volumes: []
+    ports:
+      - "127.0.0.1:3080:3081"   # Web UI; container side must stay 3081
+    init: []
+
 # Connect agents to a local or remote LLM server (Ollama, vLLM, etc.)
 llm:
   enabled: false
@@ -214,6 +223,7 @@ Each agent image can be overridden individually:
 | `VP_IMAGE_JCODE` | jcode |
 | `VP_IMAGE_FREEBUFF` | freebuff |
 | `VP_IMAGE_QWEN` | qwen |
+| `VP_IMAGE_DSH` | dsh |
 | `VP_DATASETTE_IMAGE` | datasette (logs UI) |
 | `VP_PROXY_IMAGE` | proxy |
 | `VP_SKILLS_ENGINE_IMAGE` | skills-engine (used by `vp skills`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker 
 | `jcode` | 1jehuang | `vp j` |
 | `freebuff` | CodebuffAI | `vp fb` |
 | `qwen` | Qwen (Alibaba) | `vp q` |
+| `dsh` (DeepSeek Harness) | DeepSeek | `vp ds` |
 
 ## Next Steps
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -150,7 +150,8 @@ Press **Ctrl+C** to stop the container when you are done.
 You can start agents with the full agent command. Most agents also have a single-letter
 shortcut; Pi uses `vp pi` because `vp p` is assigned to Copilot, Agy uses
 `vp n`, Tau uses `vp t`, Jcode uses `vp j`, Freebuff uses `vp fb`, and
-Qwen uses `vp q`.
+Qwen uses `vp q`. DeepSeek Harness uses `vp ds` and opens a Web UI — the URL
+is printed after start.
 
 ```bash
 vp claude   # full name

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -147,6 +147,7 @@ def _agent_skill_paths(agent: str) -> list[str]:
       - tau      reads ~/.agents/skills/ (also ~/.tau/skills/)
       - jcode    reads ~/.agents/skills/ (also ~/.jcode/skills/)
       - freebuff reads ~/.agents/skills/ (also ~/.freebuff/skills/)
+      - dsh      reads ~/.agents/skills/            → /config/.agents/skills/
       - qwen     reads ~/.qwen/skills/, which the image symlinks to /qwen/skills
         (also <project>/.qwen/skills/ in the workspace)
 
@@ -160,7 +161,7 @@ def _agent_skill_paths(agent: str) -> list[str]:
         return ["/config/.pi/agent/skills"]
     if agent == "qwen":
         return ["/qwen/skills"]
-    if agent in ("codex", "opencode", "auggie", "tau", "jcode", "freebuff"):
+    if agent in ("codex", "opencode", "auggie", "tau", "jcode", "freebuff", "dsh"):
         return ["/config/.agents/skills"]
     return []
 
@@ -230,6 +231,25 @@ def _skills_mounts_for_agent(agent: str, workspace: Path) -> list[tuple[str, str
         for base in targets:
             mounts.append((str(host_path), f"{base}/{skill_id}", "ro"))
     return mounts
+
+
+def _web_ui_url(container_port: int | None, ports: dict[str, Any] | None) -> str | None:
+    """Host URL for a published Web UI port, from docker-py port bindings."""
+    if not container_port or not ports:
+        return None
+    for key, binds in ports.items():
+        if str(key).split("/", 1)[0] != str(container_port):
+            continue
+        for bind in binds if isinstance(binds, list) else [binds]:
+            host, host_port = bind if isinstance(bind, tuple) else ("", bind)
+            if not host_port or str(host_port) == "0":
+                # Ephemeral binding: the daemon picks the host port, so it
+                # isn't knowable from the bindings dict.
+                continue
+            if not host or str(host) in ("0.0.0.0", "::"):
+                host = "127.0.0.1"
+            return f"http://{host}:{host_port}"
+    return None
 
 
 def _compose_file_present(workspace: Path) -> bool:
@@ -392,6 +412,11 @@ def run(
 
     agent_cfg = config.get("agents", {}).get(selected_agent, {})
     spec = get_agent_spec(selected_agent)
+    if spec.preview:
+        warning(
+            f"{selected_agent} is a developer preview; upstream warns of "
+            "compatibility-breaking changes. The image pins an exact version.",
+        )
     codex_oauth_login = _is_codex_oauth_login(selected_agent, passthrough_args)
     init_commands = _agent_init_commands(selected_agent, agent_cfg)
     merged_env = {
@@ -668,6 +693,11 @@ def run(
             _release_herdr_agent(selected_agent)
             _clear_herdr_metadata(selected_agent)
         raise typer.Exit(1)
+
+    web_url = _web_ui_url(spec.web_container_port, agent_ports)
+    if web_url:
+        success(f"{selected_agent} Web UI → {web_url}")
+        info("Sessions persist in the agent config dir.")
 
     if extra_network and extra_network != network_name:
         try:

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -234,20 +234,34 @@ def _skills_mounts_for_agent(agent: str, workspace: Path) -> list[tuple[str, str
 
 
 def _web_ui_url(container_port: int | None, ports: dict[str, Any] | None) -> str | None:
-    """Host URL for a published Web UI port, from docker-py port bindings."""
+    """Host URL for a published Web UI port.
+
+    Accepts both the inspected `NetworkSettings.Ports` shape (`HostIp`/`HostPort`
+    dicts — preferred, since it carries daemon-assigned ephemeral ports) and the
+    requested docker-py bindings shape (tuples/strings).
+    """
     if not container_port or not ports:
         return None
     for key, binds in ports.items():
         if str(key).split("/", 1)[0] != str(container_port):
             continue
         for bind in binds if isinstance(binds, list) else [binds]:
-            host, host_port = bind if isinstance(bind, tuple) else ("", bind)
+            if isinstance(bind, dict):
+                host, host_port = bind.get("HostIp", ""), bind.get("HostPort", "")
+            elif isinstance(bind, tuple):
+                host, host_port = bind
+            else:
+                host, host_port = "", bind
             if not host_port or str(host_port) == "0":
-                # Ephemeral binding: the daemon picks the host port, so it
-                # isn't knowable from the bindings dict.
+                # Ephemeral binding in the requested shape: the daemon picks
+                # the host port, so it isn't knowable from this dict.
                 continue
-            if not host or str(host) in ("0.0.0.0", "::"):
+            host = str(host or "")
+            if not host or host in ("0.0.0.0", "::"):
                 host = "127.0.0.1"
+            elif ":" in host:
+                # IPv6 literals must be bracketed to form a valid URL authority.
+                host = f"[{host}]"
             return f"http://{host}:{host_port}"
     return None
 
@@ -415,7 +429,8 @@ def run(
     if spec.preview:
         warning(
             f"{selected_agent} is a developer preview; upstream warns of "
-            "compatibility-breaking changes. The image pins an exact version.",
+            "compatibility-breaking changes. The default image pins an exact "
+            "harness version.",
         )
     codex_oauth_login = _is_codex_oauth_login(selected_agent, passthrough_args)
     init_commands = _agent_init_commands(selected_agent, agent_cfg)
@@ -694,7 +709,11 @@ def run(
             _clear_herdr_metadata(selected_agent)
         raise typer.Exit(1)
 
-    web_url = _web_ui_url(spec.web_container_port, agent_ports)
+    # Prefer the inspected bindings (they resolve ephemeral 0-port publishes to
+    # the daemon-assigned port); fall back to the requested bindings when the
+    # inspect payload has no Ports section.
+    inspected_ports = (container.attrs.get("NetworkSettings") or {}).get("Ports") or None
+    web_url = _web_ui_url(spec.web_container_port, inspected_ports or agent_ports)
     if web_url:
         success(f"{selected_agent} Web UI → {web_url}")
         info("Sessions persist in the agent config dir.")

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -20,6 +20,7 @@ from vibepod import __version__
 from vibepod.commands.stop import _release_herdr_entries
 from vibepod.constants import EXIT_DOCKER_NOT_RUNNING
 from vibepod.core.agents import (
+    AGENT_SPECS,
     agent_config_dir,
     effective_agent_image,
     get_agent_spec,
@@ -496,12 +497,22 @@ def task_create(
         raise typer.Exit(1)
 
     spec = get_agent_spec(selected)
-    if not spec.headless_prefix:
+    if not spec.headless_prefix and not spec.headless_command:
+        supported = ", ".join(
+            agent
+            for agent, agent_spec in AGENT_SPECS.items()
+            if agent_spec.headless_prefix or agent_spec.headless_command
+        )
         error(
-            f"Agent '{selected}' does not yet support headless task mode. "
-            "Supported in v1: claude, codex, auggie.",
+            f"Agent '{selected}' does not yet support headless task mode. Supported: {supported}.",
         )
         raise typer.Exit(1)
+
+    if spec.preview:
+        warning(
+            f"{selected} is a developer preview; upstream warns of "
+            "compatibility-breaking changes. The image pins an exact version.",
+        )
 
     workspace_path = workspace.expanduser().resolve()
     if not workspace_path.exists() or not workspace_path.is_dir():
@@ -536,6 +547,15 @@ def task_create(
     agent_cfg = config.get("agents", {}).get(selected, {})
     init_commands = agent_init_commands(selected, agent_cfg)
     agent_ports = agent_port_bindings(selected, agent_cfg) or None
+    if agent_ports and spec.web_container_port is not None:
+        # The headless profile serves no web UI; publishing the web port would
+        # collide with a concurrently running `vp run <agent>` (or a second
+        # concurrent task) already holding the host port. Drop only the web
+        # port binding — user-configured extra ports stay published.
+        web_port = str(spec.web_container_port)
+        agent_ports = {
+            key: value for key, value in agent_ports.items() if key.split("/", 1)[0] != web_port
+        } or None
     merged_env = {
         **host_identity_env(),
         **terminal_env_defaults(),
@@ -543,6 +563,10 @@ def task_create(
         **{str(k): str(v) for k, v in agent_cfg.get("env", {}).items()},
         **parse_env_pairs(env or []),
     }
+    if spec.headless_command:
+        # No web UI in one-shot mode: without this the image entrypoint would
+        # start a pointless socat forwarder for the (unpublished) web port.
+        merged_env.pop("VIBEPOD_WEB_FORWARD_PORT", None)
 
     if selected == "codex" and "CODEX_API_KEY" not in merged_env and "OPENAI_API_KEY" in merged_env:
         merged_env["CODEX_API_KEY"] = merged_env["OPENAI_API_KEY"]
@@ -637,13 +661,18 @@ def task_create(
         else:
             warning(f"--ikwid has no effect for agent '{selected}' (no auto-approve flag defined)")
 
-    command = (
-        list(base_command or [])
-        + ikwid_prefix
-        + list(spec.headless_prefix)
-        + [prompt]
-        + passthrough_args
-    )
+    if spec.headless_command:
+        # The one-shot invocation replaces the interactive command outright
+        # (dsh runs `dsh web` interactively but `dsh --profile headless` one-shot).
+        command = list(spec.headless_command) + ikwid_prefix + [prompt] + passthrough_args
+    else:
+        command = (
+            list(base_command or [])
+            + ikwid_prefix
+            + list(spec.headless_prefix or [])
+            + [prompt]
+            + passthrough_args
+        )
 
     config_dir = agent_config_dir(selected, active_profile)
     config_dir.mkdir(parents=True, exist_ok=True)

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -511,7 +511,8 @@ def task_create(
     if spec.preview:
         warning(
             f"{selected} is a developer preview; upstream warns of "
-            "compatibility-breaking changes. The image pins an exact version.",
+            "compatibility-breaking changes. The default image pins an exact "
+            "harness version.",
         )
 
     workspace_path = workspace.expanduser().resolve()

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -32,6 +32,7 @@ SUPPORTED_AGENTS = (
     "jcode",
     "freebuff",
     "qwen",
+    "dsh",
 )
 
 AGENT_SHORTCUTS: dict[str, str] = {
@@ -47,6 +48,7 @@ AGENT_SHORTCUTS: dict[str, str] = {
     "j": "jcode",
     "fb": "freebuff",
     "q": "qwen",
+    "ds": "dsh",
 }
 
 AGENT_ALIASES: dict[str, str] = {
@@ -55,6 +57,8 @@ AGENT_ALIASES: dict[str, str] = {
     # binary and image are `qwen` (Qwen Code, npm @qwen-code/qwen-code),
     # so `qwen` is the canonical id and `qwen-cli` is accepted as an alias.
     "qwen-cli": "qwen",
+    "deepseek": "dsh",
+    "deepseek-harness": "dsh",
 }
 
 IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (
@@ -72,6 +76,7 @@ IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (
     "VP_IMAGE_JCODE",
     "VP_IMAGE_FREEBUFF",
     "VP_IMAGE_QWEN",
+    "VP_IMAGE_DSH",
     "VP_DATASETTE_IMAGE",
     "VP_PROXY_IMAGE",
     "VP_SKILLS_ENGINE_IMAGE",
@@ -146,6 +151,10 @@ def get_default_images() -> dict[str, str]:
         "qwen": os.environ.get(
             "VP_IMAGE_QWEN",
             f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/qwen:latest",
+        ),
+        "dsh": os.environ.get(
+            "VP_IMAGE_DSH",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/dsh:latest",
         ),
         "datasette": os.environ.get(
             "VP_DATASETTE_IMAGE",

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -25,6 +25,15 @@ class AgentSpec:
     llm_env_map: dict[str, str | list[str]] | None = None
     llm_model_args: list[str] | None = None
     headless_prefix: list[str] | None = None
+    # headless_command replaces `command` entirely for `vp task` when the
+    # agent's one-shot invocation is not `command + headless_prefix` (dsh's
+    # interactive command is `dsh web`, its one-shot is `dsh --profile headless`).
+    # preview marks developer-preview agents; run/task print a warning.
+    # web_container_port names the container port serving a Web UI so run can
+    # print the published URL after start.
+    headless_command: list[str] | None = None
+    preview: bool = False
+    web_container_port: int | None = None
 
 
 AGENT_SPECS: dict[str, AgentSpec] = {
@@ -196,6 +205,27 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         {"QWEN_CONFIG_DIR": "/qwen"},
         ikwid_args=["--approval-mode=yolo"],
         headless_prefix=["-p"],
+    ),
+    "dsh": AgentSpec(
+        "dsh",
+        "deepseek",
+        DEFAULT_IMAGES["dsh"],
+        "dsh",
+        # dsh is Web-UI-first: `dsh web` serves http://127.0.0.1:3080 in-container
+        # (it intentionally rejects --host 0.0.0.0), and the image entrypoint runs
+        # a socat forwarder on VIBEPOD_WEB_FORWARD_PORT so Docker can publish it.
+        # --no-open: the container has no browser; the user opens the printed URL.
+        ["dsh", "web", "--no-open"],
+        "/config",
+        # dsh keeps all user data under $DSH_HOME (~/.dsh), so HOME on the
+        # persisted mount is the whole persistence contract.
+        # NODE_USE_ENV_PROXY: dsh calls DeepSeek via Node's global fetch, which
+        # ignores HTTP(S)_PROXY unless this flag is set (Node >= 22.21) — without
+        # it the traffic bypasses the vibepod-proxy mitm container.
+        {"HOME": "/config", "VIBEPOD_WEB_FORWARD_PORT": "3081", "NODE_USE_ENV_PROXY": "1"},
+        headless_command=["dsh", "--profile", "headless"],
+        preview=True,
+        web_container_port=3081,
     ),
 }
 

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -153,6 +153,19 @@ def _default_config() -> dict[str, Any]:
                 "ports": [],
                 "init": [],
             },
+            "dsh": {
+                "enabled": True,
+                "image": DEFAULT_IMAGES["dsh"],
+                "auto_pull": None,
+                "env": {},
+                "volumes": [],
+                # dsh's Web UI: host 127.0.0.1:3080 -> the image's socat forwarder
+                # on 3081 -> the loopback-bound server on 3080. Loopback-only on
+                # the host so the UI is never LAN-exposed; override here on
+                # collision.
+                "ports": ["127.0.0.1:3080:3081"],
+                "init": [],
+            },
         },
         "logging": {
             "enabled": True,

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -161,8 +161,8 @@ def _default_config() -> dict[str, Any]:
                 "volumes": [],
                 # dsh's Web UI: host 127.0.0.1:3080 -> the image's socat forwarder
                 # on 3081 -> the loopback-bound server on 3080. Loopback-only on
-                # the host so the UI is never LAN-exposed; override here on
-                # collision.
+                # the host so the UI is never LAN-exposed; override
+                # agents.dsh.ports in config.yaml on collision.
                 "ports": ["127.0.0.1:3080:3081"],
                 "init": [],
             },

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -131,17 +131,13 @@ def test_dsh_spec_matches_container_contract() -> None:
     assert spec.headless_command == ["dsh", "--profile", "headless"]
     assert spec.preview is True
     assert spec.web_container_port == 3081
+    assert int(spec.extra_env["VIBEPOD_WEB_FORWARD_PORT"]) == spec.web_container_port
 
 
-def test_non_preview_agents_default_to_no_preview() -> None:
-    assert get_agent_spec("claude").preview is False
-    assert get_agent_spec("qwen").preview is False
-
-
-def test_resolve_agent_name_dsh_aliases() -> None:
-    assert resolve_agent_name("ds") == "dsh"
-    assert resolve_agent_name("deepseek") == "dsh"
-    assert resolve_agent_name("DEEPSEEK-HARNESS") == "dsh"
+def test_only_dsh_is_preview() -> None:
+    for agent in SUPPORTED_AGENTS:
+        spec = get_agent_spec(agent)
+        assert spec.preview is (agent == "dsh"), f"{agent} preview flag unexpected"
 
 
 def test_get_agent_spec_unknown() -> None:
@@ -160,6 +156,8 @@ def test_resolve_agent_name_accepts_short_and_full_forms() -> None:
     assert resolve_agent_name("VIBE") == "devstral"
     assert resolve_agent_name("qwen-cli") == "qwen"
     assert resolve_agent_name("QWEN-CLI") == "qwen"
+    assert resolve_agent_name("deepseek") == "dsh"
+    assert resolve_agent_name("DEEPSEEK-HARNESS") == "dsh"
     assert resolve_agent_name("unknown") is None
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -115,6 +115,35 @@ def test_qwen_spec_matches_container_contract() -> None:
     assert spec.headless_prefix == ["-p"]
 
 
+def test_dsh_spec_matches_container_contract() -> None:
+    spec = get_agent_spec("dsh")
+    assert spec.id == "dsh"
+    assert spec.provider == "deepseek"
+    assert spec.image == DEFAULT_IMAGES["dsh"]
+    assert spec.config_subdir == "dsh"
+    assert spec.command == ["dsh", "web", "--no-open"]
+    assert spec.config_mount_path == "/config"
+    assert spec.extra_env["HOME"] == "/config"
+    assert spec.extra_env["VIBEPOD_WEB_FORWARD_PORT"] == "3081"
+    assert spec.extra_env["NODE_USE_ENV_PROXY"] == "1"
+    assert spec.ikwid_args is None
+    assert spec.headless_prefix is None
+    assert spec.headless_command == ["dsh", "--profile", "headless"]
+    assert spec.preview is True
+    assert spec.web_container_port == 3081
+
+
+def test_non_preview_agents_default_to_no_preview() -> None:
+    assert get_agent_spec("claude").preview is False
+    assert get_agent_spec("qwen").preview is False
+
+
+def test_resolve_agent_name_dsh_aliases() -> None:
+    assert resolve_agent_name("ds") == "dsh"
+    assert resolve_agent_name("deepseek") == "dsh"
+    assert resolve_agent_name("DEEPSEEK-HARNESS") == "dsh"
+
+
 def test_get_agent_spec_unknown() -> None:
     with pytest.raises(ValueError):
         get_agent_spec("unknown")
@@ -222,6 +251,7 @@ def test_agents_without_llm_env_map() -> None:
         "jcode",
         "freebuff",
         "qwen",
+        "dsh",
     ):
         spec = get_agent_spec(agent)
         assert spec.llm_env_map is None, f"{agent} should not have llm_env_map"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,7 +183,9 @@ def test_default_config_exposes_agent_ports(monkeypatch, tmp_path: Path) -> None
     assert isinstance(agents, dict)
 
     for agent in SUPPORTED_AGENTS:
-        assert agents[agent]["ports"] == []
+        # dsh is web-first: its Web UI port is published by default.
+        expected = ["127.0.0.1:3080:3081"] if agent == "dsh" else []
+        assert agents[agent]["ports"] == expected
 
 
 def test_default_config_exposes_agent_auto_pull(monkeypatch, tmp_path: Path) -> None:
@@ -194,6 +196,17 @@ def test_default_config_exposes_agent_auto_pull(monkeypatch, tmp_path: Path) -> 
 
     for agent in SUPPORTED_AGENTS:
         assert agents[agent]["auto_pull"] is None
+
+
+def test_default_config_dsh_publishes_web_port_loopback_only(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    config = get_config()
+
+    assert config["agents"]["dsh"]["ports"] == ["127.0.0.1:3080:3081"]
+    assert config["agents"]["dsh"]["enabled"] is True
 
 
 def test_per_agent_auto_pull_override(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -21,6 +21,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
         "VP_IMAGE_JCODE",
         "VP_IMAGE_FREEBUFF",
         "VP_IMAGE_QWEN",
+        "VP_IMAGE_DSH",
         "VP_DATASETTE_IMAGE",
         "VP_PROXY_IMAGE",
     ):
@@ -41,6 +42,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
     assert images["jcode"] == "vibepod/jcode:latest"
     assert images["freebuff"] == "vibepod/freebuff:latest"
     assert images["qwen"] == "vibepod/qwen:latest"
+    assert images["dsh"] == "vibepod/dsh:latest"
     assert images["datasette"] == "vibepod/datasette:latest"
     assert images["proxy"] == "vibepod/proxy:latest"
 
@@ -91,3 +93,16 @@ def test_qwen_image_override(monkeypatch) -> None:
     images = get_default_images()
 
     assert images["qwen"] == "example/qwen:dev"
+
+
+def test_dsh_default_image() -> None:
+    images = get_default_images()
+    assert images["dsh"] == "vibepod/dsh:latest"
+
+
+def test_dsh_image_override(monkeypatch) -> None:
+    monkeypatch.setenv("VP_IMAGE_DSH", "example/dsh:dev")
+
+    images = get_default_images()
+
+    assert images["dsh"] == "example/dsh:dev"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -95,11 +95,6 @@ def test_qwen_image_override(monkeypatch) -> None:
     assert images["qwen"] == "example/qwen:dev"
 
 
-def test_dsh_default_image() -> None:
-    images = get_default_images()
-    assert images["dsh"] == "vibepod/dsh:latest"
-
-
 def test_dsh_image_override(monkeypatch) -> None:
     monkeypatch.setenv("VP_IMAGE_DSH", "example/dsh:dev")
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -99,6 +99,7 @@ def test_agent_extra_volumes_for_other_agents(tmp_path: Path) -> None:
         "jcode",
         "freebuff",
         "qwen",
+        "dsh",
     ):
         assert run_cmd._agent_extra_volumes(agent, config_dir) == []
 
@@ -2482,3 +2483,72 @@ def test_run_prints_resume_hint_after_attach(
     run_cmd.run(agent="claude", workspace=tmp_path, detach=False)
 
     assert "vp run claude -- --resume abc-123" in capsys.readouterr().out
+
+
+def test_skills_mounts_for_dsh_use_agents_skills_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    local_root = tmp_path / "local-skills"
+    user_root = tmp_path / "user-skills"
+    skill_dir = local_root / "installed" / "example"
+    skill_dir.mkdir(parents=True)
+    user_root.mkdir()
+    (local_root / "skills-lock.json").write_text(
+        json.dumps({"skills": {"example": {"path": "installed/example"}}}),
+        encoding="utf-8",
+    )
+    (user_root / "skills-lock.json").write_text(json.dumps({"skills": {}}), encoding="utf-8")
+
+    monkeypatch.setattr(skills_engine, "local_skills_dir", lambda workspace: local_root)
+    monkeypatch.setattr(skills_engine, "user_skills_dir", lambda: user_root)
+
+    assert run_cmd._skills_mounts_for_agent("dsh", tmp_path) == [
+        (str(skill_dir.resolve()), "/config/.agents/skills/example", "ro"),
+    ]
+
+
+def test_web_ui_url_reads_published_binding() -> None:
+    ports = {"3081/tcp": [("127.0.0.1", "3080")]}
+    assert run_cmd._web_ui_url(3081, ports) == "http://127.0.0.1:3080"
+
+
+def test_web_ui_url_handles_bare_port_key_and_single_binding() -> None:
+    assert run_cmd._web_ui_url(3081, {"3081": "3080"}) == "http://127.0.0.1:3080"
+
+
+def test_web_ui_url_none_when_unpublished() -> None:
+    assert run_cmd._web_ui_url(3081, {}) is None
+    assert run_cmd._web_ui_url(None, {"3081/tcp": [("127.0.0.1", "3080")]}) is None
+
+
+def test_web_ui_url_none_for_ephemeral_host_ports() -> None:
+    # `"0:3081"`-style config is valid (daemon assigns an ephemeral port), but
+    # the host port isn't knowable from the bindings dict — print nothing.
+    assert run_cmd._web_ui_url(3081, {"3081": [None]}) is None
+    assert run_cmd._web_ui_url(3081, {"3081": ["0"]}) is None
+
+
+def test_web_ui_url_maps_wildcard_bind_address_to_loopback() -> None:
+    ports = {"3081": [("0.0.0.0", "3080")]}
+    assert run_cmd._web_ui_url(3081, ports) == "http://127.0.0.1:3080"
+
+
+def test_run_dsh_prints_preview_warning_and_web_ui_url(monkeypatch, tmp_path: Path) -> None:
+    """`vp run dsh` warns about developer-preview status and prints the Web UI URL."""
+    _CapturingDockerManager, _ = _make_capturing_docker_manager()
+
+    cfg = _make_config()
+    cfg["agents"]["dsh"] = {"env": {}, "init": [], "ports": ["127.0.0.1:3080:3081"]}
+    monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+
+    warnings: list[str] = []
+    successes: list[str] = []
+    monkeypatch.setattr(run_cmd, "warning", lambda msg: warnings.append(msg))
+    monkeypatch.setattr(run_cmd, "success", lambda msg: successes.append(msg))
+
+    run_cmd.run(agent="dsh", workspace=tmp_path, detach=True)
+
+    assert any("developer preview" in msg for msg in warnings)
+    assert any("http://127.0.0.1:3080" in msg for msg in successes)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2328,9 +2328,10 @@ def test_run_sets_default_term_when_host_term_missing(monkeypatch, tmp_path: Pat
 # ---------------------------------------------------------------------------
 
 
-def _make_capturing_docker_manager():
+def _make_capturing_docker_manager(container_attrs: dict | None = None):
     """Return a Docker manager stub that records run_agent kwargs."""
     captured: dict = {}
+    attrs = container_attrs or {"NetworkSettings": {"Networks": {}}}
 
     class _CapturingDockerManager:
         def ensure_network(self, name: str) -> None:
@@ -2354,7 +2355,7 @@ def _make_capturing_docker_manager():
                     "name": "vibepod-claude-test",
                     "id": "abc123",
                     "status": "running",
-                    "attrs": {"NetworkSettings": {"Networks": {}}},
+                    "attrs": attrs,
                     "reload": lambda self: None,
                     "labels": {},
                     "logs": lambda self, **kw: b"",
@@ -2532,6 +2533,49 @@ def test_web_ui_url_none_for_ephemeral_host_ports() -> None:
 def test_web_ui_url_maps_wildcard_bind_address_to_loopback() -> None:
     ports = {"3081": [("0.0.0.0", "3080")]}
     assert run_cmd._web_ui_url(3081, ports) == "http://127.0.0.1:3080"
+
+
+def test_web_ui_url_parses_inspected_docker_bindings() -> None:
+    # docker inspect NetworkSettings.Ports shape: HostIp/HostPort dicts. An
+    # ephemeral "0" request resolves to a real daemon-assigned port here.
+    ports = {"3081/tcp": [{"HostIp": "0.0.0.0", "HostPort": "53828"}]}
+    assert run_cmd._web_ui_url(3081, ports) == "http://127.0.0.1:53828"
+    assert run_cmd._web_ui_url(3081, {"3081/tcp": [{"HostIp": "", "HostPort": ""}]}) is None
+
+
+def test_web_ui_url_brackets_ipv6_hosts() -> None:
+    assert run_cmd._web_ui_url(3081, {"3081": [("::1", "3080")]}) == "http://[::1]:3080"
+    ports = {"3081/tcp": [{"HostIp": "::1", "HostPort": "3080"}]}
+    assert run_cmd._web_ui_url(3081, ports) == "http://[::1]:3080"
+    # Wildcard IPv6 stays mapped to loopback, unbracketed.
+    assert run_cmd._web_ui_url(3081, {"3081": [("::", "3080")]}) == "http://127.0.0.1:3080"
+
+
+def test_run_dsh_web_ui_url_prefers_inspected_ephemeral_binding(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """An ephemeral 0-port publish prints the daemon-assigned port from inspect."""
+    _CapturingDockerManager, _ = _make_capturing_docker_manager(
+        container_attrs={
+            "NetworkSettings": {
+                "Networks": {},
+                "Ports": {"3081/tcp": [{"HostIp": "127.0.0.1", "HostPort": "53828"}]},
+            },
+        },
+    )
+
+    cfg = _make_config()
+    cfg["agents"]["dsh"] = {"env": {}, "init": [], "ports": ["127.0.0.1:0:3081"]}
+    monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(run_cmd, "DockerManager", _CapturingDockerManager)
+
+    successes: list[str] = []
+    monkeypatch.setattr(run_cmd, "success", lambda msg: successes.append(msg))
+
+    run_cmd.run(agent="dsh", workspace=tmp_path, detach=True)
+
+    assert any("http://127.0.0.1:53828" in msg for msg in successes)
 
 
 def test_run_dsh_prints_preview_warning_and_web_ui_url(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -1139,3 +1139,67 @@ def test_task_create_auto_pull_failure_fallback_to_local_image(
     assert "Failed to pull latest image" in warnings[0]
     assert "Using existing local image" in warnings[0]
     assert stub.run_kwargs is not None
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.headless_command wiring (dsh)
+# ---------------------------------------------------------------------------
+
+
+def test_headless_command_set_for_dsh() -> None:
+    assert AGENT_SPECS["dsh"].headless_prefix is None
+    assert AGENT_SPECS["dsh"].headless_command == ["dsh", "--profile", "headless"]
+
+
+def test_task_create_dsh_uses_headless_profile(monkeypatch, tmp_path, tmp_task_store) -> None:
+    stub = _CapturingDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    warnings: list[str] = []
+    monkeypatch.setattr(task_cmd, "warning", lambda msg: warnings.append(msg))
+
+    task_cmd.task_create(agent="dsh", prompt="run tests", workspace=tmp_path)
+
+    assert stub.run_kwargs["command"] == ["dsh", "--profile", "headless", "run tests"]
+    assert any("developer preview" in m for m in warnings)
+
+
+def test_task_create_dsh_skips_web_port_publish(monkeypatch, tmp_path, tmp_task_store) -> None:
+    """Headless dsh tasks must not publish the Web UI port or start the forwarder.
+
+    A concurrently running `vp run dsh` holds host 3080; publishing it from a
+    task container would fail with port-already-allocated.
+    """
+    stub = _CapturingDockerManager()
+    cfg = _make_config()
+    cfg["agents"]["dsh"] = {"env": {}, "init": [], "ports": ["127.0.0.1:3080:3081"]}
+    monkeypatch.setattr(task_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    task_cmd.task_create(agent="dsh", prompt="run tests", workspace=tmp_path)
+
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["ports"] is None
+    assert "VIBEPOD_WEB_FORWARD_PORT" not in stub.run_kwargs["env"]
+
+
+def test_task_create_dsh_keeps_user_extra_ports(monkeypatch, tmp_path, tmp_task_store) -> None:
+    """Only the web port binding is dropped; user-configured extras survive."""
+    stub = _CapturingDockerManager()
+    cfg = _make_config()
+    cfg["agents"]["dsh"] = {
+        "env": {},
+        "init": [],
+        "ports": ["127.0.0.1:9999:9999", "127.0.0.1:3080:3081"],
+    }
+    monkeypatch.setattr(task_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    task_cmd.task_create(agent="dsh", prompt="run tests", workspace=tmp_path)
+
+    assert stub.run_kwargs is not None
+    ports = stub.run_kwargs["ports"]
+    assert ports is not None
+    assert all(key.split("/", 1)[0] != "3081" for key in ports)
+    assert any(key.split("/", 1)[0] == "9999" for key in ports)


### PR DESCRIPTION
Adds support for the DeepSeek Harness (`dsh`) agent throughout the VibePod project. It updates documentation, configuration, and code to recognize `dsh` as a first-class agent, including support for its Web UI, one-shot (headless) mode, and developer preview warnings. The changes also generalize agent handling to support agents with different one-shot invocation patterns and expose the published Web UI URL after container startup.

**New agent support:**

* Added `dsh` (DeepSeek Harness) as a supported agent everywhere agents are listed, including documentation, configuration (`VP_IMAGE_DSH`), and code constants.

**Command-line and agent invocation improvements:**

* Introduced `headless_command` and `web_container_port` to the `AgentSpec` class to support agents like `dsh` whose one-shot invocation differs from their interactive command, and to print the Web UI URL after startup.
* Added developer preview warnings for agents marked as such (currently `dsh`) in both `vp run` and `vp task create`.

**Configuration and aliasing:**

* Updated agent alias handling to include `ds` (`vp ds`), `deepseek`, and `deepseek-harness` as aliases for `dsh`. 
* Added default image and environment variable support for `dsh` (`VP_IMAGE_DSH`).

**Skills and one-shot support:**

* Updated skills mounting logic and documentation to support `dsh`. 
* Added `dsh` support to one-shot (headless) task mode and documented its invocation.


## Setup

Once started, the Agent opperates in the browser, not the CLI

<img width="981" height="554" alt="Screenshot from 2026-08-21 18-53-19" src="https://github.com/user-attachments/assets/13a47803-889c-4acc-8058-d90d16410d79" />

You need to configure the `workspace` directory as a Workspace, for this you cna click on the top bar and change the path:

<img width="981" height="554" alt="Screenshot from 2026-08-21 18-53-43" src="https://github.com/user-attachments/assets/74f3de6f-1c73-45c9-8ba8-5e72c3a96e72" />

Also you need to configure a model, I don't have a DeepSeek subscription, but I was able to connect it to my ollama server running `gemma4:12b-mlx` with the `openai` provider by setting a custom url, and by simply adding some random token. The model needs to be manually defined.

<img width="1072" height="840" alt="Screenshot from 2026-08-21 18-55-18" src="https://github.com/user-attachments/assets/978b0e28-bce7-40c4-b952-5fafbd15696a" />

Run example:

<img width="1425" height="1031" alt="Screenshot from 2026-08-21 18-58-28" src="https://github.com/user-attachments/assets/4a48f7fb-06e8-45d9-b241-184f576690b2" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added DeepSeek Harness support via `dsh`, `vp ds`, and DeepSeek aliases.
  - Added Web UI access with automatic startup URL display.
  - Added headless execution, session-resume guidance, image customization, and one-off port overrides.
- **Bug Fixes**
  - Improved headless task handling and Web UI port management.
  - Added compatibility warnings for preview functionality.
- **Documentation**
  - Expanded setup, configuration, authentication, customization, and usage guidance.
  - Added pip, Homebrew, conda/mamba, and pixi installation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->