### PR TITLE
Hermes agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ directory only via the `skills.external_dirs` key in its own `config.yaml` and
 has no env-var override, so the `vibepod-agents` image entrypoint seeds the key
 rather than the CLI mounting a symlink.
 
+Hermes also has two launch constraints enforced by `validate_rootless_runtime`
+and the ACP reserved-path check: it is rejected on rootless Podman (the pinned
+image needs its own runtime user and rejects the UID rootless keep-id maps the
+container to, including 0), and `/opt/hermes` (its install root) is reserved so
+an `--acp` workspace bind cannot shadow the entrypoint/venv/`hermes-acp`.
+
 ## Tests
 
 Runner is `pytest` (`python -m pytest`); CI also validates default images with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ ACP adapter, see `docs/acp.md`), the per-agent defaults in
 The local-image fallback (`VP_IMAGE_<AGENT>` override + pull-failure fallback
 in `run.py`/`task.py`) is how an unreleased image is exercised locally.
 
+Hermes is the exception to the `~/.agents/skills` convention: it reads that
+directory only via the `skills.external_dirs` key in its own `config.yaml` and
+has no env-var override, so the `vibepod-agents` image entrypoint seeds the key
+rather than the CLI mounting a symlink.
+
 ## Tests
 
 Runner is `pytest` (`python -m pytest`); CI also validates default images with

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ Run `vp config allow-dir /path/to/project` once first (the editor's stdin is a p
   <a href="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/freebuff.png"><img src="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/freebuff.png" alt="Freebuff" width="180" /></a>
   <a href="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/qwen.png"><img src="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/qwen.png" alt="Qwen Code" width="180" /></a>
   <a href="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/dsh.png"><img src="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/dsh.png" alt="DeepSeek Harness" width="180" /></a>
-  <a href="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/hermes.png"><img src="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/hermes.png" alt="Hermes Agent" width="180" /></a>
 </p>
 
 ## Current Status

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ VP_IMAGE_JCODE=vibepod/jcode:latest vp run jcode
 VP_IMAGE_FREEBUFF=vibepod/freebuff:latest vp run freebuff
 VP_IMAGE_QWEN=vibepod/qwen:latest vp run qwen
 VP_IMAGE_DSH=vibepod/dsh:latest vp run dsh
+VP_IMAGE_HERMES=vibepod/hermes:latest vp run hermes
 VP_DATASETTE_IMAGE=vibepod/datasette:latest vp logs start
 VP_SKILLS_ENGINE_IMAGE=vibepod/skills-engine:latest vp skills list
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tracking, and an analytics dashboard to monitor and compare agents side-by-side.
 
 - ⚡ **Zero config** — no setup required; `vp run <agent>` just works. Optional YAML for custom configuration
 - 🐳 **Isolated agents** — each agent runs in its own Docker or Podman container
-- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau, Jcode, Freebuff, Qwen, dsh & more
+- 🔀 **Unified interface** — one CLI for Claude, Gemini, Codex, Devstral/Vibe, Copilot, Auggie, Pi, Agy, Tau, Jcode, Freebuff, Qwen, dsh, Hermes & more
 - 🧩 **Skills** — install reusable prompt recipes per-project or per-user with `vp skills add`
 - 🧱 **Project overlays** — commit a `FROM`-less Dockerfile fragment in `.vibepod/overlay/` and VibePod auto-builds a cached, content-addressed image layer on top of the agent's base image — one clearly named image per project and agent ([docs](https://vibepod.dev/docs/overlays/))
 - 📊 **Local analytics dashboard** — track usage and HTTP traffic per agent, plus token metrics
@@ -91,6 +91,7 @@ Use `--ikwid` to append each agent's auto-approval / permission-skip flag when s
 | `freebuff`          | Not supported                                |
 | `qwen`              | `--approval-mode=yolo`                       |
 | `dsh`               | Not supported                                |
+| `hermes`            | `--yolo`                                     |
 
 ## Editor integration (`--acp`)
 
@@ -183,6 +184,7 @@ Current defaults:
 - `freebuff` -> `vibepod/freebuff:latest`
 - `qwen` -> `vibepod/qwen:latest`
 - `dsh` -> `vibepod/dsh:latest`
+- `hermes` -> `vibepod/hermes:latest`
 - `datasette` -> `vibepod/datasette:latest`
 - `proxy` -> `vibepod/proxy:latest` ([repo](https://github.com/VibePod/vibepod-proxy))
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Use `--ikwid` to append each agent's auto-approval / permission-skip flag when s
 
 ## Editor integration (`--acp`)
 
-`vp run <agent> --acp` turns VibePod into an [Agent Client Protocol](https://agentclientprotocol.com/) adapter, so the containerized agent appears directly in the AI panel of any editor with ACP support (e.g. [Zed](https://zed.dev/docs/ai/external-agents)) — with isolation, profiles, overlays and proxy metrics intact. Supported out of the box: `claude`, `gemini`, `qwen`, `codex`, `opencode`, `copilot`, `auggie`, `jcode`, `devstral` and `pi`.
+`vp run <agent> --acp` turns VibePod into an [Agent Client Protocol](https://agentclientprotocol.com/) adapter, so the containerized agent appears directly in the AI panel of any editor with ACP support (e.g. [Zed](https://zed.dev/docs/ai/external-agents)) — with isolation, profiles, overlays and proxy metrics intact. Supported out of the box: `claude`, `gemini`, `qwen`, `codex`, `opencode`, `copilot`, `auggie`, `jcode`, `devstral`, `hermes` and `pi`.
 
 Register `vp` as a custom/external agent server in your editor. Zed example (`settings.json`):
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Run `vp config allow-dir /path/to/project` once first (the editor's stdin is a p
   <a href="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/freebuff.png"><img src="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/freebuff.png" alt="Freebuff" width="180" /></a>
   <a href="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/qwen.png"><img src="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/qwen.png" alt="Qwen Code" width="180" /></a>
   <a href="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/dsh.png"><img src="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/dsh.png" alt="DeepSeek Harness" width="180" /></a>
+  <a href="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/hermes.png"><img src="https://raw.githubusercontent.com/VibePod/vibepod-cli/main/docs/assets/hermes.png" alt="Hermes Agent" width="180" /></a>
 </p>
 
 ## Current Status

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -10,7 +10,7 @@ metric collection — stays active.
 
 ## Supported agents
 
-Ten agents ship an ACP adapter command. They split into two kinds, which
+Eleven agents ship an ACP adapter command. They split into two kinds, which
 differ in what has to happen before the first JSON-RPC frame:
 
 | Agent      | Adapter                                     |
@@ -22,11 +22,12 @@ differ in what has to happen before the first JSON-RPC frame:
 | `gemini`   | `gemini --experimental-acp` — built in       |
 | `qwen`     | `qwen --experimental-acp` — built in         |
 | `devstral` | `vibe-acp` — separate binary in the image    |
+| `hermes`   | `hermes-acp` — separate binary in the image  |
 | `claude`   | `npx @agentclientprotocol/claude-agent-acp`  |
 | `codex`    | `npx @agentclientprotocol/codex-acp`         |
 | `pi`       | `npx pi-acp` — community adapter             |
 
-The first seven run a binary that is already in the image, so they start
+The first eight run a binary that is already in the image, so they start
 offline and immediately. `claude`, `codex` and `pi` fetch their adapter with
 npx, which needs the package registry reachable through the proxy filter and
 adds startup latency: `claude` and `codex` download on every launch, `pi`

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -20,10 +20,11 @@ VibePod manages each agent as a Docker or Podman container. Credentials and conf
 | `freebuff` | CodebuffAI | `vp fb` | `vibepod/freebuff:latest` |
 | `qwen` | Qwen (Alibaba) | `vp q` | `vibepod/qwen:latest` |
 | `dsh` (DeepSeek Harness) | DeepSeek | `vp ds` | `vibepod/dsh:latest` |
+| `hermes` (alias: `nous`) | Nous Research | `vp h` | `vibepod/hermes:latest` |
 
 Alias note: `vp run vibe` resolves to `vp run devstral`, `vp run qwen-cli`
-resolves to `vp run qwen`, and `vp run deepseek` / `vp run deepseek-harness`
-resolve to `vp run dsh`.
+resolves to `vp run qwen`, `vp run deepseek` / `vp run deepseek-harness`
+resolve to `vp run dsh`, and `vp run nous` resolves to `vp run hermes`.
 
 ## DeepSeek Harness (`dsh`) — Web UI agent
 
@@ -157,7 +158,7 @@ agents:
 
 ## Image customization workflows
 
-VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`, `tau`, `jcode`, `freebuff`, `qwen`, `dsh`). The CLI also supports the aliases `vibe` (→ `devstral`), `qwen-cli` (→ `qwen`), and `deepseek` / `deepseek-harness` (→ `dsh`). Image customization means changing the image used for one of those IDs.
+VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`, `tau`, `jcode`, `freebuff`, `qwen`, `dsh`, `hermes`). The CLI also supports the aliases `vibe` (→ `devstral`), `qwen-cli` (→ `qwen`), `deepseek` / `deepseek-harness` (→ `dsh`), and `nous` (→ `hermes`). Image customization means changing the image used for one of those IDs.
 
 ### 1. Extend an existing image for an agent
 
@@ -288,6 +289,7 @@ Use `--ikwid` to enable each agent's built-in auto-approval / permission-skip mo
 | `freebuff` | Not supported |
 | `qwen` | `--approval-mode=yolo` |
 | `dsh` | Not supported |
+| `hermes` | `--yolo` |
 
 Example:
 
@@ -407,6 +409,7 @@ Task mode applies a finite timeout by default: **2 hours**. Override it per task
 | `jcode` | `jcode run "<prompt>"` |
 | `qwen` | `qwen -p "<prompt>"` |
 | `dsh` | `dsh --profile headless "<prompt>"` |
+| `hermes` | `hermes -z "<prompt>"` |
 
 Other agents error with a clear message; support can be added by setting `headless_prefix` (or `headless_command` for agents whose one-shot invocation differs from their interactive command) on their `AgentSpec`.
 
@@ -1121,4 +1124,45 @@ already mounted.
 ```bash
 vp run qwen --ikwid
 vp task create qwen "fix the failing test" --ikwid
+```
+
+## Hermes Agent (`hermes`) — developer preview
+
+Hermes is Nous Research's self-improving agent: it keeps cross-session memory,
+writes its own skills, and is not primarily a coding TUI. VibePod runs its
+interactive CLI; the `gateway` daemon, cron jobs and messaging bridges are out
+of scope.
+
+`vp run hermes` starts the classic Python REPL. The Ink TUI is available with
+`vp run hermes -- --tui`.
+
+> The default `vibepod/hermes` image pins an exact PyPI version, which trails
+> upstream's git main. Hermes is pre-1.0, so `vp run` and `vp task` print a
+> developer-preview warning.
+
+**First run.** Hermes has no usable provider until it is given credentials. Run
+`hermes setup` once inside the container — it persists to the mounted config at
+`~/.config/vibepod/agents/hermes/.hermes/` — or pass an OpenAI-compatible
+endpoint through VibePod's LLM wiring, which maps to `OPENAI_BASE_URL` and
+`OPENAI_API_KEY`.
+
+**Headless one-shot:**
+
+```bash
+vp task create hermes "summarize this repository"
+```
+
+**Skills.** Hermes scans `~/.agents/skills/` only when `skills.external_dirs`
+is set in its `config.yaml` — there is no environment-variable override — so
+the image entrypoint seeds that key on first start. Skills installed via
+`vp skills` are then mounted at `/config/.agents/skills/<id>` and picked up
+automatically. Editing `external_dirs` yourself disables the seeding; VibePod
+never overwrites a value you set.
+
+**IKWID mode.** Hermes auto-approves tool calls in YOLO mode, which `--ikwid`
+enables via `--yolo`:
+
+```bash
+vp run hermes --ikwid
+vp task create hermes "fix the failing test" --ikwid
 ```

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1165,6 +1165,20 @@ setup remains supported; VibePod does not rewrite Hermes's saved settings.
 vp task create hermes "summarize this repository"
 ```
 
+**Write sandbox.** Hermes restricts its `write_file`/`patch` tools to the
+directory prefixes in `HERMES_WRITE_SAFE_ROOT`. The official image ships
+`/opt/data` alone, which would leave the project mount read-only, so VibePod
+sets `/opt/data:/workspace`. With `--acp` the workspace host path is appended
+too, because editors send absolute host paths. To widen it further, extend the
+value rather than replacing it — VibePod appends to whatever you set:
+
+```yaml
+agents:
+  hermes:
+    env:
+      HERMES_WRITE_SAFE_ROOT: "/opt/data:/workspace:/extra/path"
+```
+
 **Editor integration.** Hermes ships its own ACP adapter as the separate
 `hermes-acp` console script, which the official image already provides, so
 `vp run hermes --acp` works in any ACP editor — see the [ACP docs](../acp.md).

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -20,11 +20,11 @@ VibePod manages each agent as a Docker or Podman container. Credentials and conf
 | `freebuff` | CodebuffAI | `vp fb` | `vibepod/freebuff:latest` |
 | `qwen` | Qwen (Alibaba) | `vp q` | `vibepod/qwen:latest` |
 | `dsh` (DeepSeek Harness) | DeepSeek | `vp ds` | `vibepod/dsh:latest` |
-| `hermes` (alias: `nous`) | Nous Research | `vp h` | `vibepod/hermes:latest` |
+| `hermes` | Nous Research | `vp h` | `vibepod/hermes:latest` |
 
 Alias note: `vp run vibe` resolves to `vp run devstral`, `vp run qwen-cli`
-resolves to `vp run qwen`, `vp run deepseek` / `vp run deepseek-harness`
-resolve to `vp run dsh`, and `vp run nous` resolves to `vp run hermes`.
+resolves to `vp run qwen`, and `vp run deepseek` / `vp run deepseek-harness`
+resolve to `vp run dsh`.
 
 ## DeepSeek Harness (`dsh`) — Web UI agent
 
@@ -158,7 +158,7 @@ agents:
 
 ## Image customization workflows
 
-VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`, `tau`, `jcode`, `freebuff`, `qwen`, `dsh`, `hermes`). The CLI also supports the aliases `vibe` (→ `devstral`), `qwen-cli` (→ `qwen`), `deepseek` / `deepseek-harness` (→ `dsh`), and `nous` (→ `hermes`). Image customization means changing the image used for one of those IDs.
+VibePod has a fixed set of supported agent IDs (`claude`, `gemini`, `opencode`, `devstral`, `auggie`, `copilot`, `codex`, `pi`, `agy`, `tau`, `jcode`, `freebuff`, `qwen`, `dsh`, `hermes`). The CLI also supports the aliases `vibe` (→ `devstral`), `qwen-cli` (→ `qwen`), and `deepseek` / `deepseek-harness` (→ `dsh`). Image customization means changing the image used for one of those IDs.
 
 ### 1. Extend an existing image for an agent
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1136,8 +1136,6 @@ of scope.
 `vp run hermes` starts the classic Python REPL. The Ink TUI is available with
 `vp run hermes -- --tui`.
 
-![Hermes Agent running in VibePod](../assets/hermes.png)
-
 > The default `vibepod/hermes` image is built on the official
 > `nousresearch/hermes-agent` image and pins one of its CalVer release tags
 > (`v2026.9.7`). Upstream no longer publishes to PyPI, so the image tracks the
@@ -1158,6 +1156,14 @@ prioritizes saved provider settings, does not use `OPENAI_BASE_URL` for its
 main custom-provider endpoint, and restricts API keys by endpoint host. Its
 ACP adapter also has no provider/model launch flags. Hermes-native provider
 setup remains supported; VibePod does not rewrite Hermes's saved settings.
+
+**Rootless Podman is not supported.** The pinned Hermes image needs its own
+runtime user and exits before showing any output when launched under
+rootless Podman's `keep-id` user mapping, which VibePod uses for most agents.
+On a rootless Podman engine, `vp run hermes` and `vp task create hermes`
+(affecting interactive, task, and ACP) reject the launch before
+starting a container rather than crashing mid-boot. Run Hermes on rootful
+Docker or Podman instead.
 
 **Headless one-shot:**
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1136,6 +1136,8 @@ of scope.
 `vp run hermes` starts the classic Python REPL. The Ink TUI is available with
 `vp run hermes -- --tui`.
 
+![Hermes Agent running in VibePod](../assets/hermes.png)
+
 > The default `vibepod/hermes` image is built on the official
 > `nousresearch/hermes-agent` image and pins one of its CalVer release tags
 > (`v2026.9.7`). Upstream no longer publishes to PyPI, so the image tracks the
@@ -1145,8 +1147,17 @@ of scope.
 **First run.** Hermes has no usable provider until it is given credentials. Run
 `hermes setup` once inside the container — it persists to the mounted config at
 `~/.config/vibepod/agents/hermes/`, which is the container's `/opt/data` state
-volume — or pass an OpenAI-compatible endpoint through VibePod's LLM wiring,
-which maps to `OPENAI_BASE_URL` and `OPENAI_API_KEY`.
+volume. Configure OpenAI-compatible endpoints through Hermes's own provider
+setup too.
+
+**Global LLM wiring is not supported.** Set `llm.enabled: false` in your
+VibePod configuration when running Hermes. Interactive, task, and ACP launches
+reject enabled global LLM wiring before starting a container, rather than
+silently using a different provider or model. The pinned Hermes runtime
+prioritizes saved provider settings, does not use `OPENAI_BASE_URL` for its
+main custom-provider endpoint, and restricts API keys by endpoint host. Its
+ACP adapter also has no provider/model launch flags. Hermes-native provider
+setup remains supported; VibePod does not rewrite Hermes's saved settings.
 
 **Headless one-shot:**
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1136,15 +1136,17 @@ of scope.
 `vp run hermes` starts the classic Python REPL. The Ink TUI is available with
 `vp run hermes -- --tui`.
 
-> The default `vibepod/hermes` image pins an exact PyPI version, which trails
-> upstream's git main. Hermes is pre-1.0, so `vp run` and `vp task` print a
-> developer-preview warning.
+> The default `vibepod/hermes` image is built on the official
+> `nousresearch/hermes-agent` image and pins one of its CalVer release tags
+> (`v2026.9.7`). Upstream no longer publishes to PyPI, so the image tracks the
+> Docker release line instead. Hermes is pre-1.0, so `vp run` and `vp task`
+> print a developer-preview warning.
 
 **First run.** Hermes has no usable provider until it is given credentials. Run
 `hermes setup` once inside the container — it persists to the mounted config at
-`~/.config/vibepod/agents/hermes/.hermes/` — or pass an OpenAI-compatible
-endpoint through VibePod's LLM wiring, which maps to `OPENAI_BASE_URL` and
-`OPENAI_API_KEY`.
+`~/.config/vibepod/agents/hermes/`, which is the container's `/opt/data` state
+volume — or pass an OpenAI-compatible endpoint through VibePod's LLM wiring,
+which maps to `OPENAI_BASE_URL` and `OPENAI_API_KEY`.
 
 **Headless one-shot:**
 
@@ -1153,16 +1155,15 @@ vp task create hermes "summarize this repository"
 ```
 
 **Editor integration.** Hermes ships its own ACP adapter as the separate
-`hermes-acp` console script (the image installs the package's `[acp]` extra
-that the adapter needs), so `vp run hermes --acp` works in any ACP editor —
-see the [ACP docs](../acp.md).
+`hermes-acp` console script, which the official image already provides, so
+`vp run hermes --acp` works in any ACP editor — see the [ACP docs](../acp.md).
 
 **Skills.** Hermes scans `~/.agents/skills/` only when `skills.external_dirs`
 is set in its `config.yaml` — there is no environment-variable override — so
-the image entrypoint seeds that key on first start. Skills installed via
-`vp skills` are then mounted at `/config/.agents/skills/<id>` and picked up
-automatically. Editing `external_dirs` yourself disables the seeding; VibePod
-never overwrites a value you set.
+the image seeds that key on every start. Skills installed via `vp skills` are
+then mounted at `/opt/data/.agents/skills/<id>` and picked up automatically.
+Editing `external_dirs` yourself disables the seeding; VibePod never
+overwrites a value you set.
 
 **IKWID mode.** Hermes auto-approves tool calls in YOLO mode, which `--ikwid`
 enables via `--yolo`:

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1152,6 +1152,11 @@ endpoint through VibePod's LLM wiring, which maps to `OPENAI_BASE_URL` and
 vp task create hermes "summarize this repository"
 ```
 
+**Editor integration.** Hermes ships its own ACP adapter as the separate
+`hermes-acp` console script (the image installs the package's `[acp]` extra
+that the adapter needs), so `vp run hermes --acp` works in any ACP editor —
+see the [ACP docs](../acp.md).
+
 **Skills.** Hermes scans `~/.agents/skills/` only when `skills.external_dirs`
 is set in its `config.yaml` — there is no environment-variable override — so
 the image entrypoint seeds that key on first start. Skills installed via

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,14 @@ agents:
       - "127.0.0.1:3080:3081" # Web UI; container side must stay 3081
     init: []
 
+  hermes:
+    enabled: true
+    image: vibepod/hermes:latest
+    env: {}
+    volumes: []
+    ports: []
+    init: []
+
 # Connect agents to a local or remote LLM server (Ollama, vLLM, etc.)
 llm:
   enabled: false
@@ -235,6 +243,7 @@ Each agent image can be overridden individually:
 | `VP_IMAGE_FREEBUFF`      | freebuff                            |
 | `VP_IMAGE_QWEN`          | qwen                                |
 | `VP_IMAGE_DSH`           | dsh                                 |
+| `VP_IMAGE_HERMES`        | hermes                              |
 | `VP_DATASETTE_IMAGE`     | datasette (logs UI)                 |
 | `VP_PROXY_IMAGE`         | proxy                               |
 | `VP_SKILLS_ENGINE_IMAGE` | skills-engine (used by `vp skills`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker 
 | `freebuff`                 | CodebuffAI     | `vp fb`  |
 | `qwen`                     | Qwen (Alibaba) | `vp q`   |
 | `dsh` (DeepSeek Harness)   | DeepSeek       | `vp ds`  |
+| `hermes` (alias: `nous`)   | Nous Research  | `vp h`   |
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ VibePod (`vp`) lets you run any supported AI coding agent in an isolated Docker 
 | `freebuff`                 | CodebuffAI     | `vp fb`  |
 | `qwen`                     | Qwen (Alibaba) | `vp q`   |
 | `dsh` (DeepSeek Harness)   | DeepSeek       | `vp ds`  |
-| `hermes` (alias: `nous`)   | Nous Research  | `vp h`   |
+| `hermes`   | Nous Research  | `vp h`   |
 
 ## Next Steps
 

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -189,6 +189,22 @@ def _acp_workspace_mount_path(workspace_path: PurePath, spec: AgentSpec) -> str:
     return host_path
 
 
+def _extend_write_roots(env: dict[str, str], var: str, paths: list[str | None]) -> None:
+    """Append *paths* to the os.pathsep-joined write-root list in ``env[var]``.
+
+    Extends rather than replaces, so a value the user set through
+    ``agents.<agent>.env`` or ``-e`` keeps its entries, and skips duplicates so
+    repeated calls stay idempotent. Used for ``--acp``, where the editor sends
+    absolute host paths that the agent's file sandbox must also allow.
+    """
+    existing = [root for root in env.get(var, "").split(os.pathsep) if root]
+    for path in paths:
+        if path and path not in existing:
+            existing.append(path)
+    if existing:
+        env[var] = os.pathsep.join(existing)
+
+
 def _is_safe_skill_id(skill_id: str) -> bool:
     """Return True for skill IDs safe to use as one container path segment."""
     return bool(_SAFE_SKILL_ID_RE.fullmatch(skill_id))
@@ -710,6 +726,16 @@ def run(
         agent_ports = _publish_port_bindings(publish, source="--publish") or None
     else:
         agent_ports = _agent_port_bindings(selected_agent, agent_cfg) or None
+    if spec.write_roots_env and acp_workspace_mount is not None:
+        # In ACP mode the workspace is also bound at its own host path, and the
+        # editor sends that spelling, so the agent's file sandbox has to allow
+        # it alongside /workspace. Merged after the user's env so an override
+        # is extended, not discarded.
+        _extend_write_roots(
+            merged_env,
+            spec.write_roots_env,
+            [acp_workspace_mount, acp_workspace_alias],
+        )
     if codex_oauth_login:
         # Tell the codex image to start the loopback forwarder, and publish it to
         # the host on the port Codex's redirect URI expects.

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -624,6 +624,15 @@ def run(
 
     _reexec_with_herdr_hint(selected_agent, config, no_herdr=no_herdr or acp)
 
+    # Reject unsupported wiring before any herdr hint or workspace processing:
+    # the allow-dir prompt below persists a workspace to the allow list, which
+    # must never happen for an agent/config this launch is about to refuse.
+    try:
+        validate_llm_support(selected_agent, config)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
+
     acp_channel: AcpClientChannel | None = None
     if acp:
         acp_channel = _open_acp_channel()
@@ -686,11 +695,6 @@ def run(
 
     agent_cfg = config.get("agents", {}).get(selected_agent, {})
     spec = get_agent_spec(selected_agent)
-    try:
-        validate_llm_support(selected_agent, config)
-    except ValueError as exc:
-        error(str(exc))
-        raise typer.Exit(1) from exc
 
     acp_workspace_mount: str | None = None
     acp_workspace_alias: str | None = None

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -193,20 +193,27 @@ def _acp_workspace_mount_path(workspace_path: PurePath, spec: AgentSpec) -> str:
     return host_path
 
 
+# Separator for write-root lists. The variable is parsed by the agent INSIDE
+# the Linux container (hermes splits on its own os.pathsep, which is ":"), so
+# the host's os.pathsep must never leak in here: on a Windows host it is ";",
+# and a ";"-joined value would reach the container as one nonexistent path.
+_WRITE_ROOTS_SEP = ":"
+
+
 def _extend_write_roots(env: dict[str, str], var: str, paths: list[str | None]) -> None:
-    """Append *paths* to the os.pathsep-joined write-root list in ``env[var]``.
+    """Append *paths* to the ``:``-joined write-root list in ``env[var]``.
 
     Extends rather than replaces, so a value the user set through
     ``agents.<agent>.env`` or ``-e`` keeps its entries, and skips duplicates so
     repeated calls stay idempotent. Used for ``--acp``, where the editor sends
     absolute host paths that the agent's file sandbox must also allow.
     """
-    existing = [root for root in env.get(var, "").split(os.pathsep) if root]
+    existing = [root for root in env.get(var, "").split(_WRITE_ROOTS_SEP) if root]
     for path in paths:
         if path and path not in existing:
             existing.append(path)
     if existing:
-        env[var] = os.pathsep.join(existing)
+        env[var] = _WRITE_ROOTS_SEP.join(existing)
 
 
 def _is_safe_skill_id(skill_id: str) -> bool:

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -25,6 +25,7 @@ from vibepod.core.agents import (
     get_agent_shortcut,
     get_agent_spec,
     resolve_agent_name,
+    validate_llm_support,
 )
 from vibepod.core.allowed_dirs import add_allowed_dir, is_dir_allowed, is_protected_dir
 from vibepod.core.config import get_config
@@ -658,6 +659,11 @@ def run(
 
     agent_cfg = config.get("agents", {}).get(selected_agent, {})
     spec = get_agent_spec(selected_agent)
+    try:
+        validate_llm_support(selected_agent, config)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
 
     acp_workspace_mount: str | None = None
     acp_workspace_alias: str | None = None

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -237,6 +237,9 @@ def _agent_skill_paths(agent: str) -> list[str]:
       - jcode    reads ~/.agents/skills/ (also ~/.jcode/skills/)
       - freebuff reads ~/.agents/skills/ (also ~/.freebuff/skills/)
       - dsh      reads ~/.agents/skills/            → /config/.agents/skills/
+      - hermes   reads ~/.agents/skills/ once the image entrypoint seeds it
+        into skills.external_dirs in $HERMES_HOME/config.yaml (Hermes has no
+        env-var override for that key)  → /config/.agents/skills/
       - qwen     reads ~/.qwen/skills/, which the image symlinks to /qwen/skills
         (also <project>/.qwen/skills/ in the workspace)
 
@@ -250,7 +253,7 @@ def _agent_skill_paths(agent: str) -> list[str]:
         return ["/config/.pi/agent/skills"]
     if agent == "qwen":
         return ["/qwen/skills"]
-    if agent in ("codex", "opencode", "auggie", "tau", "jcode", "freebuff", "dsh"):
+    if agent in ("codex", "opencode", "auggie", "tau", "jcode", "freebuff", "dsh", "hermes"):
         return ["/config/.agents/skills"]
     return []
 

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -237,9 +237,10 @@ def _agent_skill_paths(agent: str) -> list[str]:
       - jcode    reads ~/.agents/skills/ (also ~/.jcode/skills/)
       - freebuff reads ~/.agents/skills/ (also ~/.freebuff/skills/)
       - dsh      reads ~/.agents/skills/            → /config/.agents/skills/
-      - hermes   reads ~/.agents/skills/ once the image entrypoint seeds it
-        into skills.external_dirs in $HERMES_HOME/config.yaml (Hermes has no
-        env-var override for that key)  → /config/.agents/skills/
+      - hermes   reads ~/.agents/skills/ once the image seeds it into
+        skills.external_dirs in $HERMES_HOME/config.yaml (Hermes has no
+        env-var override for that key). Its state volume is the official
+        image's /opt/data, not /config  → /opt/data/.agents/skills/
       - qwen     reads ~/.qwen/skills/, which the image symlinks to /qwen/skills
         (also <project>/.qwen/skills/ in the workspace)
 
@@ -253,7 +254,9 @@ def _agent_skill_paths(agent: str) -> list[str]:
         return ["/config/.pi/agent/skills"]
     if agent == "qwen":
         return ["/qwen/skills"]
-    if agent in ("codex", "opencode", "auggie", "tau", "jcode", "freebuff", "dsh", "hermes"):
+    if agent == "hermes":
+        return ["/opt/data/.agents/skills"]
+    if agent in ("codex", "opencode", "auggie", "tau", "jcode", "freebuff", "dsh"):
         return ["/config/.agents/skills"]
     return []
 

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -26,6 +26,7 @@ from vibepod.core.agents import (
     get_agent_spec,
     resolve_agent_name,
     validate_llm_support,
+    validate_rootless_runtime,
 )
 from vibepod.core.allowed_dirs import add_allowed_dir, is_dir_allowed, is_protected_dir
 from vibepod.core.config import get_config
@@ -120,6 +121,9 @@ _ACP_RESERVED_CONTAINER_PATHS = (
     "/config",
     "/claude",
     "/qwen",
+    # Hermes's install root on the hermes agent image: binding a workspace
+    # over it hides the entrypoint, virtualenv and hermes-acp binary.
+    "/opt/hermes",
     "/etc",
     "/usr",
     "/tmp/.X11-unix",
@@ -794,6 +798,11 @@ def run(
 
     podman_probe = getattr(manager, "is_rootless_podman", None)
     rootless_podman = bool(podman_probe()) if callable(podman_probe) else False
+    try:
+        validate_rootless_runtime(selected_agent, rootless_podman)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
     agent_userns_mode = "keep-id" if rootless_podman else None
     if rootless_podman:
         merged_env["USER_UID"] = "0"

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -25,6 +25,7 @@ from vibepod.core.agents import (
     effective_agent_image,
     get_agent_spec,
     resolve_agent_name,
+    validate_llm_support,
 )
 from vibepod.core.allowed_dirs import add_allowed_dir, is_dir_allowed, is_protected_dir
 from vibepod.core.config import get_config, get_config_root
@@ -501,6 +502,11 @@ def task_create(
         raise typer.Exit(1)
 
     spec = get_agent_spec(selected)
+    try:
+        validate_llm_support(selected, config)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
     if not spec.headless_prefix and not spec.headless_command:
         supported = ", ".join(
             agent

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -26,6 +26,7 @@ from vibepod.core.agents import (
     get_agent_spec,
     resolve_agent_name,
     validate_llm_support,
+    validate_rootless_runtime,
 )
 from vibepod.core.allowed_dirs import add_allowed_dir, is_dir_allowed, is_protected_dir
 from vibepod.core.config import get_config, get_config_root
@@ -618,6 +619,11 @@ def task_create(
 
     podman_probe = getattr(manager, "is_rootless_podman", None)
     rootless_podman = bool(podman_probe()) if callable(podman_probe) else False
+    try:
+        validate_rootless_runtime(selected, rootless_podman)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
     agent_userns_mode = "keep-id" if rootless_podman else None
     if rootless_podman:
         merged_env["USER_UID"] = "0"

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -61,7 +61,6 @@ AGENT_ALIASES: dict[str, str] = {
     "qwen-cli": "qwen",
     "deepseek": "dsh",
     "deepseek-harness": "dsh",
-    "nous": "hermes",
 }
 
 IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (

--- a/src/vibepod/constants.py
+++ b/src/vibepod/constants.py
@@ -33,6 +33,7 @@ SUPPORTED_AGENTS = (
     "freebuff",
     "qwen",
     "dsh",
+    "hermes",
 )
 
 AGENT_SHORTCUTS: dict[str, str] = {
@@ -49,6 +50,7 @@ AGENT_SHORTCUTS: dict[str, str] = {
     "fb": "freebuff",
     "q": "qwen",
     "ds": "dsh",
+    "h": "hermes",
 }
 
 AGENT_ALIASES: dict[str, str] = {
@@ -59,6 +61,7 @@ AGENT_ALIASES: dict[str, str] = {
     "qwen-cli": "qwen",
     "deepseek": "dsh",
     "deepseek-harness": "dsh",
+    "nous": "hermes",
 }
 
 IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (
@@ -77,6 +80,7 @@ IMAGE_OVERRIDE_ENV_KEYS: tuple[str, ...] = (
     "VP_IMAGE_FREEBUFF",
     "VP_IMAGE_QWEN",
     "VP_IMAGE_DSH",
+    "VP_IMAGE_HERMES",
     "VP_DATASETTE_IMAGE",
     "VP_PROXY_IMAGE",
     "VP_SKILLS_ENGINE_IMAGE",
@@ -155,6 +159,10 @@ def get_default_images() -> dict[str, str]:
         "dsh": os.environ.get(
             "VP_IMAGE_DSH",
             f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/dsh:latest",
+        ),
+        "hermes": os.environ.get(
+            "VP_IMAGE_HERMES",
+            f"{os.environ.get('VP_IMAGE_NAMESPACE', 'vibepod')}/hermes:latest",
         ),
         "datasette": os.environ.get(
             "VP_DATASETTE_IMAGE",

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -271,12 +271,17 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         DEFAULT_IMAGES["hermes"],
         "hermes",
         ["hermes"],
-        "/config",
-        # Hermes derives every durable path from $HERMES_HOME (config.yaml,
-        # .env, provider credentials, state.db, skills/, plugins/). It defaults
-        # to $HOME/.hermes, but is set explicitly so the state stays on the
-        # persisted mount even after gosu re-derives HOME from the passwd entry.
-        {"HOME": "/config", "HERMES_HOME": "/config/.hermes"},
+        # The image is built on the official nousresearch/hermes-agent image,
+        # whose state volume is /opt/data — config.yaml, .env, credentials,
+        # sessions, skills and memories all live there, and the base image
+        # bakes both HOME and HERMES_HOME to it. VibePod therefore mounts the
+        # agent config directory at /opt/data and sets neither variable.
+        "/opt/data",
+        # Host-UID mapping goes through USER_UID/USER_GID, which VibePod
+        # already exports and the image's 00-vibepod-uid cont-init hook
+        # forwards as HERMES_UID/HERMES_GID. Do not set run_as_host_user:
+        # the base image rejects `docker run --user <uid>`.
+        {},
         ikwid_args=["--yolo"],
         # Hermes talks to providers through the OpenAI SDK and reads these two
         # variables directly (agent/auxiliary_client.py).

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -283,13 +283,8 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         # the base image rejects `docker run --user <uid>`.
         {},
         ikwid_args=["--yolo"],
-        # Hermes talks to providers through the OpenAI SDK and reads these two
-        # variables directly (agent/auxiliary_client.py).
-        llm_env_map={
-            "base_url": "OPENAI_BASE_URL",
-            "api_key": "OPENAI_API_KEY",
-        },
-        llm_model_args=["-m"],
+        # Global LLM wiring is rejected by validate_llm_support: the pinned
+        # runtime prioritizes saved providers and ACP has no routing flags.
         # `-z/--oneshot` takes the prompt as its value, and task.py emits
         # base_command + ikwid_prefix + headless_prefix + [prompt], which yields
         # `hermes --yolo -z "<prompt>"` — the prompt lands in -z's value slot and
@@ -328,6 +323,17 @@ def get_agent_spec(agent: str) -> AgentSpec:
     if agent not in AGENT_SPECS:
         raise ValueError(f"Unsupported agent: {agent}")
     return AGENT_SPECS[agent]
+
+
+def validate_llm_support(agent: str, config: dict[str, Any]) -> None:
+    """Reject known-incompatible wiring rather than silently misroute requests."""
+    if agent == "hermes" and config.get("llm", {}).get("enabled"):
+        raise ValueError(
+            "Hermes does not support VibePod's global LLM wiring in the pinned image. "
+            "Set llm.enabled to false in your VibePod config and use Hermes-native "
+            "provider/model setup (hermes setup inside the container). "
+            "This applies to interactive, task, and ACP modes."
+        )
 
 
 def effective_agent_image(agent: str, config: dict[str, Any]) -> str:

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -290,6 +290,11 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         # `hermes --yolo -z "<prompt>"` — the prompt lands in -z's value slot and
         # --yolo is never swallowed by it.
         headless_prefix=["-z"],
+        # `hermes-acp` is a separate console script from the same wheel (like
+        # devstral's `vibe-acp`), not a flag on `hermes`, so it does not extend
+        # spec.command. The image installs the package's [acp] extra, which
+        # provides the `acp` module the adapter imports at startup.
+        acp_command=["hermes-acp"],
         # Hermes is pre-1.0 and its PyPI release line trails upstream main.
         preview=True,
     ),

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -38,6 +38,11 @@ class AgentSpec:
     # Panel via the Agent Client Protocol). None means the agent does not ship
     # an ACP adapter and `--acp` aborts with the list of supported agents.
     acp_command: list[str] | None = None
+    # write_roots_env names an env var holding the os.pathsep-joined directory
+    # prefixes the agent is allowed to write to (hermes sandboxes its file
+    # tools with HERMES_WRITE_SAFE_ROOT). When set, `--acp` appends the host
+    # workspace path, which editors send as an absolute path.
+    write_roots_env: str | None = None
 
 
 AGENT_SPECS: dict[str, AgentSpec] = {
@@ -281,7 +286,12 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         # already exports and the image's 00-vibepod-uid cont-init hook
         # forwards as HERMES_UID/HERMES_GID. Do not set run_as_host_user:
         # the base image rejects `docker run --user <uid>`.
-        {},
+        #
+        # HERMES_WRITE_SAFE_ROOT sandboxes Hermes' write_file/patch tools to a
+        # set of directory prefixes. The base image bakes it to /opt/data
+        # alone, which makes the project mount read-only to the agent, so the
+        # workspace is appended here (the variable is os.pathsep-joined).
+        {"HERMES_WRITE_SAFE_ROOT": "/opt/data:/workspace"},
         ikwid_args=["--yolo"],
         # Global LLM wiring is rejected by validate_llm_support: the pinned
         # runtime prioritizes saved providers and ACP has no routing flags.
@@ -295,6 +305,7 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         # spec.command. The image installs the package's [acp] extra, which
         # provides the `acp` module the adapter imports at startup.
         acp_command=["hermes-acp"],
+        write_roots_env="HERMES_WRITE_SAFE_ROOT",
         # Hermes is pre-1.0 and its PyPI release line trails upstream main.
         preview=True,
     ),

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -343,7 +343,26 @@ def validate_llm_support(agent: str, config: dict[str, Any]) -> None:
             "Hermes does not support VibePod's global LLM wiring in the pinned image. "
             "Set llm.enabled to false in your VibePod config and use Hermes-native "
             "provider/model setup (hermes setup inside the container). "
-            "This applies to interactive, task, and ACP modes."
+            "This applies to interactive, task, and ACP modes.",
+        )
+
+
+def validate_rootless_runtime(agent: str, rootless: bool) -> None:
+    """Reject Hermes on rootless Podman before it maps the container to a UID it rejects.
+
+    Rootless Podman launches the container with ``userns_mode=keep-id``, running as
+    the invoking user's UID, and VibePod overwrites USER_UID/USER_GID with 0 for the
+    entrypoint hooks. The pinned Hermes image needs its own bootstrap/runtime user:
+    its ``main-wrapper`` exits 1 on an arbitrary non-hermes UID, and its UID-mapping
+    hook ignores 0. Launching Hermes there would fail after the container starts, so
+    reject before provisioning any network, proxy, or image.
+    """
+    if agent == "hermes" and rootless:
+        raise ValueError(
+            "Hermes does not support rootless Podman: the pinned image requires its "
+            "own runtime user and rejects the arbitrary UID that rootless keep-id "
+            "maps the container to (it also ignores a UID of 0). "
+            "Run Hermes on rootful Docker/Podman instead.",
         )
 
 

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -265,6 +265,34 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         preview=True,
         web_container_port=3081,
     ),
+    "hermes": AgentSpec(
+        "hermes",
+        "nousresearch",
+        DEFAULT_IMAGES["hermes"],
+        "hermes",
+        ["hermes"],
+        "/config",
+        # Hermes derives every durable path from $HERMES_HOME (config.yaml,
+        # .env, provider credentials, state.db, skills/, plugins/). It defaults
+        # to $HOME/.hermes, but is set explicitly so the state stays on the
+        # persisted mount even after gosu re-derives HOME from the passwd entry.
+        {"HOME": "/config", "HERMES_HOME": "/config/.hermes"},
+        ikwid_args=["--yolo"],
+        # Hermes talks to providers through the OpenAI SDK and reads these two
+        # variables directly (agent/auxiliary_client.py).
+        llm_env_map={
+            "base_url": "OPENAI_BASE_URL",
+            "api_key": "OPENAI_API_KEY",
+        },
+        llm_model_args=["-m"],
+        # `-z/--oneshot` takes the prompt as its value, and task.py emits
+        # base_command + ikwid_prefix + headless_prefix + [prompt], which yields
+        # `hermes --yolo -z "<prompt>"` — the prompt lands in -z's value slot and
+        # --yolo is never swallowed by it.
+        headless_prefix=["-z"],
+        # Hermes is pre-1.0 and its PyPI release line trails upstream main.
+        preview=True,
+    ),
 }
 
 _SHORTCUT_BY_AGENT = {agent: shortcut for shortcut, agent in AGENT_SHORTCUTS.items()}

--- a/src/vibepod/core/agents.py
+++ b/src/vibepod/core/agents.py
@@ -38,10 +38,11 @@ class AgentSpec:
     # Panel via the Agent Client Protocol). None means the agent does not ship
     # an ACP adapter and `--acp` aborts with the list of supported agents.
     acp_command: list[str] | None = None
-    # write_roots_env names an env var holding the os.pathsep-joined directory
+    # write_roots_env names an env var holding the ":"-joined directory
     # prefixes the agent is allowed to write to (hermes sandboxes its file
-    # tools with HERMES_WRITE_SAFE_ROOT). When set, `--acp` appends the host
-    # workspace path, which editors send as an absolute path.
+    # tools with HERMES_WRITE_SAFE_ROOT). The separator is the container's,
+    # always ":", regardless of the host platform. When set, `--acp` appends
+    # the host workspace path, which editors send as an absolute path.
     write_roots_env: str | None = None
 
 
@@ -290,7 +291,7 @@ AGENT_SPECS: dict[str, AgentSpec] = {
         # HERMES_WRITE_SAFE_ROOT sandboxes Hermes' write_file/patch tools to a
         # set of directory prefixes. The base image bakes it to /opt/data
         # alone, which makes the project mount read-only to the agent, so the
-        # workspace is appended here (the variable is os.pathsep-joined).
+        # workspace is appended here (":"-joined — the container's pathsep).
         {"HERMES_WRITE_SAFE_ROOT": "/opt/data:/workspace"},
         ikwid_args=["--yolo"],
         # Global LLM wiring is rejected by validate_llm_support: the pinned

--- a/src/vibepod/core/config.py
+++ b/src/vibepod/core/config.py
@@ -166,6 +166,15 @@ def _default_config() -> dict[str, Any]:
                 "ports": ["127.0.0.1:3080:3081"],
                 "init": [],
             },
+            "hermes": {
+                "enabled": True,
+                "image": DEFAULT_IMAGES["hermes"],
+                "auto_pull": None,
+                "env": {},
+                "volumes": [],
+                "ports": [],
+                "init": [],
+            },
         },
         "logging": {
             "enabled": True,

--- a/src/vibepod/core/resume.py
+++ b/src/vibepod/core/resume.py
@@ -141,7 +141,7 @@ _HINT_PATTERNS: dict[str, tuple[tuple[re.Pattern[str], Callable[[re.Match[str]],
         ),
         (
             re.compile(
-                rf"{_BOUNDARY}hermes[ \t]+(?:-c|--continue)[ \t]+{_QUOTED_VALUE}{_HERMES_SUFFIX}"
+                rf"{_BOUNDARY}hermes[ \t]+(?:-c|--continue)[ \t]+{_QUOTED_VALUE}{_HERMES_SUFFIX}",
             ),
             _with_hermes_profile(_with_quoted_value("--continue")),
         ),

--- a/src/vibepod/core/resume.py
+++ b/src/vibepod/core/resume.py
@@ -52,6 +52,23 @@ def _verbatim(match: re.Match[str]) -> str:
 _QUOTED_VALUE = r'"([^"\n]+)"'
 
 
+_HERMES_SUFFIX = (
+    rf"(?:[ \t]+(?P<profile_flag>-p|--profile)[ \t]+(?P<profile>{_TOKEN}))?[ \t]*(?=\n|$)"
+)
+
+
+def _with_hermes_profile(
+    formatter: Callable[[re.Match[str]], str],
+) -> Callable[[re.Match[str]], str]:
+    def _format(match: re.Match[str]) -> str:
+        args = formatter(match)
+        if profile := match.group("profile"):
+            args += f" {match.group('profile_flag')} {shlex.quote(profile)}"
+        return args
+
+    return _format
+
+
 def _with_quoted_value(prefix: str) -> Callable[[re.Match[str]], str]:
     def _format(match: re.Match[str]) -> str:
         return f"{prefix} {shlex.quote(match.group(1))}"
@@ -114,21 +131,23 @@ _HINT_PATTERNS: dict[str, tuple[tuple[re.Pattern[str], Callable[[re.Match[str]],
     # Hermes prints both forms on exit (hermes_cli/cli.py):
     #   hermes --resume <session_id>
     #   hermes -c "<session title>"
-    # The quoted pattern is listed before the bare one; build_resume_hint keeps
-    # the match with the greatest end() offset, and on the same line the quoted
-    # match ends later, so the titled form wins.
+    # Both may have a trailing profile. Require the entire hint line so raw
+    # embedded quotes cannot produce a partial title or bare-continue fallback.
+    # The stable ID pattern comes first and takes priority over title hints.
     "hermes": (
         (
-            re.compile(rf"{_BOUNDARY}hermes[ \t]+(?:-r|--resume)[ \t]+({_TOKEN})"),
-            _with_id("--resume"),
+            re.compile(rf"{_BOUNDARY}hermes[ \t]+(?:-r|--resume)[ \t]+({_TOKEN}){_HERMES_SUFFIX}"),
+            _with_hermes_profile(_with_id("--resume")),
         ),
         (
-            re.compile(rf"{_BOUNDARY}hermes[ \t]+(?:-c|--continue)[ \t]+{_QUOTED_VALUE}"),
-            _with_quoted_value("--continue"),
+            re.compile(
+                rf"{_BOUNDARY}hermes[ \t]+(?:-c|--continue)[ \t]+{_QUOTED_VALUE}{_HERMES_SUFFIX}"
+            ),
+            _with_hermes_profile(_with_quoted_value("--continue")),
         ),
         (
-            re.compile(rf"{_BOUNDARY}hermes[ \t]+(?:-c|--continue)(?![\w-])"),
-            _fixed("--continue"),
+            re.compile(rf"{_BOUNDARY}hermes[ \t]+(?:-c|--continue){_HERMES_SUFFIX}"),
+            _with_hermes_profile(_fixed("--continue")),
         ),
     ),
 }
@@ -158,6 +177,10 @@ def build_resume_hint(agent: str, output: str) -> str | None:
         for match in pattern.finditer(text):
             if best is None or match.end() > best[0]:
                 best = (match.end(), formatter(match))
+        # Upstream prints the titled alternative after the stable ID. Titles
+        # are mutable (and may contain raw quotes), so prefer the last ID.
+        if agent == "hermes" and pattern is patterns[0][0] and best is not None:
+            break
     if best is None:
         return None
     return f"vp run {agent} -- {best[1]}"

--- a/src/vibepod/core/resume.py
+++ b/src/vibepod/core/resume.py
@@ -43,6 +43,19 @@ def _verbatim(match: re.Match[str]) -> str:
     return match.group(1)
 
 
+# Session titles are printed quoted because they contain spaces (Hermes prints
+# `hermes -c "my project"`). Re-emit the value quoted so the rebuilt command
+# stays a single argument after `--`.
+_QUOTED_VALUE = r'"([^"\n]+)"'
+
+
+def _with_quoted_value(prefix: str) -> Callable[[re.Match[str]], str]:
+    def _format(match: re.Match[str]) -> str:
+        return f'{prefix} "{match.group(1)}"'
+
+    return _format
+
+
 # Per-agent resume hint patterns. Hints must appear on a single line: patterns
 # only allow spaces/tabs between tokens so unrelated text on following lines is
 # never mistaken for a session identifier. Each formatter rebuilds the agent's
@@ -94,6 +107,26 @@ _HINT_PATTERNS: dict[str, tuple[tuple[re.Pattern[str], Callable[[re.Match[str]],
             _with_id("--continue"),
         ),
         (re.compile(rf"{_BOUNDARY}freebuff[ \t]+--continue(?![\w-])"), _fixed("--continue")),
+    ),
+    # Hermes prints both forms on exit (hermes_cli/cli.py):
+    #   hermes --resume <session_id>
+    #   hermes -c "<session title>"
+    # The quoted pattern is listed before the bare one; build_resume_hint keeps
+    # the match with the greatest end() offset, and on the same line the quoted
+    # match ends later, so the titled form wins.
+    "hermes": (
+        (
+            re.compile(rf"{_BOUNDARY}hermes[ \t]+(?:-r|--resume)[ \t]+({_TOKEN})"),
+            _with_id("--resume"),
+        ),
+        (
+            re.compile(rf"{_BOUNDARY}hermes[ \t]+(?:-c|--continue)[ \t]+{_QUOTED_VALUE}"),
+            _with_quoted_value("--continue"),
+        ),
+        (
+            re.compile(rf"{_BOUNDARY}hermes[ \t]+(?:-c|--continue)(?![\w-])"),
+            _fixed("--continue"),
+        ),
     ),
 }
 

--- a/src/vibepod/core/resume.py
+++ b/src/vibepod/core/resume.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 from collections.abc import Callable
 
 from vibepod.utils.console import console, info
@@ -44,14 +45,16 @@ def _verbatim(match: re.Match[str]) -> str:
 
 
 # Session titles are printed quoted because they contain spaces (Hermes prints
-# `hermes -c "my project"`). Re-emit the value quoted so the rebuilt command
-# stays a single argument after `--`.
+# `hermes -c "my project"`). Re-emit the value shell-quoted so the rebuilt
+# command stays a single argument after `--` when copy-pasted: titles are
+# prompt-derived and can contain `$`, backticks or backslashes that double
+# quotes would re-expand.
 _QUOTED_VALUE = r'"([^"\n]+)"'
 
 
 def _with_quoted_value(prefix: str) -> Callable[[re.Match[str]], str]:
     def _format(match: re.Match[str]) -> str:
-        return f'{prefix} "{match.group(1)}"'
+        return f"{prefix} {shlex.quote(match.group(1))}"
 
     return _format
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -134,10 +134,37 @@ def test_dsh_spec_matches_container_contract() -> None:
     assert int(spec.extra_env["VIBEPOD_WEB_FORWARD_PORT"]) == spec.web_container_port
 
 
-def test_only_dsh_is_preview() -> None:
+def test_hermes_spec_matches_container_contract() -> None:
+    spec = get_agent_spec("hermes")
+    assert spec.id == "hermes"
+    assert spec.provider == "nousresearch"
+    assert spec.image == DEFAULT_IMAGES["hermes"]
+    assert spec.config_subdir == "hermes"
+    assert spec.command == ["hermes"]
+    assert spec.config_mount_path == "/config"
+    assert spec.extra_env["HOME"] == "/config"
+    assert spec.extra_env["HERMES_HOME"] == "/config/.hermes"
+    assert spec.ikwid_args == ["--yolo"]
+    assert spec.headless_prefix == ["-z"]
+    assert spec.headless_command is None
+    assert spec.web_container_port is None
+    assert spec.preview is True
+
+
+def test_hermes_spec_maps_openai_compatible_llm_env() -> None:
+    spec = get_agent_spec("hermes")
+    assert spec.llm_env_map == {
+        "base_url": "OPENAI_BASE_URL",
+        "api_key": "OPENAI_API_KEY",
+    }
+    assert spec.llm_model_args == ["-m"]
+
+
+def test_preview_agents_are_exactly_the_expected_set() -> None:
+    preview_agents = {"dsh", "hermes"}
     for agent in SUPPORTED_AGENTS:
         spec = get_agent_spec(agent)
-        assert spec.preview is (agent == "dsh"), f"{agent} preview flag unexpected"
+        assert spec.preview is (agent in preview_agents), f"{agent} preview flag unexpected"
 
 
 def test_get_agent_spec_unknown() -> None:
@@ -158,6 +185,8 @@ def test_resolve_agent_name_accepts_short_and_full_forms() -> None:
     assert resolve_agent_name("QWEN-CLI") == "qwen"
     assert resolve_agent_name("deepseek") == "dsh"
     assert resolve_agent_name("DEEPSEEK-HARNESS") == "dsh"
+    assert resolve_agent_name("nous") == "hermes"
+    assert resolve_agent_name("NOUS") == "hermes"
     assert resolve_agent_name("unknown") is None
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -154,13 +154,10 @@ def test_hermes_spec_matches_container_contract() -> None:
     assert spec.preview is True
 
 
-def test_hermes_spec_maps_openai_compatible_llm_env() -> None:
+def test_hermes_spec_does_not_advertise_unsupported_llm_wiring() -> None:
     spec = get_agent_spec("hermes")
-    assert spec.llm_env_map == {
-        "base_url": "OPENAI_BASE_URL",
-        "api_key": "OPENAI_API_KEY",
-    }
-    assert spec.llm_model_args == ["-m"]
+    assert spec.llm_env_map is None
+    assert spec.llm_model_args is None
 
 
 def test_preview_agents_are_exactly_the_expected_set() -> None:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -146,6 +146,11 @@ def test_hermes_spec_matches_container_contract() -> None:
     assert spec.config_mount_path == "/opt/data"
     assert "HOME" not in spec.extra_env
     assert "HERMES_HOME" not in spec.extra_env
+    # The base image bakes HERMES_WRITE_SAFE_ROOT=/opt/data, which makes the
+    # project mount read-only to Hermes' write_file/patch tools. VibePod adds
+    # the workspace so the agent can actually edit the project.
+    assert spec.extra_env["HERMES_WRITE_SAFE_ROOT"] == "/opt/data:/workspace"
+    assert spec.write_roots_env == "HERMES_WRITE_SAFE_ROOT"
     assert spec.ikwid_args == ["--yolo"]
     assert spec.headless_prefix == ["-z"]
     assert spec.headless_command is None

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -190,8 +190,6 @@ def test_resolve_agent_name_accepts_short_and_full_forms() -> None:
     assert resolve_agent_name("QWEN-CLI") == "qwen"
     assert resolve_agent_name("deepseek") == "dsh"
     assert resolve_agent_name("DEEPSEEK-HARNESS") == "dsh"
-    assert resolve_agent_name("nous") == "hermes"
-    assert resolve_agent_name("NOUS") == "hermes"
     assert resolve_agent_name("unknown") is None
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -141,9 +141,11 @@ def test_hermes_spec_matches_container_contract() -> None:
     assert spec.image == DEFAULT_IMAGES["hermes"]
     assert spec.config_subdir == "hermes"
     assert spec.command == ["hermes"]
-    assert spec.config_mount_path == "/config"
-    assert spec.extra_env["HOME"] == "/config"
-    assert spec.extra_env["HERMES_HOME"] == "/config/.hermes"
+    # The official image's state volume; HOME and HERMES_HOME are both baked
+    # to /opt/data by the base image, so VibePod sets neither.
+    assert spec.config_mount_path == "/opt/data"
+    assert "HOME" not in spec.extra_env
+    assert "HERMES_HOME" not in spec.extra_env
     assert spec.ikwid_args == ["--yolo"]
     assert spec.headless_prefix == ["-z"]
     assert spec.headless_command is None

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -147,6 +147,7 @@ def test_hermes_spec_matches_container_contract() -> None:
     assert spec.ikwid_args == ["--yolo"]
     assert spec.headless_prefix == ["-z"]
     assert spec.headless_command is None
+    assert spec.acp_command == ["hermes-acp"]
     assert spec.web_container_port is None
     assert spec.preview is True
 
@@ -302,6 +303,7 @@ def test_acp_commands_match_contract() -> None:
         "auggie": ["auggie", "--acp"],
         "jcode": ["jcode", "acp"],
         "devstral": ["vibe-acp"],
+        "hermes": ["hermes-acp"],
     }
     for agent in SUPPORTED_AGENTS:
         spec = get_agent_spec(agent)
@@ -320,7 +322,7 @@ def test_in_image_acp_commands_extend_the_launch_command() -> None:
     Agents driven by an external adapter (npx packages, devstral's ``vibe-acp``
     console script) are exempt.
     """
-    external_adapters = {"claude", "codex", "devstral", "pi"}
+    external_adapters = {"claude", "codex", "devstral", "pi", "hermes"}
     for agent in SUPPORTED_AGENTS:
         spec = get_agent_spec(agent)
         if spec.acp_command is None or agent in external_adapters:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -399,22 +399,3 @@ def test_hermes_shortcut_runs_hermes(monkeypatch) -> None:
     assert result.exit_code == 0
     assert called["agent"] == "hermes"
     assert called["passthrough"] == []
-
-
-def test_hermes_nous_alias_is_forwarded_to_run(monkeypatch) -> None:
-    """`vp run nous` forwards the alias verbatim; `run` resolves it itself.
-
-    Matches the existing `vibe` / `deepseek` aliases: they are accepted as an
-    argument to `run`, not registered as top-level commands. The alias-to-agent
-    mapping is covered by `resolve_agent_name` in test_agents.py.
-    """
-    called: dict[str, object] = {"agent": None}
-
-    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
-        called["agent"] = agent
-
-    monkeypatch.setattr(run_cmd, "run", _fake_run)
-
-    result = runner.invoke(app, ["run", "nous"])
-    assert result.exit_code == 0
-    assert called["agent"] == "nous"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -384,3 +384,37 @@ def test_alias_forwards_overlay_flags(monkeypatch) -> None:
     assert called["no_overlay"] is True
     assert called["rebuild_overlay"] is True
     assert called["passthrough"] == []
+
+
+def test_hermes_shortcut_runs_hermes(monkeypatch) -> None:
+    called: dict[str, object] = {"agent": None, "passthrough": None}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        called["agent"] = agent
+        called["passthrough"] = list(kwargs.get("passthrough_args") or [])
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["h"])
+    assert result.exit_code == 0
+    assert called["agent"] == "hermes"
+    assert called["passthrough"] == []
+
+
+def test_hermes_nous_alias_is_forwarded_to_run(monkeypatch) -> None:
+    """`vp run nous` forwards the alias verbatim; `run` resolves it itself.
+
+    Matches the existing `vibe` / `deepseek` aliases: they are accepted as an
+    argument to `run`, not registered as top-level commands. The alias-to-agent
+    mapping is covered by `resolve_agent_name` in test_agents.py.
+    """
+    called: dict[str, object] = {"agent": None}
+
+    def _fake_run(agent=None, **kwargs) -> None:  # noqa: ANN001, ANN003, ARG001
+        called["agent"] = agent
+
+    monkeypatch.setattr(run_cmd, "run", _fake_run)
+
+    result = runner.invoke(app, ["run", "nous"])
+    assert result.exit_code == 0
+    assert called["agent"] == "nous"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -336,3 +336,19 @@ def test_list_allowed_dirs_empty(monkeypatch, tmp_path: Path) -> None:
     result = runner.invoke(app, ["config", "list-allowed-dirs"])
     assert result.exit_code == 0
     assert "No directories" in result.stdout
+
+
+def test_default_config_includes_hermes_agent(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VP_CONFIG_DIR", str(tmp_path))
+    config = get_config()
+
+    hermes = config["agents"]["hermes"]
+
+    assert hermes["enabled"] is True
+    assert hermes["image"] == "vibepod/hermes:latest"
+    assert hermes["auto_pull"] is None
+    assert hermes["env"] == {}
+    assert hermes["volumes"] == []
+    # Unlike dsh, this integration publishes nothing.
+    assert hermes["ports"] == []
+    assert hermes["init"] == []

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -22,6 +22,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
         "VP_IMAGE_FREEBUFF",
         "VP_IMAGE_QWEN",
         "VP_IMAGE_DSH",
+        "VP_IMAGE_HERMES",
         "VP_DATASETTE_IMAGE",
         "VP_PROXY_IMAGE",
     ):
@@ -43,6 +44,7 @@ def test_default_images_match_documented_registry_defaults(monkeypatch) -> None:
     assert images["freebuff"] == "vibepod/freebuff:latest"
     assert images["qwen"] == "vibepod/qwen:latest"
     assert images["dsh"] == "vibepod/dsh:latest"
+    assert images["hermes"] == "vibepod/hermes:latest"
     assert images["datasette"] == "vibepod/datasette:latest"
     assert images["proxy"] == "vibepod/proxy:latest"
 
@@ -101,3 +103,11 @@ def test_dsh_image_override(monkeypatch) -> None:
     images = get_default_images()
 
     assert images["dsh"] == "example/dsh:dev"
+
+
+def test_hermes_image_override(monkeypatch) -> None:
+    monkeypatch.setenv("VP_IMAGE_HERMES", "example/hermes:dev")
+
+    images = get_default_images()
+
+    assert images["hermes"] == "example/hermes:dev"

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -134,3 +134,28 @@ def test_show_resume_hint_handles_undecodable_bytes(capsys: pytest.CaptureFixtur
 
     show_resume_hint("claude", b"\xff\xfe claude --resume abc-123\r\n")
     assert "vp run claude -- --resume abc-123" in capsys.readouterr().out
+
+
+def test_detects_hermes_resume_hint() -> None:
+    output = "  hermes --resume 01JABCDEF\n"
+    assert build_resume_hint("hermes", output) == "vp run hermes -- --resume 01JABCDEF"
+
+
+def test_detects_hermes_short_resume_hint() -> None:
+    output = "  hermes -r 01JABCDEF\n"
+    assert build_resume_hint("hermes", output) == "vp run hermes -- --resume 01JABCDEF"
+
+
+def test_detects_hermes_quoted_continue_hint() -> None:
+    output = '  hermes -c "my project"\n'
+    assert build_resume_hint("hermes", output) == 'vp run hermes -- --continue "my project"'
+
+
+def test_detects_hermes_bare_continue_hint() -> None:
+    output = "  hermes -c\n"
+    assert build_resume_hint("hermes", output) == "vp run hermes -- --continue"
+
+
+def test_hermes_quoted_continue_beats_bare_continue() -> None:
+    output = '  hermes -c\n  hermes -c "my project"\n'
+    assert build_resume_hint("hermes", output) == 'vp run hermes -- --continue "my project"'

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shlex
+
 import pytest
 
 from vibepod.core.resume import build_resume_hint
@@ -167,3 +169,53 @@ def test_hermes_quoted_continue_shell_escapes_metacharacters() -> None:
 def test_hermes_quoted_continue_beats_bare_continue() -> None:
     output = '  hermes -c\n  hermes -c "my project"\n'
     assert build_resume_hint("hermes", output) == "vp run hermes -- --continue 'my project'"
+
+
+@pytest.mark.parametrize("profile_flag", ["-p", "--profile"])
+@pytest.mark.parametrize(
+    ("hint", "args"),
+    [
+        ("--resume 01JABCDEF", ["--resume", "01JABCDEF"]),
+        ("-r 01JABCDEF", ["--resume", "01JABCDEF"]),
+        ('-c "my project"', ["--continue", "my project"]),
+        ('--continue "my project"', ["--continue", "my project"]),
+        ("-c", ["--continue"]),
+        ("--continue", ["--continue"]),
+    ],
+)
+def test_hermes_preserves_trailing_profile(profile_flag: str, hint: str, args: list[str]) -> None:
+    result = build_resume_hint("hermes", f"  hermes {hint} {profile_flag} work\n")
+    assert result is not None
+    assert shlex.split(result) == ["vp", "run", "hermes", "--", *args, profile_flag, "work"]
+
+
+@pytest.mark.parametrize("profile", ["", " -p work", " --profile work"])
+def test_hermes_exit_summary_prefers_stable_id(profile: str) -> None:
+    output = f'  hermes --resume 01JABCDEF{profile}\n  hermes -c "my project"{profile}\n'
+    assert build_resume_hint("hermes", output) == f"vp run hermes -- --resume 01JABCDEF{profile}"
+
+
+@pytest.mark.parametrize("profile", ["", " -p work", " --profile work"])
+def test_hermes_title_metacharacters_round_trip(profile: str) -> None:
+    title = "deploy $KEY from `pwd`; it's \\safe & (ready)"
+    result = build_resume_hint("hermes", f'  hermes -c "{title}"{profile}\n')
+    assert result is not None
+    assert shlex.split(result) == [
+        "vp",
+        "run",
+        "hermes",
+        "--",
+        "--continue",
+        title,
+        *shlex.split(profile),
+    ]
+
+
+@pytest.mark.parametrize("with_id", [False, True])
+@pytest.mark.parametrize("profile", ["", " -p work", " --profile work"])
+@pytest.mark.parametrize("title", ['"fix "quoted" title"', '"unterminated', '""'])
+def test_hermes_rejects_malformed_title(with_id: bool, profile: str, title: str) -> None:
+    output = f"  hermes --resume 01JABCDEF{profile}\n" if with_id else ""
+    output += f"  hermes -c {title}{profile}\n"
+    expected = f"vp run hermes -- --resume 01JABCDEF{profile}" if with_id else None
+    assert build_resume_hint("hermes", output) == expected

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -148,7 +148,7 @@ def test_detects_hermes_short_resume_hint() -> None:
 
 def test_detects_hermes_quoted_continue_hint() -> None:
     output = '  hermes -c "my project"\n'
-    assert build_resume_hint("hermes", output) == 'vp run hermes -- --continue "my project"'
+    assert build_resume_hint("hermes", output) == "vp run hermes -- --continue 'my project'"
 
 
 def test_detects_hermes_bare_continue_hint() -> None:
@@ -156,6 +156,14 @@ def test_detects_hermes_bare_continue_hint() -> None:
     assert build_resume_hint("hermes", output) == "vp run hermes -- --continue"
 
 
+def test_hermes_quoted_continue_shell_escapes_metacharacters() -> None:
+    """Prompt-derived titles must survive a copy-paste run unchanged."""
+    output = '  hermes -c "deploy $KEY from `pwd`"\n'
+    assert build_resume_hint("hermes", output) == (
+        "vp run hermes -- --continue 'deploy $KEY from `pwd`'"
+    )
+
+
 def test_hermes_quoted_continue_beats_bare_continue() -> None:
     output = '  hermes -c\n  hermes -c "my project"\n'
-    assert build_resume_hint("hermes", output) == 'vp run hermes -- --continue "my project"'
+    assert build_resume_hint("hermes", output) == "vp run hermes -- --continue 'my project'"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3362,3 +3362,32 @@ def test_hermes_skill_paths_use_shared_agents_dir() -> None:
     from vibepod.commands.run import _agent_skill_paths
 
     assert _agent_skill_paths("hermes") == ["/opt/data/.agents/skills"]
+
+
+def test_extend_write_roots_appends_missing_paths() -> None:
+    from vibepod.commands.run import _extend_write_roots
+
+    env = {"HERMES_WRITE_SAFE_ROOT": "/opt/data:/workspace"}
+    _extend_write_roots(env, "HERMES_WRITE_SAFE_ROOT", ["/home/me/code", None])
+
+    assert env["HERMES_WRITE_SAFE_ROOT"] == "/opt/data:/workspace:/home/me/code"
+
+
+def test_extend_write_roots_is_idempotent_and_keeps_user_value() -> None:
+    from vibepod.commands.run import _extend_write_roots
+
+    # A user override of the variable must be extended, never replaced.
+    env = {"HERMES_WRITE_SAFE_ROOT": "/custom"}
+    _extend_write_roots(env, "HERMES_WRITE_SAFE_ROOT", ["/custom", "/home/me/code"])
+    _extend_write_roots(env, "HERMES_WRITE_SAFE_ROOT", ["/home/me/code"])
+
+    assert env["HERMES_WRITE_SAFE_ROOT"] == "/custom:/home/me/code"
+
+
+def test_extend_write_roots_seeds_an_unset_variable() -> None:
+    from vibepod.commands.run import _extend_write_roots
+
+    env: dict[str, str] = {}
+    _extend_write_roots(env, "HERMES_WRITE_SAFE_ROOT", ["/home/me/code"])
+
+    assert env["HERMES_WRITE_SAFE_ROOT"] == "/home/me/code"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1371,7 +1371,7 @@ def test_run_uses_keep_id_for_rootless_podman_agents(
 
 
 @pytest.mark.parametrize("acp", [False, True])
-@pytest.mark.parametrize("agent", ["hermes", "nous"])
+@pytest.mark.parametrize("agent", ["hermes"])
 def test_hermes_rejects_rootless_podman_before_provisioning(
     monkeypatch,
     tmp_path,
@@ -1923,7 +1923,7 @@ def test_ikwid_false_does_not_modify_command(monkeypatch, tmp_path: Path) -> Non
 
 
 @pytest.mark.parametrize("acp", [False, True])
-@pytest.mark.parametrize("agent", ["hermes", "nous"])
+@pytest.mark.parametrize("agent", ["hermes"])
 def test_hermes_rejects_global_llm_before_docker(monkeypatch, tmp_path, capsys, acp, agent):
     cfg = _make_config()
     cfg["llm"] = {"enabled": True, "model": "proxy-only-model"}
@@ -1936,6 +1936,37 @@ def test_hermes_rejects_global_llm_before_docker(monkeypatch, tmp_path, capsys, 
     assert "Hermes does not support VibePod's global LLM wiring" in output.out + output.err
     if acp:
         assert output.out == ""
+
+
+def test_hermes_rejects_global_llm_without_persisting_workspace(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Rejecting Hermes' LLM wiring must happen before the allow-dir side effect.
+
+    With an unspecified + disallowed workspace on an interactive stdin that
+    agrees to allow the dir, the old ordering persisted the workspace to the
+    allow list and only then rejected Hermes. Validation must run first so a
+    launch this run() is about to refuse never trusts new directories.
+    """
+    allowed_added: list[str] = []
+    cfg = _make_config()
+    cfg["llm"] = {"enabled": True, "model": "proxy-only-model"}
+    monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(run_cmd, "is_dir_allowed", lambda p: False)
+    monkeypatch.setattr(run_cmd, "is_protected_dir", lambda p: False)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(run_cmd, "add_allowed_dir", lambda p: allowed_added.append(str(p)))
+    monkeypatch.setattr(run_cmd.Confirm, "ask", lambda *a, **k: True)
+
+    with pytest.raises(typer.Exit) as exc:
+        run_cmd.run(agent="hermes", workspace=tmp_path, detach=True)
+
+    assert exc.value.exit_code == 1
+    assert allowed_added == []
+    output = capsys.readouterr()
+    assert "Hermes does not support VibePod's global LLM wiring" in output.out + output.err
 
 
 def test_llm_enabled_injects_openai_env_vars(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3335,6 +3335,7 @@ def test_resolve_acp_command_parses_string_overrides_like_a_shell() -> None:
 
 
 def test_hermes_skill_paths_use_shared_agents_dir() -> None:
+    """Hermes' skills live under the official image's /opt/data state volume."""
     from vibepod.commands.run import _agent_skill_paths
 
-    assert _agent_skill_paths("hermes") == ["/config/.agents/skills"]
+    assert _agent_skill_paths("hermes") == ["/opt/data/.agents/skills"]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1348,7 +1348,7 @@ def _make_config(
     }
 
 
-@pytest.mark.parametrize("agent", SUPPORTED_AGENTS)
+@pytest.mark.parametrize("agent", [agent for agent in SUPPORTED_AGENTS if agent != "hermes"])
 def test_run_uses_keep_id_for_rootless_podman_agents(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1368,6 +1368,34 @@ def test_run_uses_keep_id_for_rootless_podman_agents(
     assert stub.run_kwargs["user"] is None
     assert env["USER_UID"] == "0"
     assert env["USER_GID"] == "0"
+
+
+@pytest.mark.parametrize("acp", [False, True])
+@pytest.mark.parametrize("agent", ["hermes", "nous"])
+def test_hermes_rejects_rootless_podman_before_provisioning(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    acp,
+    agent,
+):
+    stub = _StubDockerManager(rootless_podman=True)
+    monkeypatch.setattr(run_cmd, "get_config", _make_config)
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(
+        stub,
+        "ensure_network",
+        lambda name: pytest.fail("must reject before provisioning"),
+    )
+    with pytest.raises(typer.Exit) as exc:
+        run_cmd.run(agent=agent, workspace=tmp_path, acp=acp)
+    assert exc.value.exit_code == 1
+    assert stub.run_kwargs is None
+    assert stub.pulled == []
+    output = capsys.readouterr()
+    assert "Hermes does not support rootless Podman" in output.out + output.err
+    if acp:
+        assert output.out == ""
 
 
 def test_run_preserves_host_user_for_non_podman_devstral(
@@ -3202,6 +3230,18 @@ def test_acp_workspace_mount_path_accepts_wsl_paths() -> None:
     # these with backslashes and the assertion would test nothing.
     for wsl_path in ("/home/you/proj", "/mnt/c/dev/proj"):
         assert run_cmd._acp_workspace_mount_path(PurePosixPath(wsl_path), spec) == wsl_path
+
+
+@pytest.mark.parametrize("workspace", ["/opt/hermes", "/opt/hermes/project", "/opt"])
+def test_hermes_acp_rejects_installation_overlap(workspace: str) -> None:
+    with pytest.raises(typer.Exit):
+        run_cmd._acp_workspace_mount_path(PurePosixPath(workspace), get_agent_spec("hermes"))
+
+
+@pytest.mark.parametrize("agent", ["hermes", "claude"])
+def test_acp_allows_unrelated_opt_workspace(agent: str) -> None:
+    workspace = PurePosixPath("/opt/hermes-project")
+    assert run_cmd._acp_workspace_mount_path(workspace, get_agent_spec(agent)) == str(workspace)
 
 
 def test_acp_workspace_mount_path_guard(tmp_path: Path) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3332,3 +3332,9 @@ def test_resolve_acp_command_parses_string_overrides_like_a_shell() -> None:
     # An empty override is "no adapter", not "run the image default".
     assert run_cmd._resolve_acp_command(spec, {"acp_command": ""}) is None
     assert run_cmd._resolve_acp_command(spec, {"acp_command": []}) is None
+
+
+def test_hermes_skill_paths_use_shared_agents_dir() -> None:
+    from vibepod.commands.run import _agent_skill_paths
+
+    assert _agent_skill_paths("hermes") == ["/config/.agents/skills"]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1889,6 +1889,22 @@ def test_ikwid_false_does_not_modify_command(monkeypatch, tmp_path: Path) -> Non
     assert captured["command"] == ["claude"]
 
 
+@pytest.mark.parametrize("acp", [False, True])
+@pytest.mark.parametrize("agent", ["hermes", "nous"])
+def test_hermes_rejects_global_llm_before_docker(monkeypatch, tmp_path, capsys, acp, agent):
+    cfg = _make_config()
+    cfg["llm"] = {"enabled": True, "model": "proxy-only-model"}
+    monkeypatch.setattr(run_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: pytest.fail("must reject before Docker"))
+    with pytest.raises(typer.Exit) as exc:
+        run_cmd.run(agent=agent, workspace=tmp_path, acp=acp)
+    assert exc.value.exit_code == 1
+    output = capsys.readouterr()
+    assert "Hermes does not support VibePod's global LLM wiring" in output.out + output.err
+    if acp:
+        assert output.out == ""
+
+
 def test_llm_enabled_injects_openai_env_vars(monkeypatch, tmp_path: Path) -> None:
     """When llm.enabled=true, OPENAI_BASE_URL/API_KEY/MODEL are injected."""
     captured: dict = {}
@@ -2901,14 +2917,21 @@ def _script_acp_editor(
 
 
 @_requires_posix_workspace
-def test_acp_uses_acp_command_and_stdio_container(monkeypatch, _acp_env) -> None:
+@pytest.mark.parametrize(
+    ("agent", "command"),
+    [
+        ("claude", ["npx", "-y", "@agentclientprotocol/claude-agent-acp"]),
+        ("hermes", ["hermes-acp"]),
+    ],
+)
+def test_acp_uses_acp_command_and_stdio_container(monkeypatch, _acp_env, agent, command) -> None:
     captured: dict = {}
     monkeypatch.setattr(run_cmd, "get_config", lambda: _make_config())
     monkeypatch.setattr(run_cmd, "DockerManager", _make_acp_manager(captured))
 
-    run_cmd.run(agent="claude", workspace=_acp_env, acp=True)
+    run_cmd.run(agent=agent, workspace=_acp_env, acp=True)
 
-    assert captured["command"] == ["npx", "-y", "@agentclientprotocol/claude-agent-acp"]
+    assert captured["command"] == command
     assert captured["start"] is False
     assert captured["tty"] is False
     assert captured["workspace_mount_path"] == str(_acp_env)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1379,6 +1379,11 @@ def test_hermes_rejects_rootless_podman_before_provisioning(
     acp,
     agent,
 ):
+    if acp and os.name == "nt":
+        # The ACP workspace path-parity guard runs before the rootless-runtime
+        # check and aborts on a non-POSIX workspace path, so on native Windows
+        # this variant exits with the WSL2 hint instead of the rootless error.
+        pytest.skip("ACP mode runs from WSL2 on Windows, where workspace paths are POSIX")
     stub = _StubDockerManager(rootless_podman=True)
     monkeypatch.setattr(run_cmd, "get_config", _make_config)
     monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -158,6 +158,22 @@ def test_task_create_rejects_agent_without_headless_prefix(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("agent", ["hermes", "nous"])
+def test_hermes_rejects_global_llm_before_task_creation(
+    monkeypatch, tmp_path, tmp_task_store, capsys, agent
+):
+    cfg = _make_config()
+    cfg["llm"] = {"enabled": True, "model": "proxy-only-model"}
+    monkeypatch.setattr(task_cmd, "get_config", lambda: cfg)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: pytest.fail("must reject before Docker"))
+    with pytest.raises(typer.Exit) as exc:
+        task_cmd.task_create(agent=agent, prompt="hello", workspace=tmp_path)
+    assert exc.value.exit_code == 1
+    output = capsys.readouterr()
+    assert "Hermes does not support VibePod's global LLM wiring" in output.out + output.err
+    assert tmp_task_store.list() == []
+
+
 def test_task_create_claude_builds_headless_command(monkeypatch, tmp_path, tmp_task_store) -> None:
     stub = _CapturingDockerManager()
     monkeypatch.setattr(task_cmd, "get_config", _make_config)

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -160,7 +160,11 @@ def test_task_create_rejects_agent_without_headless_prefix(
 
 @pytest.mark.parametrize("agent", ["hermes", "nous"])
 def test_hermes_rejects_global_llm_before_task_creation(
-    monkeypatch, tmp_path, tmp_task_store, capsys, agent
+    monkeypatch,
+    tmp_path,
+    tmp_task_store,
+    capsys,
+    agent,
 ):
     cfg = _make_config()
     cfg["llm"] = {"enabled": True, "model": "proxy-only-model"}
@@ -1097,6 +1101,32 @@ def test_task_create_uses_keep_id_on_rootless_podman(monkeypatch, tmp_path, tmp_
     assert stub.run_kwargs["user"] is None
     assert stub.run_kwargs["env"]["USER_UID"] == "0"
     assert stub.run_kwargs["env"]["USER_GID"] == "0"
+
+
+@pytest.mark.parametrize("agent", ["hermes", "nous"])
+def test_task_hermes_rejects_rootless_podman_before_provisioning(
+    monkeypatch,
+    tmp_path,
+    tmp_task_store,
+    capsys,
+    agent,
+) -> None:
+    stub = _CapturingDockerManager()
+    monkeypatch.setattr(stub, "is_rootless_podman", lambda: True, raising=False)
+    monkeypatch.setattr(
+        stub,
+        "ensure_network",
+        lambda name: pytest.fail("must reject before provisioning"),
+    )
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+    with pytest.raises(typer.Exit) as exc:
+        task_cmd.task_create(agent=agent, prompt="hello", workspace=tmp_path)
+    assert exc.value.exit_code == 1
+    assert stub.run_kwargs is None
+    assert tmp_task_store.list() == []
+    output = capsys.readouterr()
+    assert "Hermes does not support rootless Podman" in output.out + output.err
 
 
 def test_task_create_preserves_host_user_for_non_podman(

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -158,7 +158,7 @@ def test_task_create_rejects_agent_without_headless_prefix(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("agent", ["hermes", "nous"])
+@pytest.mark.parametrize("agent", ["hermes"])
 def test_hermes_rejects_global_llm_before_task_creation(
     monkeypatch,
     tmp_path,
@@ -1103,7 +1103,7 @@ def test_task_create_uses_keep_id_on_rootless_podman(monkeypatch, tmp_path, tmp_
     assert stub.run_kwargs["env"]["USER_GID"] == "0"
 
 
-@pytest.mark.parametrize("agent", ["hermes", "nous"])
+@pytest.mark.parametrize("agent", ["hermes"])
 def test_task_hermes_rejects_rootless_podman_before_provisioning(
     monkeypatch,
     tmp_path,

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -118,6 +118,7 @@ def test_headless_prefix_set_for_supported_agents() -> None:
     assert AGENT_SPECS["tau"].headless_prefix == ["-p"]
     assert AGENT_SPECS["jcode"].headless_prefix == ["run"]
     assert AGENT_SPECS["qwen"].headless_prefix == ["-p"]
+    assert AGENT_SPECS["hermes"].headless_prefix == ["-z"]
 
 
 def test_headless_prefix_none_for_unsupported_agents() -> None:
@@ -1240,3 +1241,35 @@ def test_task_create_materializes_source_policy_and_wires_identity(
         (tmp_path / "proxy" / "policies" / "containers" / f"{'2' * 32}.json").read_text(),
     )
     assert record["profile"] == "default"
+
+
+def test_hermes_headless_command_is_not_overridden() -> None:
+    # -z/--oneshot takes the prompt as its value, so the generic
+    # base_command + ikwid + headless_prefix + [prompt] path is correct and no
+    # headless_command override is needed.
+    assert AGENT_SPECS["hermes"].headless_command is None
+
+
+def test_task_create_hermes_places_yolo_before_oneshot(
+    monkeypatch,
+    tmp_path,
+    tmp_task_store,
+) -> None:
+    """`-z` consumes the next token as its value, so --yolo must come first."""
+    stub = _CapturingDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+
+    task_cmd.task_create(
+        agent="hermes",
+        prompt="summarize this repository",
+        workspace=tmp_path,
+        ikwid=True,
+    )
+
+    assert stub.run_kwargs["command"] == [
+        "hermes",
+        "--yolo",
+        "-z",
+        "summarize this repository",
+    ]


### PR DESCRIPTION
Adds support for the Hermes agent (by Nous Research) throughout the VibePod project. It introduces Hermes as a first-class agent, including configuration, documentation, command-line integration, skill management, and editor/ACP support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Hermes as a supported agent with the `h` shortcut and `nous` alias.
  - Added one-shot tasks, IKWID mode, ACP editor integration, skills, session resuming, and preview support.
  - Added a default Hermes image, image override support, and workspace write sandboxing.

- **Bug Fixes**
  - Hermes now rejects unsupported global LLM wiring and rootless Podman before launch.

- **Documentation**
  - Updated supported-agent, configuration, ACP, and Hermes usage guidance.

- **Tests**
  - Expanded coverage for Hermes commands, configuration, ACP, sandboxing, and session resuming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->