### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vibepod"
-version = "0.20.1"
+version = "0.21.0"
 description = "One CLI for containerized AI coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/vibepod/__init__.py
+++ b/src/vibepod/__init__.py
@@ -1,3 +1,3 @@
 """VibePod package."""
 
-__version__ = "0.20.1"
+__version__ = "0.21.0"

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from platformdirs import user_config_dir
 
 APP_NAME = "vibepod"
-VERSION = "0.20.1"
+VERSION = "0.21.0"
 
 CONFIG_DIR = Path(user_config_dir(APP_NAME))
 GLOBAL_CONFIG_FILE = CONFIG_DIR / "config.yaml"


### PR DESCRIPTION
This pull request updates the version of the VibePod package from 0.20.1 to 0.21.0 across the project files to ensure consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application and package version to **0.21.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->