### PR TITLE
Skip the herdr socket mount on VM-backed Podman engines, closes #170

### DIFF
--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -61,8 +61,15 @@ API: send a `pane.report_agent` JSON request over the unix socket at
 
 ## Limitations
 
-- Windows hosts are skipped: herdr uses named pipes there, which cannot be
-  bind-mounted into Linux containers.
+- Windows hosts are skipped entirely: herdr uses named pipes there (not a
+  filesystem Unix socket), so neither the container wiring nor the host-side
+  pane report works; `vp run` simply runs without herdr integration.
+- Podman on macOS runs the engine inside a VM and shares host paths over
+  virtiofs, which does not carry socket inodes — the socket mount fails
+  outright there. VibePod skips the container wiring on such engines and only
+  reports the `vp:<agent>` pane identity from the host, so the agent still
+  appears in herdr but without working/blocked/idle transitions. (On Windows
+  even this host-side report is unavailable, for the named-pipe reason above.)
 - Shell/JavaScript hooks need `node` in the agent image or a `herdr` binary
   that can run inside the container. Tau instead uses its installed Python
   runtime. Homebrew-on-Linux and musl-linked host binaries may not run in stock

--- a/src/vibepod/commands/doctor.py
+++ b/src/vibepod/commands/doctor.py
@@ -15,7 +15,7 @@ import typer
 from vibepod.core.agents import agent_config_dir
 from vibepod.core.config import get_config
 from vibepod.core.profiles import resolve_profile
-from vibepod.utils.console import console, error, success, warning
+from vibepod.utils.console import console, error, info, success, warning
 
 app = typer.Typer(help="Inspect agent auth and config state")
 
@@ -275,6 +275,20 @@ def _elf_linkage(path: Path) -> str:
     return "static"
 
 
+def _engine_mounts_host_sockets() -> bool:
+    """True when the container engine can bind-mount a host unix socket.
+
+    Never raises: an unreachable engine returns True so the probe below reports
+    the real error instead of a misleading capability skip.
+    """
+    try:
+        from vibepod.core.docker import DockerManager
+
+        return DockerManager().supports_host_socket_mounts()
+    except Exception:  # noqa: BLE001 - diagnostics must not abort on a dead engine
+        return True
+
+
 def _herdr_log_relpath(agent: str) -> str | None:
     """Config-dir-relative path of the hook trace log for sh-hook agents."""
     return {
@@ -493,14 +507,25 @@ def herdr_doctor(
     console.print()
     console.print(f"[bold]Injected files ({agent})[/bold]")
     cfg_dir = agent_config_dir(agent, active_profile)
+    # On VM-backed engines (Podman off Linux) vp run intentionally never injects
+    # these hooks, so a missing file is not a failure there. Compute once and
+    # reuse for the container probe below (never raises; a dead engine reads as
+    # "supported" so the real connection error is reported instead).
+    socket_supported = _engine_mounts_host_sockets()
     entries = herdr_core.BUILTIN_INTEGRATIONS.get(agent, [])
     if not entries:
         console.print("  (no built-in integration for this agent)")
     for _resource, dest in entries:
         target = cfg_dir / dest
         if not target.is_file():
-            warning(f"  missing: {target} — run `vp run {agent}` inside a pane to inject")
-            failures += 1
+            if socket_supported:
+                warning(f"  missing: {target} — run `vp run {agent}` inside a pane to inject")
+                failures += 1
+            else:
+                info(
+                    f"  {target} absent (expected: this engine can't mount the herdr "
+                    "socket, so hooks are never injected)",
+                )
         else:
             exec_ok = os.access(target, os.X_OK) if dest.endswith(".sh") else True
             console.print(f"  {target} ({'executable' if exec_ok else 'NOT EXECUTABLE'})")
@@ -512,22 +537,26 @@ def herdr_doctor(
             encoding="utf-8",
             errors="replace",
         )
-        (console.print if registered else warning)(
-            f"  settings.json hooks: {'registered' if registered else 'NOT REGISTERED'}",
-        )
-        if not registered:
+        if registered:
+            console.print("  settings.json hooks: registered")
+        elif socket_supported:
+            warning("  settings.json hooks: NOT REGISTERED")
             failures += 1
+        else:
+            info("  settings.json hooks: not registered (engine can't mount the herdr socket)")
     if agent == "codex":
         toml_path = cfg_dir / ".codex" / "config.toml"
         registered = toml_path.is_file() and "herdr-agent-state.sh" in toml_path.read_text(
             encoding="utf-8",
             errors="replace",
         )
-        (console.print if registered else warning)(
-            f"  config.toml notify: {'registered' if registered else 'NOT REGISTERED'}",
-        )
-        if not registered:
+        if registered:
+            console.print("  config.toml notify: registered")
+        elif socket_supported:
+            warning("  config.toml notify: NOT REGISTERED")
             failures += 1
+        else:
+            info("  config.toml notify: not registered (engine can't mount the herdr socket)")
 
     log_dirs = {"claude": "", "codex": ".codex", "copilot": ".copilot"}
     if agent in log_dirs:
@@ -558,6 +587,12 @@ def herdr_doctor(
     probe_reported = False
     if not volumes or not pane or agent not in probe_payloads:
         warning("  skipped (needs socket + pane env; sh-hook agents only)")
+    elif not socket_supported:
+        warning(
+            "  skipped: this container engine cannot bind-mount the herdr socket "
+            "(Podman runs the engine in a VM on macOS and Windows); vp run reports "
+            "pane identity from the host instead, without live agent state",
+        )
     else:
         manager = None
         image = None

--- a/src/vibepod/commands/run.py
+++ b/src/vibepod/commands/run.py
@@ -39,6 +39,9 @@ from vibepod.core.herdr import (
     clear_pane_metadata as _clear_herdr_metadata,
 )
 from vibepod.core.herdr import (
+    pane_reporting_enabled as _herdr_pane_reporting_enabled,
+)
+from vibepod.core.herdr import (
     reexec_with_agent_hint as _reexec_with_herdr_hint,
 )
 from vibepod.core.herdr import (
@@ -761,6 +764,9 @@ def run(
         merged_env["USER_UID"] = "0"
         merged_env["USER_GID"] = "0"
 
+    socket_mount_probe = getattr(manager, "supports_host_socket_mounts", None)
+    herdr_socket_mounts = bool(socket_mount_probe()) if callable(socket_mount_probe) else True
+
     network_name = str(config.get("network", "vibepod-network"))
     manager.ensure_network(network_name)
     extra_network = network or _maybe_select_network(
@@ -873,13 +879,17 @@ def run(
         config_dir,
         config,
         no_herdr=no_herdr or acp,
+        mount_socket=herdr_socket_mounts,
     )
+    # Host-side reporting works even when the socket cannot be mounted, so it
+    # is gated on the pane, not on the container wiring.
+    herdr_pane = _herdr_pane_reporting_enabled(config, no_herdr=no_herdr or acp)
     herdr_labels = (
         {_HERDR_PANE_LABEL: os.environ["HERDR_PANE_ID"]}
-        if herdr_volumes and os.environ.get("HERDR_PANE_ID")
+        if herdr_pane and os.environ.get("HERDR_PANE_ID")
         else {}
     )
-    if herdr_volumes:
+    if herdr_pane:
         _report_herdr_metadata(selected_agent)
     extra_volumes.extend(herdr_volumes)
     # setdefault: explicit -e HERDR_* overrides (already in merged_env) win
@@ -980,6 +990,9 @@ def run(
     except Exception:
         if proxy_policy_id is not None:
             remove_container_policy(config, proxy_policy_id)
+        if herdr_pane:
+            _release_herdr_agent(selected_agent)
+            _clear_herdr_metadata(selected_agent)
         raise
 
     container.reload()
@@ -993,7 +1006,7 @@ def run(
                 sys.stderr.flush()
             else:
                 print(recent)
-        if herdr_volumes:
+        if herdr_pane:
             _release_herdr_agent(selected_agent)
             _clear_herdr_metadata(selected_agent)
         raise typer.Exit(1)
@@ -1063,7 +1076,7 @@ def run(
                 "the setup-token flow requires an interactive session.",
             )
             container.stop(timeout=5)
-            if herdr_volumes:
+            if herdr_pane:
                 _release_herdr_agent(selected_agent)
                 _clear_herdr_metadata(selected_agent)
             raise typer.Exit(1)
@@ -1122,7 +1135,7 @@ def run(
         raise
     finally:
         logger.close_session(exit_reason)
-        if herdr_volumes:
+        if herdr_pane:
             _release_herdr_agent(selected_agent)
             _clear_herdr_metadata(selected_agent)
 

--- a/src/vibepod/commands/task.py
+++ b/src/vibepod/commands/task.py
@@ -29,7 +29,14 @@ from vibepod.core.agents import (
 from vibepod.core.allowed_dirs import add_allowed_dir, is_dir_allowed, is_protected_dir
 from vibepod.core.config import get_config, get_config_root
 from vibepod.core.docker import DockerClientError, DockerManager, _is_latest_tag
-from vibepod.core.herdr import PANE_LABEL, apply_herdr_if_enabled
+from vibepod.core.herdr import (
+    PANE_LABEL,
+    apply_herdr_if_enabled,
+    clear_pane_metadata,
+    pane_reporting_enabled,
+    release_agent,
+    report_pane_metadata,
+)
 from vibepod.core.launch import (
     agent_extra_volumes,
     agent_init_commands,
@@ -686,161 +693,180 @@ def task_create(
     for host_path, _, _ in extra_volumes:
         Path(host_path).mkdir(parents=True, exist_ok=True)
 
+    socket_mount_probe = getattr(manager, "supports_host_socket_mounts", None)
     herdr_volumes, herdr_env = apply_herdr_if_enabled(
         selected,
         config_dir,
         config,
         no_herdr=no_herdr,
+        mount_socket=bool(socket_mount_probe()) if callable(socket_mount_probe) else True,
     )
     extra_volumes.extend(herdr_volumes)
+    # Host-side reporting works even when the socket cannot be mounted, so it
+    # is gated on the pane, not on the container wiring (matches `vp run`).
+    herdr_pane = pane_reporting_enabled(config, no_herdr=no_herdr)
     herdr_labels = (
         {PANE_LABEL: os.environ["HERDR_PANE_ID"]}
-        if herdr_volumes and os.environ.get("HERDR_PANE_ID")
+        if herdr_pane and os.environ.get("HERDR_PANE_ID")
         else {}
     )
-    # setdefault: explicit -e HERDR_* overrides (already in merged_env) win
-    for key, value in herdr_env.items():
-        merged_env.setdefault(key, value)
-
-    proxy_cfg = config.get("proxy", {})
-    proxy_enabled = bool(proxy_cfg.get("enabled", True))
-    proxy_ca_dir_value = str(proxy_cfg.get("ca_dir", "")).strip()
-    proxy_ca_path_value = str(proxy_cfg.get("ca_path", "")).strip()
-    proxy_ca_dir = Path(proxy_ca_dir_value).expanduser().resolve() if proxy_ca_dir_value else None
-    proxy_ca_path = (
-        Path(proxy_ca_path_value).expanduser().resolve() if proxy_ca_path_value else None
-    )
-    proxy_db_path: Path | None = None
-    proxy_policy_id: str | None = None
-
-    if proxy_enabled:
-        proxy_image = str(proxy_cfg.get("image", "vibepod/proxy:latest"))
-        proxy_db_path = (
-            Path(str(proxy_cfg.get("db_path", "~/.config/vibepod/proxy/proxy.db")))
-            .expanduser()
-            .resolve()
-        )
-
-        actual_ca_dir = proxy_ca_dir or proxy_db_path.parent / "mitmproxy"
-        try:
-            provision_proxy(
-                manager,
-                image=proxy_image,
-                db_path=proxy_db_path,
-                ca_dir=actual_ca_dir,
-                network=network_name,
-                auto_clean=bool(config.get("auto_clean", True)),
-            )
-            proxy_policy_id = materialize_launch_policy(
-                manager,
-                config,
-                profile=active_profile,
-                workspace=workspace_path,
-            )
-        except (DockerClientError, ValueError) as exc:
-            error(str(exc))
-            raise typer.Exit(1) from exc
-
-        if proxy_ca_path:
-            deadline = time.time() + 10
-            while time.time() < deadline:
-                if proxy_ca_path.exists():
-                    break
-                time.sleep(0.25)
-
-        apply_proxy_env(merged_env, proxy_policy_id)
-
-        extra_volumes.append((str(actual_ca_dir), "/etc/vibepod-proxy-ca", "ro"))
-
-    info(f"Starting task on {selected} with image {image}")
-    container_user = None
-    if not rootless_podman and spec.run_as_host_user:
-        container_user = host_user()
-    launch_labels = dict(herdr_labels)
-    launch_labels["vibepod.profile"] = active_profile
-    if proxy_policy_id is not None:
-        launch_labels["vibepod.proxy-policy"] = proxy_policy_id
     try:
-        container = manager.run_agent(
-            agent=selected,
-            image=image,
-            workspace=workspace_path,
-            config_dir=config_dir,
-            config_mount_path=spec.config_mount_path,
-            env=merged_env,
-            command=command,
-            auto_remove=False,  # tasks keep the container so logs/exit survive
-            name=name,
-            version=__version__,
-            network=network_name,
-            ports=agent_ports,
-            extra_volumes=extra_volumes,
-            platform=spec.platform,
-            user=container_user,
-            entrypoint=entrypoint,
-            userns_mode=agent_userns_mode,
-            extra_labels=launch_labels,
+        if herdr_pane:
+            report_pane_metadata(selected)
+        # setdefault: explicit -e HERDR_* overrides (already in merged_env) win
+        for key, value in herdr_env.items():
+            merged_env.setdefault(key, value)
+
+        proxy_cfg = config.get("proxy", {})
+        proxy_enabled = bool(proxy_cfg.get("enabled", True))
+        proxy_ca_dir_value = str(proxy_cfg.get("ca_dir", "")).strip()
+        proxy_ca_path_value = str(proxy_cfg.get("ca_path", "")).strip()
+        proxy_ca_dir = (
+            Path(proxy_ca_dir_value).expanduser().resolve() if proxy_ca_dir_value else None
         )
-    except Exception:
+        proxy_ca_path = (
+            Path(proxy_ca_path_value).expanduser().resolve() if proxy_ca_path_value else None
+        )
+        proxy_db_path: Path | None = None
+        proxy_policy_id: str | None = None
+
+        if proxy_enabled:
+            proxy_image = str(proxy_cfg.get("image", "vibepod/proxy:latest"))
+            proxy_db_path = (
+                Path(str(proxy_cfg.get("db_path", "~/.config/vibepod/proxy/proxy.db")))
+                .expanduser()
+                .resolve()
+            )
+
+            actual_ca_dir = proxy_ca_dir or proxy_db_path.parent / "mitmproxy"
+            try:
+                provision_proxy(
+                    manager,
+                    image=proxy_image,
+                    db_path=proxy_db_path,
+                    ca_dir=actual_ca_dir,
+                    network=network_name,
+                    auto_clean=bool(config.get("auto_clean", True)),
+                )
+                proxy_policy_id = materialize_launch_policy(
+                    manager,
+                    config,
+                    profile=active_profile,
+                    workspace=workspace_path,
+                )
+            except (DockerClientError, ValueError) as exc:
+                error(str(exc))
+                raise typer.Exit(1) from exc
+
+            if proxy_ca_path:
+                deadline = time.time() + 10
+                while time.time() < deadline:
+                    if proxy_ca_path.exists():
+                        break
+                    time.sleep(0.25)
+
+            apply_proxy_env(merged_env, proxy_policy_id)
+
+            extra_volumes.append((str(actual_ca_dir), "/etc/vibepod-proxy-ca", "ro"))
+
+        info(f"Starting task on {selected} with image {image}")
+        container_user = None
+        if not rootless_podman and spec.run_as_host_user:
+            container_user = host_user()
+        launch_labels = dict(herdr_labels)
+        launch_labels["vibepod.profile"] = active_profile
         if proxy_policy_id is not None:
-            remove_container_policy(config, proxy_policy_id)
-        raise
-
-    container.reload()
-    if container.status not in {"running", "created"}:
-        recent = container.logs(tail=50).decode("utf-8", errors="replace")
-        error("Container exited immediately after start.")
-        if recent.strip():
-            print(recent)
-        raise typer.Exit(1)
-
-    if network and network != network_name:
+            launch_labels["vibepod.proxy-policy"] = proxy_policy_id
         try:
-            manager.connect_network(container, network)
-            info(f"Connected to additional network: {network}")
-        except DockerClientError as exc:
-            warning(str(exc))
-
-    if proxy_db_path is not None:
-        container_ip = get_container_ip(container, network_name)
-        if container_ip:
-            mapping_path = proxy_db_path.parent / "containers.json"
-            update_container_mapping(
-                mapping_path,
-                container_ip,
-                container.id,
-                container.name,
-                selected,
-                policy_id=proxy_policy_id,
-                profile=active_profile,
+            container = manager.run_agent(
+                agent=selected,
+                image=image,
+                workspace=workspace_path,
+                config_dir=config_dir,
+                config_mount_path=spec.config_mount_path,
+                env=merged_env,
+                command=command,
+                auto_remove=False,  # tasks keep the container so logs/exit survive
+                name=name,
+                version=__version__,
+                network=network_name,
+                ports=agent_ports,
+                extra_volumes=extra_volumes,
+                platform=spec.platform,
+                user=container_user,
+                entrypoint=entrypoint,
+                userns_mode=agent_userns_mode,
+                extra_labels=launch_labels,
             )
+        except Exception:
+            if proxy_policy_id is not None:
+                remove_container_policy(config, proxy_policy_id)
+            raise
 
-    state = container.attrs.get("State", {}) or {}
-    if not isinstance(state, dict):
-        state = {}
-    initial_status = TASK_STATUS_RUNNING if container.status == "running" else TASK_STATUS_STARTING
+        container.reload()
+        if container.status not in {"running", "created"}:
+            recent = container.logs(tail=50).decode("utf-8", errors="replace")
+            error("Container exited immediately after start.")
+            if recent.strip():
+                print(recent)
+            raise typer.Exit(1)
 
-    store = _task_store()
-    try:
-        record = store.create(
-            agent=selected,
-            prompt=prompt,
-            workspace=str(workspace_path),
-            container_id=container.id,
-            container_name=container.name,
-            image=image,
-            vibepod_version=__version__,
-            status=initial_status,
-            started_at=_state_timestamp(state, "StartedAt"),
+        if network and network != network_name:
+            try:
+                manager.connect_network(container, network)
+                info(f"Connected to additional network: {network}")
+            except DockerClientError as exc:
+                warning(str(exc))
+
+        if proxy_db_path is not None:
+            container_ip = get_container_ip(container, network_name)
+            if container_ip:
+                mapping_path = proxy_db_path.parent / "containers.json"
+                update_container_mapping(
+                    mapping_path,
+                    container_ip,
+                    container.id,
+                    container.name,
+                    selected,
+                    policy_id=proxy_policy_id,
+                    profile=active_profile,
+                )
+
+        state = container.attrs.get("State", {}) or {}
+        if not isinstance(state, dict):
+            state = {}
+        initial_status = (
+            TASK_STATUS_RUNNING if container.status == "running" else TASK_STATUS_STARTING
         )
-    except Exception as exc:
-        error(f"Failed to persist task record: {exc}. Stopping container {container.name}.")
+
+        store = _task_store()
         try:
-            manager.stop_container(container.id, force=True)
-            container.remove(force=True)
-        except Exception as cleanup_exc:
-            warning(f"Container {container.name} may be orphaned: {cleanup_exc}")
-        raise typer.Exit(1) from exc
+            record = store.create(
+                agent=selected,
+                prompt=prompt,
+                workspace=str(workspace_path),
+                container_id=container.id,
+                container_name=container.name,
+                image=image,
+                vibepod_version=__version__,
+                status=initial_status,
+                started_at=_state_timestamp(state, "StartedAt"),
+            )
+        except Exception as exc:
+            error(f"Failed to persist task record: {exc}. Stopping container {container.name}.")
+            try:
+                manager.stop_container(container.id, force=True)
+                container.remove(force=True)
+            except Exception as cleanup_exc:
+                warning(f"Container {container.name} may be orphaned: {cleanup_exc}")
+            raise typer.Exit(1) from exc
+    except BaseException:
+        # A failed launch has no task lifecycle to clear its host-side report.
+        # Include interruption and keep reports only once the task is persisted.
+        if herdr_pane:
+            release_agent(selected)
+            clear_pane_metadata(selected)
+        raise
     success(f"Task started: {record.id}")
     info(f"  container: {container.name}")
     if timeout_seconds is None:

--- a/src/vibepod/core/docker.py
+++ b/src/vibepod/core/docker.py
@@ -264,6 +264,22 @@ class DockerManager:
                 ) from retry_exc
 
         self._rootless_podman: bool | None = None
+        self._podman: bool | None = None
+
+    def is_podman(self) -> bool:
+        """Return True when the Docker-compatible engine is Podman."""
+        cached = getattr(self, "_podman", None)
+        if isinstance(cached, bool):
+            return cached
+
+        try:
+            version = self.client.version()
+        except (APIError, DockerException, AttributeError):
+            self._podman = False
+            return False
+
+        self._podman = _version_is_podman(version)
+        return self._podman
 
     def is_rootless_podman(self) -> bool:
         """Return True for a rootless Podman engine exposed through the Docker API."""
@@ -273,7 +289,6 @@ class DockerManager:
 
         try:
             info = self.client.info()
-            version = self.client.version()
         except (APIError, DockerException, AttributeError):
             self._rootless_podman = False
             return False
@@ -287,8 +302,20 @@ class DockerManager:
             isinstance(security_options, list)
             and any(str(option).lower() == "name=rootless" for option in security_options)
         )
-        self._rootless_podman = rootless and _version_is_podman(version)
+        self._rootless_podman = rootless and self.is_podman()
         return self._rootless_podman
+
+    def supports_host_socket_mounts(self) -> bool:
+        """Return True when a host unix socket can be bind-mounted into a container.
+
+        Podman off Linux always runs the engine inside a VM and reaches host
+        paths through a virtiofs share, which does not carry socket inodes: the
+        bind fails with ``make volume mountpoint for volume …: operation not
+        supported`` and takes the whole run down with it (issue #170).
+        """
+        if sys.platform.startswith("linux"):
+            return True
+        return not self.is_podman()
 
     def _pull_image_with_progress(self, image: str) -> None:
         from rich.progress import (

--- a/src/vibepod/core/herdr.py
+++ b/src/vibepod/core/herdr.py
@@ -290,7 +290,8 @@ def release_agent(
 
     pane = pane or os.environ.get("HERDR_PANE_ID")
     sock_path = resolve_socket()
-    if not pane or sock_path is None:
+    # Python on Windows exposes no AF_UNIX even though a socket path may resolve
+    if not pane or sock_path is None or not hasattr(socket_module, "AF_UNIX"):
         return False
     request = {
         "id": f"vibepod:{os.getpid()}:release",
@@ -356,7 +357,8 @@ def _report_agent_via_socket(agent: str, pane: str) -> bool:
     import socket as socket_module
 
     sock_path = resolve_socket()
-    if sock_path is None:
+    # Python on Windows exposes no AF_UNIX even though a socket path may resolve
+    if sock_path is None or not hasattr(socket_module, "AF_UNIX"):
         return False
     request = {
         "id": f"vibepod:{os.getpid()}:metadata",

--- a/src/vibepod/core/herdr.py
+++ b/src/vibepod/core/herdr.py
@@ -326,7 +326,7 @@ def reexec_with_agent_hint(agent: str, config: dict[str, Any], *, no_herdr: bool
     hook events, so screen detection is their only state source). No-op
     when the hint already matches (post-re-exec) or herdr is inactive.
     """
-    if no_herdr or not herdr_enabled(config) or not herdr_active():
+    if not pane_reporting_enabled(config, no_herdr=no_herdr):
         return
     if os.environ.get("HERDR_AGENT") == agent or not sys.argv:
         return
@@ -434,18 +434,37 @@ def herdr_enabled(config: dict[str, Any]) -> bool:
     return bool(value)
 
 
+def pane_reporting_enabled(config: dict[str, Any], *, no_herdr: bool) -> bool:
+    """True when this run should report its agent to the herdr pane.
+
+    Host-side reports (``report_pane_metadata`` / ``release_agent``) talk to
+    the socket directly, so they work even when the container wiring does not.
+    """
+    return not no_herdr and herdr_enabled(config) and herdr_active()
+
+
 def apply_herdr_if_enabled(
     agent: str,
     config_dir: Path,
     config: dict[str, Any],
     *,
     no_herdr: bool,
+    mount_socket: bool = True,
 ) -> tuple[list[tuple[str, str, str]], dict[str, str]]:
     """Wire herdr for this run when inside a herdr pane. Never raises.
 
-    Returns (extra_volumes, env). Empty when disabled or not in a pane.
+    Returns (extra_volumes, env). Empty when disabled, not in a pane, or when
+    *mount_socket* is False because the container engine cannot bind-mount a
+    host unix socket — the caller still reports pane identity from the host.
     """
-    if no_herdr or not herdr_enabled(config) or not herdr_active():
+    if not pane_reporting_enabled(config, no_herdr=no_herdr):
+        return [], {}
+    if not mount_socket:
+        warning(
+            "herdr: this container engine cannot bind-mount the herdr socket "
+            "(Podman runs the engine in a VM on macOS and Windows); reporting pane "
+            "identity from the host only, without live agent state",
+        )
         return [], {}
     volumes, env = herdr_volumes_and_env()
     if not volumes:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -13,6 +13,49 @@ from vibepod.cli import app
 runner = CliRunner()
 
 
+def test_engine_mounts_host_sockets_assumes_capable_when_engine_unreachable(monkeypatch) -> None:
+    """A dead engine must not read as a capability skip, so the probe reports the
+    real connection error instead of a misleading 'skipped' message."""
+    from vibepod.commands import doctor as doctor_cmd
+
+    class _UnreachableEngine:
+        def __init__(self) -> None:
+            raise RuntimeError("engine not reachable")
+
+    monkeypatch.setattr("vibepod.core.docker.DockerManager", _UnreachableEngine)
+    assert doctor_cmd._engine_mounts_host_sockets() is True
+
+
+def test_herdr_doctor_vm_backed_engine_skips_injected_file_failures(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """On a VM-backed engine the deliberately-uninjected hook files and unregistered
+    settings are reported as expected, not counted as failures."""
+    from vibepod.commands import doctor as doctor_cmd
+
+    monkeypatch.setenv("HERDR_ENV", "1")
+    monkeypatch.setenv("HERDR_PANE_ID", "pane-1")
+    cfg_dir = tmp_path / "cfg"
+    cfg_dir.mkdir()
+
+    monkeypatch.setattr(doctor_cmd, "agent_config_dir", lambda _agent, _profile="default": cfg_dir)
+    monkeypatch.setattr(doctor_cmd, "resolve_profile", lambda _profile, _config: "default")
+    monkeypatch.setattr(doctor_cmd, "get_config", lambda: {})
+    monkeypatch.setattr("vibepod.core.herdr.resolve_socket", lambda: Path("/fake/herdr.sock"))
+    monkeypatch.setattr("vibepod.core.herdr.resolve_binary", lambda: None)
+    monkeypatch.setattr(doctor_cmd, "_engine_mounts_host_sockets", lambda: False)
+
+    # A VM-backed engine can't inject hooks, so this must NOT raise typer.Exit(1)
+    # even though no hook files or settings registration exist yet.
+    doctor_cmd.herdr_doctor(agent="claude")
+
+    out = capsys.readouterr().out
+    assert "run `vp run claude` inside a pane to inject" not in out
+    assert "absent (expected" in out
+
+
 def test_doctor_missing_dir(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(
         "vibepod.commands.doctor.agent_config_dir",

--- a/tests/test_herdr.py
+++ b/tests/test_herdr.py
@@ -376,6 +376,44 @@ def test_apply_wires_codex_notify(monkeypatch, tmp_path: Path) -> None:
     assert (config_dir / ".codex" / "config.toml").is_file()
 
 
+def test_apply_skips_wiring_when_socket_mounts_unsupported(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _activate(monkeypatch, tmp_path)
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    volumes, env = herdr.apply_herdr_if_enabled(
+        "claude",
+        config_dir,
+        {},
+        no_herdr=False,
+        mount_socket=False,
+    )
+
+    assert (volumes, env) == ([], {})
+    # no dead hook files left behind: they could only report through the socket
+    assert not (config_dir / "hooks" / "herdr-agent-state.sh").exists()
+    assert "cannot bind-mount the herdr socket" in capsys.readouterr().out
+
+
+def test_pane_reporting_enabled_ignores_socket_mount_support(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _activate(monkeypatch, tmp_path)
+    assert herdr.pane_reporting_enabled({}, no_herdr=False) is True
+    assert herdr.pane_reporting_enabled({}, no_herdr=True) is False
+    assert herdr.pane_reporting_enabled({"herdr": False}, no_herdr=False) is False
+
+
+def test_pane_reporting_disabled_outside_herdr(monkeypatch) -> None:
+    monkeypatch.delenv("HERDR_ENV", raising=False)
+    assert herdr.pane_reporting_enabled({}, no_herdr=False) is False
+
+
 def test_apply_warns_without_binary(monkeypatch, tmp_path: Path, capsys) -> None:
     _activate(monkeypatch, tmp_path, with_binary=False)
     config_dir = tmp_path / "cfg"

--- a/tests/test_herdr.py
+++ b/tests/test_herdr.py
@@ -677,6 +677,22 @@ def test_release_agent_noop_without_pane(monkeypatch, tmp_path: Path) -> None:
     assert herdr.release_agent("claude") is False
 
 
+def test_release_agent_noop_without_af_unix(monkeypatch, tmp_path: Path) -> None:
+    """Windows Python exposes no socket.AF_UNIX: with a resolvable socket path
+    (`vp doctor herdr` reaches here through the pane label) release must
+    degrade to False per its never-raises contract, not AttributeError."""
+    monkeypatch.delattr(socket_module, "AF_UNIX", raising=False)
+    monkeypatch.setattr(herdr, "resolve_socket", lambda: tmp_path / "herdr.sock")
+    monkeypatch.setenv("HERDR_PANE_ID", "w1:p1")
+    assert herdr.release_agent("claude") is False
+
+
+def test_report_agent_via_socket_noop_without_af_unix(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delattr(socket_module, "AF_UNIX", raising=False)
+    monkeypatch.setattr(herdr, "resolve_socket", lambda: tmp_path / "herdr.sock")
+    assert herdr._report_agent_via_socket("claude", "w1:p1") is False
+
+
 def test_run_module_imports_release() -> None:
     from vibepod.commands import run as run_module
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -44,12 +44,15 @@ def _write_overlay(workspace: Path, *parts: str) -> Path:
     return dockerfile
 
 
-def test_list_json_includes_short_and_full_agent_names(monkeypatch) -> None:
+def test_list_json_includes_short_and_full_agent_names(monkeypatch, tmp_path: Path) -> None:
     class _FakeDockerManager:
         def list_managed(self, all_containers: bool = True):  # noqa: ARG002
             return []
 
     monkeypatch.setattr(list_cmd, "DockerManager", _FakeDockerManager)
+    # cwd-hermetic: a stray .vibepod/overlay in the invoking project would
+    # otherwise pull overlay resolution (and image_id) into this test
+    monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["list", "--json"])
     assert result.exit_code == 0

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -879,6 +879,69 @@ def test_run_publish_flag_rejects_invalid_entry(monkeypatch, _tmp_config_root) -
     assert stub.run_kwargs is None
 
 
+class _NoSocketMountManager(_PortCapturingManager):
+    """Engine that cannot bind-mount a host unix socket (Podman in a VM)."""
+
+    def supports_host_socket_mounts(self) -> bool:
+        return False
+
+
+def _run_in_herdr_pane(monkeypatch, workspace: Path, stub) -> dict:
+    """Invoke `vp run` as if inside a herdr pane, returning the wiring calls."""
+    calls: dict = {}
+
+    def _fake_apply(agent, config_dir, config, *, no_herdr, mount_socket=True):
+        calls["mount_socket"] = mount_socket
+        # what apply_herdr_if_enabled returns when the socket cannot be mounted
+        return ([], {}) if not mount_socket else ([("/s.sock", "/herdr/herdr.sock", "rw")], {})
+
+    monkeypatch.setenv("HERDR_PANE_ID", "pane-1")
+    monkeypatch.setattr(run_cmd, "_reexec_with_herdr_hint", lambda *a, **kw: None)
+    monkeypatch.setattr(run_cmd, "_herdr_pane_reporting_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(run_cmd, "_apply_herdr_if_enabled", _fake_apply)
+    monkeypatch.setattr(
+        run_cmd,
+        "_report_herdr_metadata",
+        lambda agent: calls.setdefault("reported", agent),
+    )
+    monkeypatch.setattr(run_cmd, "get_config", lambda: _ports_config("claude", None))
+    monkeypatch.setattr(run_cmd, "DockerManager", lambda: stub)
+
+    result = CliRunner().invoke(app, ["run", "claude", "-w", str(workspace), "--detach"])
+    assert result.exit_code == 0, result.output
+    return calls
+
+
+def test_run_skips_herdr_socket_mount_on_vm_backed_engine(
+    monkeypatch,
+    _tmp_config_root,
+) -> None:
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _NoSocketMountManager()
+
+    calls = _run_in_herdr_pane(monkeypatch, workspace, stub)
+
+    assert calls["mount_socket"] is False
+    assert stub.run_kwargs is not None
+    assert all(dest != "/herdr/herdr.sock" for _, dest, _ in stub.run_kwargs["extra_volumes"])
+    # host-side pane identity survives: it never goes through the container
+    assert calls["reported"] == "claude"
+    assert stub.run_kwargs["extra_labels"]["vibepod.herdr.pane"] == "pane-1"
+
+
+def test_run_mounts_herdr_socket_on_native_engine(monkeypatch, _tmp_config_root) -> None:
+    workspace = _tmp_config_root / "workspace"
+    workspace.mkdir()
+    stub = _PortCapturingManager()
+
+    calls = _run_in_herdr_pane(monkeypatch, workspace, stub)
+
+    assert calls["mount_socket"] is True
+    assert stub.run_kwargs is not None
+    assert any(dest == "/herdr/herdr.sock" for _, dest, _ in stub.run_kwargs["extra_volumes"])
+
+
 def test_run_agent_is_rootless_podman_detects_podman_engine() -> None:
     client = _EngineClient(
         {"Rootless": True, "SecurityOptions": ["name=rootless"]},
@@ -915,6 +978,41 @@ def test_run_agent_is_rootless_podman_requires_rootless_podman_evidence(
     manager.client = client  # type: ignore[assignment]
 
     assert manager.is_rootless_podman() is False
+
+
+@pytest.mark.parametrize(
+    ("platform", "version", "expected"),
+    [
+        # Podman off Linux is VM-backed: host paths arrive over virtiofs, which
+        # cannot carry the herdr socket (issue #170).
+        ("darwin", {"Components": [{"Name": "Podman Engine"}]}, False),
+        ("win32", {"Components": [{"Name": "Podman Engine"}]}, False),
+        ("linux", {"Components": [{"Name": "Podman Engine"}]}, True),
+        ("darwin", {"Components": [{"Name": "Docker Engine"}]}, True),
+    ],
+)
+def test_supports_host_socket_mounts(
+    monkeypatch,
+    platform: str,
+    version: dict,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(sys, "platform", platform)
+    manager = object.__new__(DockerManager)
+    manager.client = _EngineClient({}, version)  # type: ignore[assignment]
+
+    assert manager.supports_host_socket_mounts() is expected
+
+
+def test_supports_host_socket_mounts_assumes_docker_when_engine_is_silent(monkeypatch) -> None:
+    class _NoVersionClient:
+        pass
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    manager = object.__new__(DockerManager)
+    manager.client = _NoVersionClient()  # type: ignore[assignment]
+
+    assert manager.supports_host_socket_mounts() is True
 
 
 def test_run_agent_is_rootless_podman_treats_sdk_failures_as_false() -> None:

--- a/tests/test_task_cmd.py
+++ b/tests/test_task_cmd.py
@@ -106,6 +106,13 @@ class _CapturingDockerManager:
         )()
 
 
+class _NoSocketMountManager(_CapturingDockerManager):
+    """Engine that cannot bind-mount a host unix socket (Podman in a VM)."""
+
+    def supports_host_socket_mounts(self) -> bool:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # AgentSpec.headless_prefix wiring
 # ---------------------------------------------------------------------------
@@ -181,6 +188,179 @@ def test_task_create_publishes_configured_ports(monkeypatch, tmp_path, tmp_task_
 
     assert stub.run_kwargs is not None
     assert stub.run_kwargs["ports"] == {"8000": ["8000"], "6000/udp": ["6000"]}
+
+
+def test_task_create_skips_herdr_socket_mount_on_vm_backed_engine(
+    monkeypatch,
+    tmp_path,
+    tmp_task_store,
+) -> None:
+    """VM-backed Podman can't bind-mount the herdr socket, but the run must not
+    die and must still report the pane identity from the host."""
+    stub = _NoSocketMountManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+    calls: dict = {}
+
+    def _fake_apply(agent, config_dir, config, *, no_herdr, mount_socket=True):
+        calls["mount_socket"] = mount_socket
+        return ([], {}) if not mount_socket else ([("/s.sock", "/herdr/herdr.sock", "rw")], {})
+
+    monkeypatch.setattr(task_cmd, "apply_herdr_if_enabled", _fake_apply)
+    monkeypatch.setattr(task_cmd, "pane_reporting_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        task_cmd,
+        "report_pane_metadata",
+        lambda agent: calls.setdefault("reported", agent),
+    )
+    monkeypatch.setenv("HERDR_PANE_ID", "pane-1")
+
+    task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
+
+    assert calls["mount_socket"] is False
+    assert stub.run_kwargs is not None
+    assert all(dest != "/herdr/herdr.sock" for _, dest, _ in stub.run_kwargs["extra_volumes"])
+    # host-side pane identity survives: it never goes through the container
+    assert calls["reported"] == "claude"
+    assert stub.run_kwargs["extra_labels"]["vibepod.herdr.pane"] == "pane-1"
+
+
+def test_task_create_mounts_herdr_socket_on_native_engine(
+    monkeypatch,
+    tmp_path,
+    tmp_task_store,
+) -> None:
+    stub = _CapturingDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+    calls: dict = {}
+
+    def _fake_apply(agent, config_dir, config, *, no_herdr, mount_socket=True):
+        calls["mount_socket"] = mount_socket
+        return ([], {}) if not mount_socket else ([("/s.sock", "/herdr/herdr.sock", "rw")], {})
+
+    monkeypatch.setattr(task_cmd, "apply_herdr_if_enabled", _fake_apply)
+    monkeypatch.setattr(task_cmd, "pane_reporting_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        task_cmd,
+        "report_pane_metadata",
+        lambda agent: calls.setdefault("reported", agent),
+    )
+    monkeypatch.setenv("HERDR_PANE_ID", "pane-1")
+
+    task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
+
+    assert calls["mount_socket"] is True
+    assert stub.run_kwargs is not None
+    assert any(dest == "/herdr/herdr.sock" for _, dest, _ in stub.run_kwargs["extra_volumes"])
+    assert calls["reported"] == "claude"
+    assert stub.run_kwargs["extra_labels"]["vibepod.herdr.pane"] == "pane-1"
+
+
+def test_task_create_lacks_herdr_report_when_disabled(
+    monkeypatch,
+    tmp_path,
+    tmp_task_store,
+) -> None:
+    """When herdr is disabled, no pane identity is reported and no label set."""
+    stub = _CapturingDockerManager()
+    monkeypatch.setattr(task_cmd, "get_config", _make_config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+    calls: dict = {}
+
+    def _fake_apply(agent, config_dir, config, *, no_herdr, mount_socket=True):
+        calls["mount_socket"] = mount_socket
+        return ([], {})
+
+    monkeypatch.setattr(task_cmd, "apply_herdr_if_enabled", _fake_apply)
+    monkeypatch.setattr(task_cmd, "pane_reporting_enabled", lambda *a, **kw: False)
+    monkeypatch.setattr(
+        task_cmd,
+        "report_pane_metadata",
+        lambda agent: calls.setdefault("reported", agent),
+    )
+    monkeypatch.setenv("HERDR_PANE_ID", "pane-1")
+
+    task_cmd.task_create(agent="claude", prompt="do the thing", workspace=tmp_path)
+
+    assert stub.run_kwargs is not None
+    assert "reported" not in calls
+    assert "vibepod.herdr.pane" not in stub.run_kwargs["extra_labels"]
+
+
+@pytest.mark.parametrize("herdr_enabled", [True, False])
+@pytest.mark.parametrize(
+    "failure",
+    ["proxy", "launch", "reload", "exited", "store", "interrupt", None],
+)
+def test_task_create_cleans_up_herdr_only_on_failure(
+    monkeypatch,
+    tmp_path,
+    tmp_task_store,
+    herdr_enabled,
+    failure,
+) -> None:
+    from unittest.mock import Mock
+
+    stub = _NoSocketMountManager()
+    container = stub.run_agent()
+    container.stop = Mock()
+    container.remove = Mock()
+    stub.stop_container = Mock()
+    stub.run_agent = Mock(return_value=container)
+    config = _make_config()
+    expected_error = typer.Exit
+    if failure == "proxy":
+        config["proxy"] = {"enabled": True, "db_path": str(tmp_path / "proxy.db")}
+        monkeypatch.setattr(
+            task_cmd,
+            "provision_proxy",
+            Mock(side_effect=ValueError("proxy failed")),
+        )
+    elif failure == "launch":
+        stub.run_agent.side_effect = RuntimeError("launch failed")
+        expected_error = RuntimeError
+    elif failure == "reload":
+        container.reload = Mock(side_effect=RuntimeError("reload failed"))
+        expected_error = RuntimeError
+    elif failure == "exited":
+        container.status = "exited"
+    elif failure == "store":
+        monkeypatch.setattr(
+            tmp_task_store,
+            "create",
+            Mock(side_effect=RuntimeError("store failed")),
+        )
+        monkeypatch.setattr(task_cmd, "_task_store", lambda: tmp_task_store)
+    elif failure == "interrupt":
+        stub.run_agent.side_effect = KeyboardInterrupt
+        expected_error = KeyboardInterrupt
+
+    monkeypatch.setattr(task_cmd, "get_config", lambda: config)
+    monkeypatch.setattr(task_cmd, "DockerManager", lambda: stub)
+    monkeypatch.setattr(task_cmd, "apply_herdr_if_enabled", lambda *a, **kw: ([], {}))
+    monkeypatch.setattr(task_cmd, "pane_reporting_enabled", lambda *a, **kw: herdr_enabled)
+    monkeypatch.setenv("HERDR_PANE_ID", "pane-1")
+    report = Mock()
+    release = Mock()
+    clear = Mock()
+    monkeypatch.setattr(task_cmd, "report_pane_metadata", report)
+    monkeypatch.setattr(task_cmd, "release_agent", release)
+    monkeypatch.setattr(task_cmd, "clear_pane_metadata", clear)
+
+    if failure is None:
+        task_cmd.task_create(agent="claude", prompt="test", workspace=tmp_path)
+    else:
+        with pytest.raises(expected_error):
+            task_cmd.task_create(agent="claude", prompt="test", workspace=tmp_path)
+
+    assert report.call_count == int(herdr_enabled)
+    if herdr_enabled and failure is not None:
+        release.assert_called_once_with("claude")
+        clear.assert_called_once_with("claude")
+    else:
+        release.assert_not_called()
+        clear.assert_not_called()
 
 
 def test_task_create_rejects_invalid_ports_before_docker(


### PR DESCRIPTION
Improves support for running VibePod with container engines that cannot bind-mount host Unix sockets, such as Podman on macOS and Windows (where the engine runs inside a VM). The changes ensure that herdr agent pane reporting continues to work via the host even when socket mounting is not possible, and that the UI and diagnostics accurately reflect this limitation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved herdr compatibility with Podman on macOS by skipping unsupported socket mounts while preserving host-side pane identity reporting.
  * On Windows, `vp run` now operates without herdr integration when Unix sockets are unavailable.
  * Updated diagnostics to provide informational guidance when socket mounting is unavailable.
  * Improved herdr state cleanup after failed task launches.

* **Documentation**
  * Documented herdr integration limitations for VM-backed Podman engines on macOS and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->