### PR TITLE
Add -p/--publish flag to vp run for one-off port publishing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,6 +292,12 @@ agents:
 
 Like other agent keys, a project-level `ports` list replaces the global one for that agent. The list applies to both `vp run` and `vp task` containers; note that two containers cannot publish the same host port at the same time, so a fixed host port limits you to one such container per agent.
 
+For a one-off override, `vp run` (and the agent alias commands) accept a repeatable `-p/--publish` flag with the same syntax. When given, it replaces the resolved config list for that run — the last level of the defaults → global → project → CLI chain:
+
+```bash
+vp run claude -p 127.0.0.1:3090:3081 -p 6000:6000/udp
+```
+
 ## The built-in proxy
 
 VibePod starts a `vibepod-proxy` container alongside every agent. It acts as an HTTP(S) MITM proxy and logs all outbound requests to a SQLite database viewable in the Datasette UI (`vp logs start`).

--- a/src/vibepod/cli.py
+++ b/src/vibepod/cli.py
@@ -66,6 +66,17 @@ def run_command(
         list[str] | None,
         typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
     ] = None,
+    publish: Annotated[
+        list[str] | None,
+        typer.Option(
+            "-p",
+            "--publish",
+            help="Publish a container port in `docker run -p` syntax "
+            "(e.g. 127.0.0.1:3090:3081); replaces configured agents.<agent>.ports "
+            "for this run",
+            show_default=False,
+        ),
+    ] = None,
     name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
     network: Annotated[
         str | None,
@@ -100,6 +111,7 @@ def run_command(
         no_herdr=no_herdr,
         detach=detach,
         env=env,
+        publish=publish,
         name=name,
         network=network,
         paste_images=paste_images,
@@ -155,6 +167,17 @@ def _register_run_alias(command_name: str, agent_name: str) -> None:
             list[str] | None,
             typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
         ] = None,
+        publish: Annotated[
+            list[str] | None,
+            typer.Option(
+                "-p",
+                "--publish",
+                help="Publish a container port in `docker run -p` syntax "
+                "(e.g. 127.0.0.1:3090:3081); replaces configured agents.<agent>.ports "
+                "for this run",
+                show_default=False,
+            ),
+        ] = None,
         name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
         network: Annotated[
             str | None,
@@ -191,6 +214,7 @@ def _register_run_alias(command_name: str, agent_name: str) -> None:
             no_herdr=no_herdr,
             detach=detach,
             env=env,
+            publish=publish,
             name=name,
             network=network,
             paste_images=paste_images,

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -401,11 +401,14 @@ def run(
         **{str(k): str(v) for k, v in agent_cfg.get("env", {}).items()},
         **_parse_env_pairs(env or []),
     }
-    agent_ports: dict[str, Any] | None = _agent_port_bindings(selected_agent, agent_cfg) or None
+    # The flag replaces the resolved config list, mirroring the config chain's
+    # list-replace semantics (defaults -> global -> project -> CLI), so the
+    # replaced config list is never parsed or validated when the flag is given.
+    agent_ports: dict[str, Any] | None
     if publish:
-        # The flag replaces the resolved config list, mirroring the config
-        # chain's list-replace semantics (defaults -> global -> project -> CLI).
         agent_ports = _publish_port_bindings(publish, source="--publish") or None
+    else:
+        agent_ports = _agent_port_bindings(selected_agent, agent_cfg) or None
     if codex_oauth_login:
         # Tell the codex image to start the loopback forwarder, and publish it to
         # the host on the port Codex's redirect URI expects.

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -74,6 +74,9 @@ from vibepod.core.launch import (
     prepare_x11_auth as _prepare_x11_auth,
 )
 from vibepod.core.launch import (
+    publish_port_bindings as _publish_port_bindings,
+)
+from vibepod.core.launch import (
     read_claude_stored_token as _read_claude_stored_token,
 )
 from vibepod.core.launch import (
@@ -294,6 +297,17 @@ def run(
         list[str] | None,
         typer.Option("-e", "--env", help="Environment variable KEY=VALUE", show_default=False),
     ] = None,
+    publish: Annotated[
+        list[str] | None,
+        typer.Option(
+            "-p",
+            "--publish",
+            help="Publish a container port in `docker run -p` syntax "
+            "(e.g. 127.0.0.1:3090:3081); replaces configured agents.<agent>.ports "
+            "for this run",
+            show_default=False,
+        ),
+    ] = None,
     name: Annotated[str | None, typer.Option("--name", help="Custom container name")] = None,
     network: Annotated[
         str | None,
@@ -388,6 +402,10 @@ def run(
         **_parse_env_pairs(env or []),
     }
     agent_ports: dict[str, Any] | None = _agent_port_bindings(selected_agent, agent_cfg) or None
+    if publish:
+        # The flag replaces the resolved config list, mirroring the config
+        # chain's list-replace semantics (defaults -> global -> project -> CLI).
+        agent_ports = _publish_port_bindings(publish, source="--publish") or None
     if codex_oauth_login:
         # Tell the codex image to start the loopback forwarder, and publish it to
         # the host on the port Codex's redirect URI expects.

--- a/src/vibepod/core/launch.py
+++ b/src/vibepod/core/launch.py
@@ -134,7 +134,7 @@ def agent_init_commands(agent: str, agent_cfg: dict[str, Any]) -> list[str]:
     return commands
 
 
-def _check_publish_port(value: Any, *, minimum: int, agent: str, index: int, entry: str) -> None:
+def _check_publish_port(value: Any, *, minimum: int, source: str, index: int, entry: str) -> None:
     """Reject port numbers docker-py's syntax-only parser lets through.
 
     Catches YAML 1.1 sexagesimal surprises: an unquoted `3000:30` loads as the
@@ -145,17 +145,44 @@ def _check_publish_port(value: Any, *, minimum: int, agent: str, index: int, ent
     text = str(value)
     if text.isdigit() and not minimum <= int(text) <= 65535:
         raise typer.BadParameter(
-            f"Invalid agents.{agent}.ports[{index}] value '{entry}': "
+            f"Invalid {source}[{index}] value '{entry}': "
             f"port {text} is out of range {minimum}-65535.",
         )
 
 
-def agent_port_bindings(agent: str, agent_cfg: dict[str, Any]) -> dict[str, Any]:
-    """Read and validate per-agent published ports from config.
+def publish_port_bindings(items: list[Any], *, source: str) -> dict[str, Any]:
+    """Validate published-port entries and return docker-py port-bindings form.
 
     Entries use `docker run -p` syntax (`8000:8000`, `127.0.0.1:8080:80`,
-    `6000:6000/udp`, ...) and are returned in docker-py port-bindings form.
+    `6000:6000/udp`, ...); `source` names the origin in error messages
+    (`agents.<agent>.ports` or `--publish`).
     """
+    bindings: dict[str, Any] = {}
+    for index, item in enumerate(items, start=1):
+        if isinstance(item, bool) or not isinstance(item, (str, int)):
+            raise typer.BadParameter(
+                f"Invalid {source}[{index}] value, expected a string like '8000:8000'.",
+            )
+        entry = str(item).strip()
+        try:
+            parsed = build_port_bindings([entry])
+        except ValueError as exc:
+            raise typer.BadParameter(
+                f"Invalid {source}[{index}] value '{entry}': {exc}",
+            ) from exc
+        for internal, binds in parsed.items():
+            container_port = internal.split("/", 1)[0]
+            _check_publish_port(container_port, minimum=1, source=source, index=index, entry=entry)
+            for bind in binds:
+                host_port = bind[1] if isinstance(bind, tuple) else bind
+                # Host port 0 is valid: the daemon assigns an ephemeral port.
+                _check_publish_port(host_port, minimum=0, source=source, index=index, entry=entry)
+            bindings.setdefault(internal, []).extend(binds)
+    return bindings
+
+
+def agent_port_bindings(agent: str, agent_cfg: dict[str, Any]) -> dict[str, Any]:
+    """Read and validate per-agent published ports from config."""
     raw_ports = agent_cfg.get("ports", [])
     if raw_ports is None:
         return {}
@@ -170,28 +197,7 @@ def agent_port_bindings(agent: str, agent_cfg: dict[str, Any]) -> dict[str, Any]
             "expected a string like '8000:8000' or a list of them.",
         )
 
-    bindings: dict[str, Any] = {}
-    for index, item in enumerate(items, start=1):
-        if isinstance(item, bool) or not isinstance(item, (str, int)):
-            raise typer.BadParameter(
-                f"Invalid agents.{agent}.ports[{index}] value, expected a string like '8000:8000'.",
-            )
-        entry = str(item).strip()
-        try:
-            parsed = build_port_bindings([entry])
-        except ValueError as exc:
-            raise typer.BadParameter(
-                f"Invalid agents.{agent}.ports[{index}] value '{entry}': {exc}",
-            ) from exc
-        for internal, binds in parsed.items():
-            container_port = internal.split("/", 1)[0]
-            _check_publish_port(container_port, minimum=1, agent=agent, index=index, entry=entry)
-            for bind in binds:
-                host_port = bind[1] if isinstance(bind, tuple) else bind
-                # Host port 0 is valid: the daemon assigns an ephemeral port.
-                _check_publish_port(host_port, minimum=0, agent=agent, index=index, entry=entry)
-            bindings.setdefault(internal, []).extend(binds)
-    return bindings
+    return publish_port_bindings(items, source=f"agents.{agent}.ports")
 
 
 def init_entrypoint(init_commands: list[str]) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -326,6 +326,28 @@ def test_run_command_forwards_overlay_flags(monkeypatch) -> None:
     assert called["passthrough"] == []
 
 
+def test_run_and_alias_forward_publish_flag(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        called["agent"] = agent
+        called["publish"] = kwargs.get("publish")
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["run", "claude", "-p", "127.0.0.1:3090:3081"])
+    assert result.exit_code == 0
+    assert called["publish"] == ["127.0.0.1:3090:3081"]
+    assert called["passthrough"] == []
+
+    result = runner.invoke(app, ["claude", "-p", "8000:8000", "--publish", "6000:6000/udp"])
+    assert result.exit_code == 0
+    assert called["agent"] == "claude"
+    assert called["publish"] == ["8000:8000", "6000:6000/udp"]
+    assert called["passthrough"] == []
+
+
 def test_alias_forwards_overlay_flags(monkeypatch) -> None:
     called: dict[str, object] = {}
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -832,6 +832,27 @@ def test_run_publish_flag_replaces_configured_ports(monkeypatch, _tmp_config_roo
     }
 
 
+def test_run_publish_flag_bypasses_invalid_configured_ports(
+    monkeypatch,
+    _tmp_config_root,
+) -> None:
+    """A valid --publish override must not evaluate a malformed config list it replaces."""
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _PortCapturingManager()
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _ports_config("claude", ["not-a-port"]))
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    result = CliRunner().invoke(
+        app,
+        ["run", "claude", "-w", str(workspace), "--detach", "-p", "8000:8000"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["ports"] == {"8000": ["8000"]}
+
+
 def test_run_publish_flag_rejects_invalid_entry(monkeypatch, _tmp_config_root) -> None:
     workspace = _tmp_config_root / "workspace"
     workspace.mkdir()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -6,6 +6,7 @@ import builtins
 import importlib
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -798,6 +799,56 @@ def test_run_rejects_invalid_configured_ports(monkeypatch, _tmp_config_root) -> 
 
     assert result.exit_code != 0
     assert "agents.claude.ports" in result.output
+    assert stub.run_kwargs is None
+
+
+def test_run_publish_flag_replaces_configured_ports(monkeypatch, _tmp_config_root) -> None:
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _PortCapturingManager()
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _ports_config("claude", ["8000:8000"]))
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "claude",
+            "-w",
+            str(workspace),
+            "--detach",
+            "-p",
+            "127.0.0.1:3090:3081",
+            "-p",
+            "6000:6000/udp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert stub.run_kwargs is not None
+    assert stub.run_kwargs["ports"] == {
+        "3081": [("127.0.0.1", "3090")],
+        "6000/udp": ["6000"],
+    }
+
+
+def test_run_publish_flag_rejects_invalid_entry(monkeypatch, _tmp_config_root) -> None:
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _PortCapturingManager()
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _ports_config("claude", None))
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    result = CliRunner().invoke(
+        app,
+        ["run", "claude", "-w", str(workspace), "--detach", "-p", "70000:80"],
+    )
+
+    assert result.exit_code != 0
+    # Rich's option highlighter may inject color escapes inside "--publish"
+    # (e.g. on CI, where color is forced), so match on the de-styled text.
+    plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "--publish" in plain_output
     assert stub.run_kwargs is None
 
 


### PR DESCRIPTION
Adds support for a repeatable `--publish` (`-p`) flag to the `vp run` command and agent alias commands, allowing users to override the configured agent port mappings for a single run using Docker's `-p` syntax. The implementation includes validation, error handling, and comprehensive tests to ensure correct behavior and user feedback.

**New CLI feature:**

* Added a repeatable `-p/--publish` flag to `vp run` and agent alias commands, allowing users to specify port mappings in Docker's `-p` syntax for one-off overrides. This flag replaces the configured `agents.<agent>.ports` for that run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added repeatable `-p`/`--publish` options to `run` commands and agent aliases.
  - Supports TCP and UDP port mappings.
  - Explicit port mappings override configured ports for that run.

- **Bug Fixes**
  - Invalid port mappings are rejected with clear validation errors before execution.

- **Documentation**
  - Added usage guidance and examples for publishing ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->