### PR TITLE
docs(overlays): add ready-to-copy recipes page

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -283,7 +283,7 @@ vp list --running    # shows only running agents
 vp list --json       # machine-readable output
 ```
 
-When the current project has [overlays](../overlays.md), `vp list` adds a
+When the current project has [overlays](../overlays/index.md), `vp list` adds a
 **Project Overlays** table naming the overlay image each agent resolves to and
 whether it is already built.
 

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -67,5 +67,5 @@ API: send a `pane.report_agent` JSON request over the unix socket at
   that can run inside the container. Tau instead uses its installed Python
   runtime. Homebrew-on-Linux and musl-linked host binaries may not run in stock
   images; direct socket integrations avoid that dependency. For custom agents
-  without a compatible runtime, add one via an [overlay](overlays.md).
+  without a compatible runtime, add one via an [overlay](overlays/index.md).
 - `vp doctor herdr [agent]` diagnoses the whole chain from inside a pane.

--- a/docs/overlays/index.md
+++ b/docs/overlays/index.md
@@ -55,7 +55,7 @@ machine or may point outside the committed project.
 - `agents.<agent>.init` re-runs shell commands on **every** start — good for
   tiny setup, slow for package installs.
 - A custom image (`agents.<agent>.image`, see
-  [Customizing agent images](agents/index.md#overriding-the-image)) is fully
+  [Customizing agent images](../agents/index.md#overriding-the-image)) is fully
   manual: write a complete Dockerfile, build, tag, configure.
 - An overlay sits in between: persistent like a custom image, zero-ceremony
   like `init`.
@@ -75,3 +75,9 @@ machine or may point outside the committed project.
 
 Superseded overlay images for the same project and agent are removed
 automatically after each successful build.
+
+## Recipes
+
+Ready-to-copy fragments for common needs — apt packages, Python requirements,
+the pixi package manager, a PDF/OCR toolchain — live on the
+[recipes page](recipes.md).

--- a/docs/overlays/recipes.md
+++ b/docs/overlays/recipes.md
@@ -1,0 +1,131 @@
+# Overlay recipes
+
+Ready-to-copy overlay fragments for common needs. Each recipe is a `FROM`-less
+Dockerfile: drop it into `.vibepod/overlay/Dockerfile` to apply it to every
+agent in the project, or into `.vibepod/overlay/<agent>/Dockerfile` for a
+single agent. See the [overview](index.md) for how overlays are built and
+cached.
+
+Fragments compose — a single `Dockerfile` can combine several recipes.
+
+## apt packages
+
+System packages from the distribution repositories. The smallest useful
+overlay.
+
+```dockerfile
+# .vibepod/overlay/Dockerfile — no FROM line
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        jq ripgrep sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+- `--no-install-recommends` and the `apt` list cleanup keep the overlay image
+  small.
+- Agent base images are Debian-based; swap in `apk`/`dnf` only if you have
+  overridden the base image with something else.
+
+## Python requirements
+
+The overlay directory is the docker build context, so a fragment can `COPY`
+files committed next to it.
+
+```text
+.vibepod/overlay/
+├── Dockerfile
+└── requirements.txt
+```
+
+```dockerfile
+# .vibepod/overlay/Dockerfile — no FROM line
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+```
+
+Editing `requirements.txt` changes the overlay hash, so the image rebuilds on
+the next run — no manual invalidation needed.
+
+## pixi package manager
+
+[pixi](https://pixi.sh) gives agents on-demand access to the conda-forge
+ecosystem — PDF tools, image libraries, scientific stacks — without root or a
+rebuild at runtime (`pixi init && pixi add poppler`). From
+[issue #140](https://github.com/VibePod/vibepod-cli/issues/140).
+
+```dockerfile
+# .vibepod/overlay/Dockerfile — no FROM line
+ADD https://github.com/prefix-dev/pixi/releases/download/v0.76.2/pixi-x86_64-unknown-linux-musl.tar.gz /tmp/pixi.tar.gz
+RUN mkdir -p /opt/pixi/bin && tar -xzf /tmp/pixi.tar.gz -C /opt/pixi/bin && rm /tmp/pixi.tar.gz
+ENV PATH="/opt/pixi/bin:${PATH}"
+```
+
+- **`ADD` from URL instead of `curl | bash`** — works even when the base image
+  ships no curl.
+- **Fixed path `/opt/pixi` instead of `$HOME/.pixi`** — several agents
+  override `HOME` at runtime, so a build-time `~` would not resolve to the
+  same place. `ENV PATH` persists in the image config regardless of `HOME`.
+- **Pinned version** — with `latest`, the overlay cache keeps whatever pixi
+  version the first build downloaded until the fragment text changes.
+- **Architecture** — the URL above is x86_64; on an arm64 host (Apple
+  silicon), use the `pixi-aarch64-unknown-linux-musl.tar.gz` tarball. For a
+  fragment that works on both, pick the tarball at build time with `uname -m`
+  (matches pixi's tarball naming; requires curl in the base image). Overlays
+  build with the classic builder, so BuildKit's `TARGETARCH` arg is not
+  available:
+
+    ```dockerfile
+    RUN mkdir -p /opt/pixi/bin && \
+        curl -fsSL "https://github.com/prefix-dev/pixi/releases/download/v0.76.2/pixi-$(uname -m)-unknown-linux-musl.tar.gz" \
+        | tar -xz -C /opt/pixi/bin
+    ENV PATH="/opt/pixi/bin:${PATH}"
+    ```
+
+## pixi + PDF/OCR toolchain
+
+A real-world fragment by [@ReimarBauer](https://github.com/ReimarBauer) from
+[issue #140](https://github.com/VibePod/vibepod-cli/issues/140): pixi with
+checksum verification, plus a pre-built environment with poppler, qpdf,
+ghostscript, and tesseract for PDF and OCR work. Described in his
+[blog post on local AI-assisted PDF processing](https://www.fz-juelich.de/de/blogs/programmiere/lokale-ki-gestuetzte-pdf-verarbeitung-vibepod-pi-lm-studio-und-pixi).
+
+```dockerfile
+# .vibepod/overlay/Dockerfile — no FROM line
+ENV PIXI_HOME=/opt/pixi
+
+# Download pixi binary + official SHA256 checksum via Docker ADD (no curl/wget needed)
+ADD https://github.com/prefix-dev/pixi/releases/latest/download/pixi-aarch64-unknown-linux-musl.tar.gz /tmp/pixi.tar.gz
+ADD https://github.com/prefix-dev/pixi/releases/latest/download/pixi-aarch64-unknown-linux-musl.tar.gz.sha256 /tmp/pixi.sha256
+
+# Verify checksum with sha256sum -c, then extract to $PIXI_HOME/bin
+RUN set -ex && \
+    cd /tmp && \
+    sed 's|pixi-aarch64-unknown-linux-musl.tar.gz|/tmp/pixi.tar.gz|g' pixi.sha256 | sha256sum -c - && \
+    mkdir -p ${PIXI_HOME}/bin && \
+    tar xzf /tmp/pixi.tar.gz -C ${PIXI_HOME}/bin && \
+    chmod +x ${PIXI_HOME}/bin/pixi && \
+    rm -f /tmp/pixi.tar.gz /tmp/pixi.sha256
+
+ENV PATH=/opt/pixi/bin:$PATH
+RUN pixi --version
+
+# Create vp_pixi project at /opt/vp_pixi (/opt to avoid overwriting user pixi installations)
+RUN mkdir -p /opt/vp_pixi
+WORKDIR /opt/vp_pixi
+RUN pixi init
+
+# Install PDF tools + OCR: poppler, qpdf, ghostscript, tesseract (all with checksum verification)
+RUN pixi add poppler qpdf ghostscript tesseract
+
+ENV PATH=/opt/vp_pixi/.pixi/envs/default/bin:$PATH
+```
+
+- Targets an arm64 host; on x86_64 replace `aarch64` with `x86_64` in both
+  `ADD` URLs and the `sed` pattern.
+- Uses `latest`; pin a release (as in the previous recipe) for
+  reproducibility.
+
+## Contributing a recipe
+
+Got an overlay other projects could reuse? Open an issue or PR with the
+fragment and a line on what it is for — this page is meant to grow from
+real-world use.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,9 @@ nav:
     - Overview: skills/index.md
     - Locator format: skills/locators.md
     - Authoring: skills/authoring.md
-  - Project overlays: overlays.md
+  - Project overlays:
+    - Overview: overlays/index.md
+    - Recipes: overlays/recipes.md
   - Herdr integration: herdr.md
   - Configuration: configuration.md
   - LLM Integration: llm.md


### PR DESCRIPTION
Collect overlay fragments users can copy directly: apt packages, pip requirements, pixi package manager, and a checksum-verified pixi + PDF/OCR toolchain contributed by @ReimarBauer. Move overlays.md to overlays/index.md (rendered URL unchanged) so the section can grow.

Refs #140